### PR TITLE
[WIP] Adding support for CosmosDB as a storage backend

### DIFF
--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -96,6 +96,20 @@ func main() {
 		log.Fatal(err)
 	}
 
+	storageConfig, err := getStorageConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cosmosDBConfig := cosmosDBConfig{}
+	if storageConfig.StorageType == StorageTypeCosmosDB {
+		var err error
+		cosmosDBConfig, err = getCosmosDBConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	// Create broker
 	broker, err := broker.NewBroker(
 		redisClient,
@@ -105,6 +119,7 @@ func main() {
 		modulesConfig.MinStability,
 		azureConfig.DefaultLocation,
 		azureConfig.DefaultResourceGroup,
+		getCreateStorageFunc(redisClient, storageConfig, cosmosDBConfig),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/broker/config.go
+++ b/cmd/broker/config.go
@@ -9,6 +9,11 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
+const (
+	StorageTypeCosmosDB = "cosmosdb"
+	StorageTypeRedis    = "redis"
+)
+
 // logConfig represents configuration options for the broker's leveled logging
 type logConfig struct {
 	LevelStr string `envconfig:"LOG_LEVEL" default:"INFO"`
@@ -45,6 +50,26 @@ type modulesConfig struct {
 type azureConfig struct {
 	DefaultLocation      string `envconfig:"AZURE_DEFAULT_LOCATION"`
 	DefaultResourceGroup string `envconfig:"AZURE_DEFAULT_RESOURCE_GROUP"`
+}
+
+// storageConfig exposes an environment variable that tells the broker
+// what kind of storage to use. The current choices are 'redis' and 'cosmosdb'
+//
+// this configuration will be used for stable storage like instances, bindings,
+// etc... It won't be used for the asynchronous queue
+//
+// If you pass 'cosmosdb' as the storage type, you need to also give the broker
+// a CosmosDB configuration (see the cosmosDBConfig struct). Regardless of what
+// you pass, you always need to pass a Redis config (see the redisConfig struct)
+type storageConfig struct {
+	StorageType string `envconfig:"STORAGE_TYPE" default:"redis"`
+}
+
+type cosmosDBConfig struct {
+	ConnectionURL          string `envconfig:"COSMOS_CONNECTION_URL"`
+	DBName                 string `envconfig:"COSMOS_DB_NAME"`
+	InstanceCollectionName string `envconfig:"COSMOS_INSTANCE_COLLECTION_NAME"`
+	BindingCollectionName  string `envconfig:"COSMOS_BINDING_COLLECTION_NAME"`
 }
 
 func getLogConfig() (logConfig, error) {
@@ -102,4 +127,16 @@ func getAzureConfig() (azureConfig, error) {
 	ac := azureConfig{}
 	err := envconfig.Process("", &ac)
 	return ac, err
+}
+
+func getStorageConfig() (storageConfig, error) {
+	sc := storageConfig{}
+	err := envconfig.Process("", &sc)
+	return sc, err
+}
+
+func getCosmosDBConfig() (cosmosDBConfig, error) {
+	cc := cosmosDBConfig{}
+	err := envconfig.Process("", &cc)
+	return cc, err
 }

--- a/cmd/broker/storage.go
+++ b/cmd/broker/storage.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"github.com/Azure/open-service-broker-azure/pkg/broker"
+	"github.com/Azure/open-service-broker-azure/pkg/crypto"
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+	"github.com/Azure/open-service-broker-azure/pkg/storage"
+	"github.com/Azure/open-service-broker-azure/pkg/storage/cosmosdb"
+	"github.com/go-redis/redis"
+	mgo "gopkg.in/mgo.v2"
+)
+
+// getCreateStorageFunc creates a new broker.CreateStorageFunc that creates
+// and returns the proper storage driver based on the given storageConfig.
+//
+// The only supported storage drivers are 'redis' and 'cosmosdb'. This function
+// will return a StorageFunc for redis if storageConfig.StorageType is not
+// 'cosmosdb'
+func getCreateStorageFunc(
+	redisClient *redis.Client,
+	storageConfig storageConfig,
+	cosmosConfig cosmosDBConfig,
+) broker.CreateStorageFunc {
+	return func(catalog service.Catalog, codec crypto.Codec) (storage.Store, error) {
+		if storageConfig.StorageType == StorageTypeCosmosDB {
+			db, err := getMongoDB(cosmosConfig.ConnectionURL, cosmosConfig.DBName)
+			if err != nil {
+				return nil, err
+			}
+			return cosmosdb.NewStore(
+				db,
+				cosmosConfig.InstanceCollectionName,
+				cosmosConfig.BindingCollectionName,
+			), nil
+		}
+		return storage.NewStore(redisClient, catalog, codec), nil
+	}
+}
+
+func getMongoDB(url, dbName string) (*mgo.Database, error) {
+	sess, err := mgo.Dial(url)
+	if err != nil {
+		return nil, err
+	}
+	return sess.DB(dbName), nil
+}

--- a/pkg/service/binding.go
+++ b/pkg/service/binding.go
@@ -9,16 +9,16 @@ import (
 
 // Binding represents a binding to a service
 type Binding struct {
-	BindingID                  string            `json:"bindingId"`
-	InstanceID                 string            `json:"instanceId"`
-	ServiceID                  string            `json:"serviceId"`
-	EncryptedBindingParameters []byte            `json:"bindingParameters"`
-	BindingParameters          BindingParameters `json:"-"`
-	Status                     string            `json:"status"`
-	StatusReason               string            `json:"statusReason"`
-	EncryptedDetails           []byte            `json:"details"`
-	Details                    BindingDetails    `json:"-"`
-	Created                    time.Time         `json:"created"`
+	BindingID                  string            `json:"bindingId" bson:"bindingId"`
+	InstanceID                 string            `json:"instanceId" bson:"instanceId"`
+	ServiceID                  string            `json:"serviceId" bson:"serviceId"`
+	EncryptedBindingParameters []byte            `json:"bindingParameters" bson:"bindingParameters"`
+	BindingParameters          BindingParameters `json:"-" bson:"-"`
+	Status                     string            `json:"status" bson:"status"`
+	StatusReason               string            `json:"statusReason" bson:"statusReason"`
+	EncryptedDetails           []byte            `json:"details" bson:"details"`
+	Details                    BindingDetails    `json:"-" bson:"-"`
+	Created                    time.Time         `json:"created" bson:"created"`
 }
 
 // NewBindingFromJSON returns a new Binding unmarshalled from the provided JSON

--- a/pkg/service/instance.go
+++ b/pkg/service/instance.go
@@ -9,21 +9,22 @@ import (
 
 // Instance represents an instance of a service
 type Instance struct {
-	InstanceID                      string                 `json:"instanceId"`             // nolint: lll
-	ServiceID                       string                 `json:"serviceId"`              // nolint: lll
-	PlanID                          string                 `json:"planId"`                 // nolint: lll
-	EncryptedProvisioningParameters []byte                 `json:"provisioningParameters"` // nolint: lll
-	ProvisioningParameters          ProvisioningParameters `json:"-"`
-	EncryptedUpdatingParameters     []byte                 `json:"updatingParameters"` // nolint: lll
-	UpdatingParameters              UpdatingParameters     `json:"-"`
-	Status                          string                 `json:"status"`        // nolint: lll
-	StatusReason                    string                 `json:"statusReason"`  // nolint: lll
-	Location                        string                 `json:"location"`      // nolint: lll
-	ResourceGroup                   string                 `json:"resourceGroup"` // nolint: lll
-	Tags                            map[string]string      `json:"tags"`
-	EncryptedDetails                []byte                 `json:"details"` // nolint: lll
-	Details                         InstanceDetails        `json:"-"`
-	Created                         time.Time              `json:"created"` // nolint: lll
+	InstanceID                      string                 `json:"instanceId" bson:"instanceId"`                         // nolint: lll
+	ServiceID                       string                 `json:"serviceId" bson:"serviceId"`                           // nolint: lll
+	PlanID                          string                 `json:"planId" bson:"planId"`                                 // nolint: lll
+	EncryptedProvisioningParameters []byte                 `json:"provisioningParameters" bson:"provisioningParameters"` // nolint: lll
+	ProvisioningParameters          ProvisioningParameters `json:"-" bson:"-"`
+	EncryptedUpdatingParameters     []byte                 `json:"updatingParameters" bson:"updatingParameters"` // nolint: lll
+	UpdatingParameters              UpdatingParameters     `json:"-" bson:"-"`
+	Status                          string                 `json:"status" bson:"status"`               // nolint: lll
+	StatusReason                    string                 `json:"statusReason" bson:"statusReason"`   // nolint: lll
+	Location                        string                 `json:"location" bson:"location"`           // nolint: lll
+	ResourceGroup                   string                 `json:"resourceGroup" bson:"resourceGroup"` // nolint: lll
+	Tags                            map[string]string      `json:"tags" bson:"tags"`
+	EncryptedDetails                []byte                 `json:"details" bson:"details"` // nolint: lll
+	Details                         InstanceDetails        `json:"-" bson:"-"`
+	Created                         time.Time              `json:"created" bson:"created"` // nolint: lll
+
 }
 
 // NewInstanceFromJSON returns a new Instance unmarshalled from the provided

--- a/pkg/storage/cosmosdb/store.go
+++ b/pkg/storage/cosmosdb/store.go
@@ -32,21 +32,21 @@ func NewStore(db *mgo.Database, instCollName, bindCollName string) *Store {
 }
 
 // WriteInstance persists the given instance to the underlying storage
-func (s *Store) WriteInstance(instance *service.Instance) error {
+func (s *Store) WriteInstance(instance service.Instance) error {
 	coll := s.instColl()
 	return coll.Insert(instance)
 }
 
 // GetInstance retrieves a persisted instance from the underlying storage by
 // instance id
-func (s *Store) GetInstance(instanceID string) (*service.Instance, bool, error) {
+func (s *Store) GetInstance(instanceID string) (service.Instance, bool, error) {
 	res := new(service.Instance)
 	coll := s.instColl()
 	findErr := coll.Find(bson.M{"instanceId": instanceID}).One(res)
 	if findErr != nil {
-		return nil, false, findErr
+		return service.Instance{}, false, findErr
 	}
-	return res, true, nil
+	return *res, true, nil
 }
 
 // DeleteInstance deletes a persisted instance from the underlying storage by
@@ -60,21 +60,21 @@ func (s *Store) DeleteInstance(instanceID string) (bool, error) {
 }
 
 // WriteBinding persists the given binding to the underlying storage
-func (s *Store) WriteBinding(binding *service.Binding) error {
+func (s *Store) WriteBinding(binding service.Binding) error {
 	coll := s.bindColl()
 	return coll.Insert(binding)
 }
 
 // GetBinding retrieves a persisted instance from the underlying storage by
 // binding id
-func (s *Store) GetBinding(bindingID string) (*service.Binding, bool, error) {
+func (s *Store) GetBinding(bindingID string) (service.Binding, bool, error) {
 	res := new(service.Binding)
 	coll := s.bindColl()
 	findErr := coll.Find(bson.M{"bindingId": bindingID}).One(res)
 	if findErr != nil {
-		return nil, false, findErr
+		return service.Binding{}, false, findErr
 	}
-	return res, true, nil
+	return *res, true, nil
 }
 
 // DeleteBinding deletes a persisted binding from the underlying storage by

--- a/pkg/storage/cosmosdb/store.go
+++ b/pkg/storage/cosmosdb/store.go
@@ -1,0 +1,102 @@
+package cosmosdb
+
+import (
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+	mgo "gopkg.in/mgo.v2"
+	bson "gopkg.in/mgo.v2/bson"
+)
+
+// Store is a (./pkg/storage).Store interface implementation to store
+// data in Microsoft Azure CosmosDB.
+//
+// See https://docs.microsoft.com/en-us/azure/cosmos-db/introduction)
+// for more details on CosmosDB
+type Store struct {
+	db           *mgo.Database
+	instCollName string
+	bindCollName string
+}
+
+// NewStore creates a new Store implementation that is backed by CosmosDB's
+// MongoDB API
+//
+// The given session should be configured to talk to CosmosDB, and the given
+// instDBName and bindDBName will be used as the names for the Mongo
+// collections in which to store instances and bindings, respectively
+func NewStore(db *mgo.Database, instCollName, bindCollName string) *Store {
+	return &Store{
+		db:           db,
+		instCollName: instCollName,
+		bindCollName: bindCollName,
+	}
+}
+
+// WriteInstance persists the given instance to the underlying storage
+func (s *Store) WriteInstance(instance *service.Instance) error {
+	coll := s.instColl()
+	return coll.Insert(instance)
+}
+
+// GetInstance retrieves a persisted instance from the underlying storage by
+// instance id
+func (s *Store) GetInstance(instanceID string) (*service.Instance, bool, error) {
+	res := new(service.Instance)
+	coll := s.instColl()
+	findErr := coll.Find(bson.M{"instanceId": instanceID}).One(res)
+	if findErr != nil {
+		return nil, false, findErr
+	}
+	return res, true, nil
+}
+
+// DeleteInstance deletes a persisted instance from the underlying storage by
+// instance id
+func (s *Store) DeleteInstance(instanceID string) (bool, error) {
+	coll := s.instColl()
+	if err := coll.Remove(bson.M{"instanceId": instanceID}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// WriteBinding persists the given binding to the underlying storage
+func (s *Store) WriteBinding(binding *service.Binding) error {
+	coll := s.bindColl()
+	return coll.Insert(binding)
+}
+
+// GetBinding retrieves a persisted instance from the underlying storage by
+// binding id
+func (s *Store) GetBinding(bindingID string) (*service.Binding, bool, error) {
+	res := new(service.Binding)
+	coll := s.bindColl()
+	findErr := coll.Find(bson.M{"bindingId": bindingID}).One(res)
+	if findErr != nil {
+		return nil, false, findErr
+	}
+	return res, true, nil
+}
+
+// DeleteBinding deletes a persisted binding from the underlying storage by
+// binding id
+func (s *Store) DeleteBinding(bindingID string) (bool, error) {
+	coll := s.bindColl()
+	if err := coll.Remove(bson.M{"bindingId": bindingID}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// TestConnection tests the connection to the underlying database (if there
+// is one)
+func (s *Store) TestConnection() error {
+	return s.db.Session.Ping()
+}
+
+func (s *Store) instColl() *mgo.Collection {
+	return s.db.C(s.instCollName)
+}
+
+func (s *Store) bindColl() *mgo.Collection {
+	return s.db.C(s.bindCollName)
+}


### PR DESCRIPTION
This patch aims to add support for CosmosDB as a storage backend (note that it doesn't aim to replace the backend for the async queue processing engine - that may come in a follow-up).

It is currently a work in progress. Things to do:

- [ ] Add tests to the integration suite
- [x] Add a config parameter to the `main` function
    - If `main` sees that CosmosDB should be turned on, it should create a connection and pass it the cosmosDB storage backend

@jeremyrickard @krancour I think this would be a good addition to the broker. Do you foresee any problems here?