### PR TITLE
add example sqldb manifests

### DIFF
--- a/contrib/k8s/examples/sqldb-binding.yaml
+++ b/contrib/k8s/examples/sqldb-binding.yaml
@@ -1,0 +1,9 @@
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: my-sqldb-binding
+  namespace: default
+spec:
+  instanceRef:
+    name: my-sqldb-instance
+  secretName: my-sqldb-secret

--- a/contrib/k8s/examples/sqldb-instance.yaml
+++ b/contrib/k8s/examples/sqldb-instance.yaml
@@ -1,0 +1,11 @@
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  name: my-sqldb-instance
+  namespace: default
+spec:
+  clusterServiceClassExternalName: azure-sqldb
+  clusterServicePlanExternalName: basic
+  parameters:
+    location: eastus
+    resourceGroup: demo


### PR DESCRIPTION
No CI required. It doesn't test these example manifests.