### PR TITLE
Using the quay Docker repo

### DIFF
--- a/contrib/k8s/charts/azure-service-broker/values.yaml
+++ b/contrib/k8s/charts/azure-service-broker/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   ## Image location, NOT including the tag
-  repository: microsoft/azure-service-broker
+  repository: quay.io/deisci/azure-service-broker
   ## Image tag
   tag: canary
   ## "IfNotPresent", "Always", or "Never"


### PR DESCRIPTION
This allows us to deploy the helm chart ~~w/o requiring an `imagePullSecret`~~ using a robot account for pulling a private image from quay.

cc/ @krancour 