### PR TITLE
Update to quick start to have a better command for opening wordpress

### DIFF
--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -259,8 +259,7 @@ quickstart-wordpress   1         1         1            1           2m
 
 1. Run the following command to open WordPress in your browser:
     ```
-    open http://$(minikube ip):$(kubectl get service quickstart-wordpress \ 
-       -o jsonpath={.spec.ports[?\(@.name==\"http\"\)].nodePort}) 
+    open http://$(minikube ip):$(kubectl get service quickstart-wordpress -o jsonpath={.spec.ports[?\(@.name==\"http\"\)].nodePort}) 
     ```
 
     **Note**: We are using the `minikube ip` to get the WordPress URL, instead of

--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -259,7 +259,7 @@ quickstart-wordpress   1         1         1            1           2m
 
 1. Run the following command to open WordPress in your browser:
     ```
-    open http://$(minikube ip):$(kubectl get service quickstart-wordpress -o jsonpath={.spec.ports[?\(@.name==\"http\"\)].nodePort}) 
+    open http://$(minikube ip):$(kubectl get service quickstart-wordpress -o jsonpath={.spec.ports[?\(@.name==\"http\"\)].nodePort})/admin 
     ```
 
     **Note**: We are using the `minikube ip` to get the WordPress URL, instead of

--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -259,7 +259,8 @@ quickstart-wordpress   1         1         1            1           2m
 
 1. Run the following command to open WordPress in your browser:
     ```
-    open http://$(minikube ip):$(kubectl get service quickstart-wordpress -o jsonpath={.spec.ports[?\(@.name==\"http\"\)].nodePort}) 
+    open http://$(minikube ip):$(kubectl get service quickstart-wordpress \ 
+       -o jsonpath={.spec.ports[?\(@.name==\"http\"\)].nodePort}) 
     ```
 
     **Note**: We are using the `minikube ip` to get the WordPress URL, instead of

--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -259,12 +259,13 @@ quickstart-wordpress   1         1         1            1           2m
 
 1. Run the following command to open WordPress in your browser:
     ```
-    open http://$(minikube ip):31215/admin
+    open http://$(minikube ip):$(kubectl get service quickstart-wordpress -o jsonpath={.spec.ports[?\(@.name==\"http\"\)].nodePort}) 
     ```
 
     **Note**: We are using the `minikube ip` to get the WordPress URL, instead of
     the command from the WordPress deployment output because with Minikube the
-    WordPress service won't have a public IP address assigned.
+    WordPress service won't have a public IP address assigned. We are also using
+    kubectl in order to find the node port of the `http` port. 
 1. Login using the following credentials:
     ```
     echo Username: user


### PR DESCRIPTION
After the install of the chart, use kubectl + JSONPath to find the
nodePort of the http port in the service definition.

Fixes: #125