### PR TITLE
better aci validation

### DIFF
--- a/pkg/services/aci/provision.go
+++ b/pkg/services/aci/provision.go
@@ -26,6 +26,12 @@ func (m *module) ValidateProvisioningParameters(
 			fmt.Sprintf(`invalid location: "%s"`, pp.Location),
 		)
 	}
+	if pp.ImageName == "" {
+		return service.NewValidationError(
+			"image",
+			fmt.Sprintf(`invalid image: "%s"`, pp.ImageName),
+		)
+	}
 	return nil
 }
 

--- a/pkg/services/aci/provision_test.go
+++ b/pkg/services/aci/provision_test.go
@@ -1,0 +1,41 @@
+package aci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateProvisioningParametersWithNoLocation(t *testing.T) {
+	m, pp := getModuleAndValidTestProvisioningParameters(t)
+	pp.Location = ""
+	err := m.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, err)
+}
+
+func TestValidateProvisioningParametersWithInvalidLocation(t *testing.T) {
+	m, pp := getModuleAndValidTestProvisioningParameters(t)
+	pp.Location = "boguswest"
+	err := m.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, err)
+}
+
+func TestValidateProvisioningParametersWithNoImageName(t *testing.T) {
+	m, pp := getModuleAndValidTestProvisioningParameters(t)
+	pp.ImageName = ""
+	err := m.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, err)
+}
+
+func getModuleAndValidTestProvisioningParameters(
+	t *testing.T,
+) (*module, *ProvisioningParameters) {
+	m, pp := &module{}, &ProvisioningParameters{
+		Location:      "eastus",
+		ResourceGroup: "test",
+		ImageName:     "nginx:latest",
+	}
+	err := m.ValidateProvisioningParameters(pp)
+	assert.Nil(t, err)
+	return m, pp
+}


### PR DESCRIPTION
Fixes #60

After recent changes to provide default values for memory and cpu requested, the only field remaining that should have some kind of validation but doesn't is `ImageName`. This adds it.

I've also added some simple tests for these validations. I'm going to open a separate issue to add more such tests for all modules.