### PR TITLE
Update test to conditionally use assert.Equals 

### DIFF
--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -123,7 +123,7 @@ func TestGetExistingBinding(t *testing.T) {
 	// Assert that the retrieval was successful
 	assert.True(t, ok)
 	assert.Nil(t, err)
-	// Assert that binding is not nil before using 
+	// Assert that binding is not nil before using
 	if assert.NotNil(t, binding, "binding should not be nil") {
 		assert.Equal(t, bindingID, binding.BindingID)
 	}


### PR DESCRIPTION
Fixes #8 

Two tests TestGetExistingBinding and TestGetExistingInstance attempted to use
references that were nil. This change does an assert that the object is
not nil and then conditionally does the existing assert.Equals