### PR TITLE
allow multi-valued params in the cli

### DIFF
--- a/contrib/cmd/cli/params.go
+++ b/contrib/cmd/cli/params.go
@@ -3,25 +3,29 @@ package main
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/Azure/azure-service-broker/contrib/pkg/client"
+	parms "github.com/Azure/azure-service-broker/contrib/pkg/params"
 	"github.com/urfave/cli"
 )
 
+// parseParams iterates, in turn, over string, int, float, and bool params as
+// specified by the user and parses them into a map[string]interface{}.
 func parseParams(c *cli.Context) (map[string]interface{}, error) {
 	params := client.ProvisioningParameters{}
 	rawParamStrs := c.StringSlice(flagParameter)
 	for _, rawParamStr := range rawParamStrs {
-		key, val, err := parseParam(rawParamStr)
+		key, val, err := parms.Parse(rawParamStr)
 		if err != nil {
 			return nil, err
 		}
-		params[key] = val
+		if err := parms.Add(params, key, val); err != nil {
+			return nil, err
+		}
 	}
 	rawParamStrs = c.StringSlice(flagIntParameter)
 	for _, rawParamStr := range rawParamStrs {
-		key, valStr, err := parseParam(rawParamStr)
+		key, valStr, err := parms.Parse(rawParamStr)
 		if err != nil {
 			return nil, err
 		}
@@ -32,11 +36,13 @@ func parseParams(c *cli.Context) (map[string]interface{}, error) {
 				rawParamStr,
 			)
 		}
-		params[key] = val
+		if err := parms.Add(params, key, val); err != nil {
+			return nil, err
+		}
 	}
 	rawParamStrs = c.StringSlice(flagFloatParameter)
 	for _, rawParamStr := range rawParamStrs {
-		key, valStr, err := parseParam(rawParamStr)
+		key, valStr, err := parms.Parse(rawParamStr)
 		if err != nil {
 			return nil, err
 		}
@@ -47,11 +53,13 @@ func parseParams(c *cli.Context) (map[string]interface{}, error) {
 				rawParamStr,
 			)
 		}
-		params[key] = val
+		if err := parms.Add(params, key, val); err != nil {
+			return nil, err
+		}
 	}
 	rawParamStrs = c.StringSlice(flagBoolParameter)
 	for _, rawParamStr := range rawParamStrs {
-		key, valStr, err := parseParam(rawParamStr)
+		key, valStr, err := parms.Parse(rawParamStr)
 		if err != nil {
 			return nil, err
 		}
@@ -62,19 +70,9 @@ func parseParams(c *cli.Context) (map[string]interface{}, error) {
 				rawParamStr,
 			)
 		}
-		params[key] = val
+		if err := parms.Add(params, key, val); err != nil {
+			return nil, err
+		}
 	}
 	return params, nil
-}
-
-func parseParam(rawParamStr string) (string, string, error) {
-	rawParamStr = strings.TrimSpace(rawParamStr)
-	tokens := strings.Split(rawParamStr, "=")
-	if len(tokens) != 2 {
-		return "", "", fmt.Errorf(
-			`parameter string "%s" is incorrectly formatted`,
-			rawParamStr,
-		)
-	}
-	return strings.TrimSpace(tokens[0]), strings.TrimSpace(tokens[1]), nil
 }

--- a/contrib/pkg/params/adder.go
+++ b/contrib/pkg/params/adder.go
@@ -1,0 +1,60 @@
+package params
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Add adds the given key/value pair to the given map[string]interface{}, but
+// complex keys that specify an index (for multi-valued / array parameters) have
+// their values added to that map as a []interface{} under that key. That slice
+// is re-sized as needed.
+func Add(params map[string]interface{}, key string, val interface{}) error {
+	if matches := arrayParamKeyRegex.FindStringSubmatch(key); len(matches) > 0 {
+		// Key is indexed
+		key = matches[1]
+		indexStr := matches[2]
+		// Can't get an error here because we already know indexStr is parsable as
+		// an integer
+		index, _ := strconv.Atoi(indexStr)
+		var slice []interface{}
+		existingVal, ok := params[key]
+		if ok { // If something already exists under this key...
+			slice, ok = existingVal.([]interface{})
+			if !ok { // And it's NOT a []interface{}...
+				// We have a problem
+				return fmt.Errorf(
+					`key "%s" used in both single-valued and multi-valued context`,
+					key,
+				)
+			}
+			// Something already exists here AND it's a slice!
+			if len(slice) < index+1 { // If the slice isn't big enough...
+				// Grow it!
+				// By how much?
+				diff := (index + 1) - len(slice)
+				slice = append(slice, make([]interface{}, diff)...)
+			}
+		} else { // If nothing already exists under this key...
+			// Make a slice that's big enough
+			slice = make([]interface{}, index+1)
+		}
+		slice[index] = val
+		params[key] = slice
+	} else {
+		// Key isn't indexed
+		existingVal, ok := params[key]
+		if ok { // If something already exists under this key...
+			_, ok := existingVal.([]interface{})
+			if ok { // And it's a []interface{}...
+				// We have a problem
+				return fmt.Errorf(
+					`key "%s" used in both single-valued and multi-valued context`,
+					key,
+				)
+			}
+		}
+		params[key] = val
+	}
+	return nil
+}

