### PR TITLE
[WIP] - ACI broker - Using the template features

### DIFF
--- a/pkg/services/aci/arm_template.go
+++ b/pkg/services/aci/arm_template.go
@@ -41,6 +41,34 @@ var armTemplateBytes = []byte(`
 					},
 					"defaultValue": "1.5"
 			},
+			{{if .storageaccountname}}
+			"sharename": {
+					"type": "string"
+			},
+			"storageaccountname": {
+					"type": "string"
+			},
+			"storageaccountkey": {
+					"type": "securestring"
+			},
+			"volumename": {
+					"type": "string"
+			},
+			"mountpoint": {
+					"type": "string"
+			},
+			{{end}}
+			{{if .imageRegistryLoginServer}}
+			"imageRegistryLoginServer": {        
+				"type": "string"
+			},
+			"imageUsername": {        
+				"type": "string"
+			},
+			"imagePassword": {        
+				"type": "string"
+			},
+			{{end}}
 			"tags": {
 				"type": "object"
 			}
@@ -63,6 +91,12 @@ var armTemplateBytes = []byte(`
 																			"port": "[parameters('port')]" 
 																	}
 															],
+															{{if .storageaccountname}}
+															"volumeMounts": [{
+																"name": "[parameters('volumename')]",
+																"mountPath": "[parameters('mountpoint')]"
+															  }],
+															{{end}}
 															"resources": {
 																	"requests": {
 																			"cpu": "[parameters('cpuCores')]",
@@ -73,6 +107,25 @@ var armTemplateBytes = []byte(`
 											}
 									],
 									"osType": "Linux",
+									{{if .imageRegistryLoginServer}}
+									"imageRegistryCredentials": [
+									{
+										"server": "[parameters('imageRegistryLoginServer')]",
+										"username": "[parameters('imageUsername')]",
+										"password": "[parameters('imagePassword')]"
+									}
+									],
+									{{end}}
+									{{if .storageaccountname}}
+									"volumes": [{
+										"name": "[parameters('volumename')]",
+										"azureFile": {
+											"shareName": "[parameters('sharename')]",
+											"storageAccountName": "[parameters('storageaccountname')]",
+											"storageAccountKey": "[parameters('storageaccountkey')]"
+										}
+									  }],
+									{{end}}
 									"ipAddress": {
 											"type": "Public",
 											"ports": [

--- a/pkg/services/aci/provision.go
+++ b/pkg/services/aci/provision.go
@@ -89,18 +89,33 @@ func (m *module) deployARMTemplate(
 		)
 	}
 
+	// This part seems pretty ugly no ?
+	params := map[string]interface{}{
+		"name":       pc.ContainerName,
+		"image":      pp.ImageName,
+		"port":       pp.Port,
+		"cpuCores":   pp.NumberCores,
+		"memoryInGb": pp.Memory,
+	}
+	if pp.Storageaccountname != "" {
+		params["sharename"] = pp.Sharename
+		params["storageaccountname"] = pp.Storageaccountname
+		params["storageaccountkey"] = pp.Storageaccountkey
+		params["volumename"] = pp.Volumename
+		params["mountpoint"] = pp.Mountpoint
+	}
+	if pp.ImageRegistryLoginServer != "" {
+		params["imageRegistryLoginServer"] = pp.ImageRegistryLoginServer
+		params["imageUsername"] = pp.ImageUsername
+		params["imagePassword"] = pp.ImagePassword
+	}
+
 	outputs, err := m.armDeployer.Deploy(
 		pc.ARMDeploymentName,
 		pc.ResourceGroupName,
 		pp.Location,
 		armTemplateBytes,
-		map[string]interface{}{
-			"name":       pc.ContainerName,
-			"image":      pp.ImageName,
-			"port":       pp.Port,
-			"cpuCores":   pp.NumberCores,
-			"memoryInGb": pp.Memory,
-		},
+		params,
 		pp.Tags,
 	)
 	if err != nil {

--- a/pkg/services/aci/types.go
+++ b/pkg/services/aci/types.go
@@ -4,13 +4,21 @@ import "github.com/Azure/azure-service-broker/pkg/service"
 
 // ProvisioningParameters encapsulates aci-specific provisioning options
 type ProvisioningParameters struct {
-	Location      string            `json:"location"`
-	ResourceGroup string            `json:"resourceGroup"`
-	Tags          map[string]string `json:"tags"`
-	ImageName     string            `json:"image"`
-	NumberCores   string            `json:"cpuCores"`
-	Memory        string            `json:"memoryInGb"`
-	Port          string            `json:"port"`
+	Location                 string            `json:"location"`
+	ResourceGroup            string            `json:"resourceGroup"`
+	Tags                     map[string]string `json:"tags"`
+	ImageName                string            `json:"image"`
+	NumberCores              string            `json:"cpuCores"`
+	Memory                   string            `json:"memoryInGb"`
+	Port                     string            `json:"port"`
+	Sharename                string            `json:"sharename"`
+	Storageaccountname       string            `json:"storageaccountname"`
+	Storageaccountkey        string            `json:"storageaccountkey"`
+	Volumename               string            `json:"volumename"`
+	Mountpoint               string            `json:"mountpoint"`
+	ImageRegistryLoginServer string            `json:"imageRegistryLoginServer"`
+	ImageUsername            string            `json:"imageUsername"`
+	ImagePassword            string            `json:"imagePassword"`
 }
 
 type aciProvisioningContext struct {


### PR DESCRIPTION
_this PR was originally opened by @julienstroheker_

# This is related to #31 and need it to be able to work

### The idea is to have one `arm_template.go` with multiples ways to deploy it.

### For example :

## Basic ACI deployment

```
go run contrib/cmd/cli/*.go -H localhost -u username -P password provision -sid 451d5d19-4575-4d4a-9474-116f705ecc95 --plan-id d48798e2-21db-405b-abc7-aa6f0ff08f6c --param location=eastus --param image=julienstroheker/web-debug --param memoryInGb=1.5 --param cpuCores=1 --param port=80 --poll
```

## ACI with Mount Share (Azure Storage) options

```
go run contrib/cmd/cli/*.go -H localhost -u username -P password provision -sid 451d5d19-4575-4d4a-9474-116f705ecc95 --plan-id d48798e2-21db-405b-abc7-aa6f0ff08f6c --param location=eastus --param image=julienstroheker/web-debug --param memoryInGb=1.5 --param cpuCores=1 --param port=80 --param sharename=foo --param storageaccountname=foo --param storageaccountkey=foo --param volumename=foo --param mountpoint=foo --poll
```

## ACI with Private Registry

```
go run contrib/cmd/cli/*.go -H localhost -u username -P password provision -sid 451d5d19-4575-4d4a-9474-116f705ecc95 --plan-id d48798e2-21db-405b-abc7-aa6f0ff08f6c --param location=eastus --param image=julienstroheker/web-debug --param memoryInGb=1.5 --param cpuCores=1 --param port=80 --param imageRegistryLoginServer=foo --param imageUsername=foo --param imagePassword=foo --poll
```

## ACI with Private Registry and Mount Share

```
go run contrib/cmd/cli/*.go -H localhost -u username -P password provision -sid 451d5d19-4575-4d4a-9474-116f705ecc95 --plan-id d48798e2-21db-405b-abc7-aa6f0ff08f6c --param location=eastus --param image=julienstroheker/web-debug --param memoryInGb=1.5 --param cpuCores=1 --param port=80 --param sharename=foo --param storageaccountname=foo --param storageaccountkey=foo --param volumename=foo --param mountpoint=foo --param imageRegistryLoginServer=foo --param imageUsername=foo --param imagePassword=foo --poll
```