### PR TITLE
cf manifest improvements

### DIFF
--- a/contrib/cf/manifest.yml
+++ b/contrib/cf/manifest.yml
@@ -1,6 +1,7 @@
 ---
-  name: asb
-  buildpack: go_buildpack
+applications:
+- name: asb
+  buildpack: https://github.com/cloudfoundry/go-buildpack/releases/download/v1.8.13/go-buildpack-v1.8.13.zip
   command: broker 
   env:
     AZURE_SUBSCRIPTION_ID: <YOUR SUBSCRIPTION ID>


### PR DESCRIPTION
I deployed the broker on CF for the first time earlier today. I had a little bit of trouble because the broker required Go 1.9 to compile and the Go buildpack in my (brand new) PCF dev VM didn't have Go 1.9.x as an option. This could trip up a lot of people, potentially, so I've pinned the manifest to a specific (newer) version of the Go buildpack.

While researching this, I also noticed minor discrepancies in manifest format between the CF documentation and our own manifest, so I've corrected those as well.

The application deploys fine with these changes in place.