--- a/contrib/pkg/params/adder_test.go
+++ b/contrib/pkg/params/adder_test.go
@@ -1,0 +1,60 @@
+package params
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddSingleValuedParameter(t *testing.T) {
+	params := map[string]interface{}{}
+	err := Add(params, "foo", "bar")
+	assert.Nil(t, err)
+	err = Add(params, "bat", "baz")
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"foo": "bar",
+		"bat": "baz",
+	}, params)
+
+	// Test that it's a failure to now reuse a key in a mutli-valued context
+	err = Add(params, "foo[0]", "bar")
+	assert.NotNil(t, err)
+}
+
+func TestAddMultiValuedParameter(t *testing.T) {
+	params := map[string]interface{}{}
+	err := Add(params, "foo[0]", "bar")
+	assert.Nil(t, err)
+	err = Add(params, "foo[1]", "bat")
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"foo": []interface{}{"bar", "bat"},
+	}, params)
+
+	// Test that it's a failure to now reuse a key in a single-valued context
+	err = Add(params, "foo", "bar")
+	assert.NotNil(t, err)
+}
+
+func TestAddMultiValuedParametersOutOfOrder(t *testing.T) {
+	params := map[string]interface{}{}
+	err := Add(params, "foo[1]", "bar")
+	assert.Nil(t, err)
+	err = Add(params, "foo[0]", 5)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"foo": []interface{}{5, "bar"},
+	}, params)
+}
+
+func TestAddMultiValuedParametersWithGaps(t *testing.T) {
+	params := map[string]interface{}{}
+	err := Add(params, "foo[0]", "bar")
+	assert.Nil(t, err)
+	err = Add(params, "foo[2]", 5)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"foo": []interface{}{"bar", nil, 5},
+	}, params)
+}

--- a/contrib/pkg/params/parser.go
+++ b/contrib/pkg/params/parser.go
@@ -1,0 +1,23 @@
+package params
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var arrayParamKeyRegex = regexp.MustCompile(`^([\-\w]+)\[(\d+)\]$`)
+
+// Parse splits a single param into key and value components, using "=" as a
+// delimiter.
+func Parse(rawParamStr string) (string, string, error) {
+	rawParamStr = strings.TrimSpace(rawParamStr)
+	tokens := strings.SplitN(rawParamStr, "=", 2)
+	if len(tokens) != 2 {
+		return "", "", fmt.Errorf(
+			`parameter string "%s" is incorrectly formatted`,
+			rawParamStr,
+		)
+	}
+	return strings.TrimSpace(tokens[0]), strings.TrimSpace(tokens[1]), nil
+}

--- a/contrib/pkg/params/parser_test.go
+++ b/contrib/pkg/params/parser_test.go
@@ -1,0 +1,29 @@
+package params
+
+import "testing"
+import "github.com/stretchr/testify/assert"
+
+func TestParseParam(t *testing.T) {
+	// A param is invalid if it contains no "="
+	_, _, err := Parse("foo")
+	assert.NotNil(t, err)
+
+	// Test a normal scenario
+	key, val, err := Parse("foo=bar")
+	assert.Nil(t, err)
+	assert.Equal(t, "foo", key)
+	assert.Equal(t, "bar", val)
+
+	// Test that complex (indexed) keys are ok
+	key, val, err = Parse("foo[0]=bar")
+	assert.Nil(t, err)
+	assert.Equal(t, "foo[0]", key)
+	assert.Equal(t, "bar", val)
+
+	// Test that multiple "=" are not a problem-- i.e. values can contain "="
+	// ("=" is a base64 character and therefore somewhat common!)
+	key, val, err = Parse("foo=bar==")
+	assert.Nil(t, err)
+	assert.Equal(t, "foo", key)
+	assert.Equal(t, "bar==", val)
+}


### PR DESCRIPTION
Fixes #63 

Related to #61 

Also useful for specifying postgres extensions. Example:

```
$ go run contrib/cmd/cli/*.go \
    --username username --password password provision \
    --sid b43b4bba-5741-4d98-a10b-17dc5cee0175 \
    --pid b2ed210f-6a10-4593-a6c4-964e6b6fad62 \
    --param location=eastus --param resourceGroup=demo \
    --param extensions[0]=uuid-ossp \
    --param extensions[1]=postgis \
    --poll
```