### PR TITLE
Update to quickstart section regarding service principal creation

### DIFF
--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -148,14 +148,14 @@ resources on your account on behalf of Kubernetes.
 
     **Bash**
     ```
-    export AZURE_TENANT_ID=<DisplayName>
+    export AZURE_TENANT_ID=<Tenant>
     export AZURE_CLIENT_ID=<AppId>
     export AZURE_CLIENT_SECRET=<Password>
     ```
 
     **PowerShell**
     ```
-    $env:AZURE_TENANT_ID = "<DisplayName>"
+    $env:AZURE_TENANT_ID = "<Tenant>"
     $env:AZURE_CLIENT_ID = "<AppId>"
     $env:AZURE_CLIENT_SECRET = "<Password>"
     ```


### PR DESCRIPTION
Update to step 2 of the "Create a service principal" section to
update the instructions for setting AZURE_TENANT_ID

Fixes #131