### PR TITLE
refactor event function signatures

### DIFF
--- a/cmd/compliance-test-broker/compliance-test-broker.go
+++ b/cmd/compliance-test-broker/compliance-test-broker.go
@@ -34,11 +34,12 @@ func main() {
 		password,
 	)
 
+	noopCodec := noop.NewCodec()
 	server, err := api.NewServer(
 		8080,
-		memoryStorage.NewStore(),
+		memoryStorage.NewStore(noopCodec),
 		fakeAsync.NewEngine(),
-		noop.NewCodec(),
+		noopCodec,
 		authenticator,
 		fakeCatalog,
 		" ",

--- a/pkg/api/bind.go
+++ b/pkg/api/bind.go
@@ -119,7 +119,7 @@ func (s *server) bind(w http.ResponseWriter, r *http.Request) {
 	// Now that we have a serviceManager, we can get empty objects of the correct
 	// types, so we can take a second pass at retrieving an instance from storage
 	// with more concrete details filled in.
-	instance, ok, err = s.store.GetInstance(
+	instance, _, err = s.store.GetInstance(
 		instanceID,
 		serviceManager.GetEmptyProvisioningParameters(),
 		serviceManager.GetEmptyUpdatingParameters(),

--- a/pkg/api/bind.go
+++ b/pkg/api/bind.go
@@ -257,9 +257,8 @@ func (s *server) bind(w http.ResponseWriter, r *http.Request) {
 	// specific code has left us in, so we'll attempt to record the error in
 	// the datastore.
 	bindingContext, credentials, err := serviceManager.Bind(
-		instance.StandardProvisioningContext,
-		instance.ProvisioningContext,
-		bindingRequest.Parameters,
+		instance,
+		bindingParameters,
 	)
 	if err != nil {
 		s.handleBindingError(

--- a/pkg/api/bind.go
+++ b/pkg/api/bind.go
@@ -262,7 +262,7 @@ func (s *server) bind(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	binding = &service.Binding{
+	binding = service.Binding{
 		InstanceID: instanceID,
 		BindingID:  bindingID,
 		Created:    time.Now(),
@@ -349,7 +349,7 @@ func (s *server) bind(w http.ResponseWriter, r *http.Request) {
 // so we log that failure and kill the process. Barring such a failure, a nicely
 // formatted error message is logged.
 func (s *server) handleBindingError(
-	binding *service.Binding,
+	binding service.Binding,
 	e error,
 	msg string,
 	w http.ResponseWriter,

--- a/pkg/api/bind_test.go
+++ b/pkg/api/bind_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Azure/open-service-broker-azure/pkg/crypto/noop"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/Azure/open-service-broker-azure/pkg/services/fake"
 	"github.com/stretchr/testify/assert"
@@ -178,14 +177,10 @@ func TestBindingWithExistingBindingWithDifferentParameters(
 	existingBinding := service.Binding{
 		InstanceID: instanceID,
 		BindingID:  bindingID,
-	}
-	err = existingBinding.SetBindingParameters(
-		&fake.BindingParameters{
+		BindingParameters: &fake.BindingParameters{
 			SomeParameter: "foo",
 		},
-		noop.NewCodec(),
-	)
-	assert.Nil(t, err)
+	}
 	err = s.store.WriteBinding(existingBinding)
 	assert.Nil(t, err)
 	req, err := getBindingRequest(

--- a/pkg/api/bind_test.go
+++ b/pkg/api/bind_test.go
@@ -33,7 +33,7 @@ func TestBindingWithInstanceThatIsNotFullyProvisioned(t *testing.T) {
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
 	planID := getDisposablePlanID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  getDisposableServiceID(),
 		PlanID:     planID,
@@ -57,7 +57,7 @@ func TestBindingWithServiceIDDifferentFromInstanceServiceID(t *testing.T) {
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
 	planID := getDisposablePlanID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  getDisposableServiceID(),
 		PlanID:     planID,
@@ -84,7 +84,7 @@ func TestBindingWithPlanIDDifferentFromInstancePlanID(t *testing.T) {
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
 	serviceID := getDisposableServiceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  serviceID,
 		PlanID:     getDisposablePlanID(),
@@ -111,7 +111,7 @@ func TestBindingModuleNotFoundForServiceID(t *testing.T) {
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
 	serviceID := getDisposableServiceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  serviceID,
 		PlanID:     getDisposablePlanID(),
@@ -136,7 +136,7 @@ func TestBindingWithExistingBindingWithDifferentInstanceID(
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,
@@ -144,7 +144,7 @@ func TestBindingWithExistingBindingWithDifferentInstanceID(
 	})
 	assert.Nil(t, err)
 	bindingID := getDisposableBindingID()
-	err = s.store.WriteBinding(&service.Binding{
+	err = s.store.WriteBinding(service.Binding{
 		InstanceID: getDisposableInstanceID(),
 		BindingID:  bindingID,
 	})
@@ -167,7 +167,7 @@ func TestBindingWithExistingBindingWithDifferentParameters(
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,
@@ -175,7 +175,7 @@ func TestBindingWithExistingBindingWithDifferentParameters(
 	})
 	assert.Nil(t, err)
 	bindingID := getDisposableBindingID()
-	existingBinding := &service.Binding{
+	existingBinding := service.Binding{
 		InstanceID: instanceID,
 		BindingID:  bindingID,
 	}
@@ -210,7 +210,7 @@ func TestBindingWithExistingBoundBindingWithSameAttributes(
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,
@@ -218,7 +218,7 @@ func TestBindingWithExistingBoundBindingWithSameAttributes(
 	})
 	assert.Nil(t, err)
 	bindingID := getDisposableBindingID()
-	err = s.store.WriteBinding(&service.Binding{
+	err = s.store.WriteBinding(service.Binding{
 		InstanceID: instanceID,
 		BindingID:  bindingID,
 		Status:     service.BindingStateBound,
@@ -242,7 +242,7 @@ func TestBindingWithExistingFailedBindingWithSameAttributes(
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,
@@ -250,7 +250,7 @@ func TestBindingWithExistingFailedBindingWithSameAttributes(
 	})
 	assert.Nil(t, err)
 	bindingID := getDisposableBindingID()
-	err = s.store.WriteBinding(&service.Binding{
+	err = s.store.WriteBinding(service.Binding{
 		InstanceID: instanceID,
 		BindingID:  bindingID,
 		Status:     service.BindingStateBindingFailed,
@@ -287,7 +287,7 @@ func TestBrandNewBinding(t *testing.T) {
 		return nil, nil, nil
 	}
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -56,11 +56,12 @@ func getTestServer(
 	if err != nil {
 		return nil, nil, err
 	}
+	noopCodec := noop.NewCodec()
 	s, err := NewServer(
 		8080,
-		memoryStorage.NewStore(),
+		memoryStorage.NewStore(noopCodec),
 		fakeAsync.NewEngine(),
-		noop.NewCodec(),
+		noopCodec,
 		always.NewAuthenticator(),
 		fakeCatalog,
 		defaultAzureLocation,

--- a/pkg/api/deprovision.go
+++ b/pkg/api/deprovision.go
@@ -111,7 +111,7 @@ func (s *server) deprovision(w http.ResponseWriter, r *http.Request) {
 	// Now that we have a serviceManager, we can get empty objects of the correct
 	// types, so we can take a second pass at retrieving an instance from storage
 	// with more concrete details filled in.
-	instance, ok, err = s.store.GetInstance(
+	instance, _, err = s.store.GetInstance(
 		instanceID,
 		serviceManager.GetEmptyProvisioningParameters(),
 		serviceManager.GetEmptyUpdatingParameters(),

--- a/pkg/api/deprovision.go
+++ b/pkg/api/deprovision.go
@@ -42,7 +42,7 @@ func (s *server) deprovision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	instance, ok, err := s.store.GetInstance(instanceID)
+	instance, ok, err := s.store.GetInstance(instanceID, nil, nil, nil)
 	if err != nil {
 		logFields["error"] = err
 		log.WithFields(logFields).Error(
@@ -107,6 +107,24 @@ func (s *server) deprovision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	serviceManager := svc.GetServiceManager()
+
+	// Now that we have a serviceManager, we can get empty objects of the correct
+	// types, so we can take a second pass at retrieving an instance from storage
+	// with more concrete details filled in.
+	instance, ok, err = s.store.GetInstance(
+		instanceID,
+		serviceManager.GetEmptyProvisioningParameters(),
+		serviceManager.GetEmptyUpdatingParameters(),
+		serviceManager.GetEmptyProvisioningContext(),
+	)
+	if err != nil {
+		logFields["error"] = err
+		log.WithFields(logFields).Error(
+			"pre-deprovisioning error: error retrieving instance by id",
+		)
+		s.writeResponse(w, http.StatusInternalServerError, responseEmptyJSON)
+		return
+	}
 
 	deprovisioner, err := serviceManager.GetDeprovisioner(plan)
 	if err != nil {

--- a/pkg/api/deprovision_test.go
+++ b/pkg/api/deprovision_test.go
@@ -59,7 +59,7 @@ func TestDeprovisioningInstanceThatIsAlreadyDeprovisioning(t *testing.T) {
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,
@@ -83,7 +83,7 @@ func TestDeprovisioningInstanceThatIsStillProvisioning(t *testing.T) {
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,
@@ -107,7 +107,7 @@ func TestKickOffNewAsyncDeprovisioning(t *testing.T) {
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,

--- a/pkg/api/poll.go
+++ b/pkg/api/poll.go
@@ -49,7 +49,7 @@ func (s *server) poll(
 
 	logFields["operation"] = operation
 
-	instance, ok, err := s.store.GetInstance(instanceID)
+	instance, ok, err := s.store.GetInstance(instanceID, nil, nil, nil)
 	if err != nil {
 		logFields["error"] = err
 		log.WithFields(logFields).Error(

--- a/pkg/api/poll_test.go
+++ b/pkg/api/poll_test.go
@@ -36,7 +36,7 @@ func TestPollingWithInstanceProvisioning(t *testing.T) {
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		Status:     service.InstanceStateProvisioning,
 	})
@@ -53,7 +53,7 @@ func TestPollingWithInstanceProvisioned(t *testing.T) {
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		Status:     service.InstanceStateProvisioned,
 	})
@@ -70,7 +70,7 @@ func TestPollingWithInstanceProvisioningFailed(t *testing.T) {
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		Status:     service.InstanceStateProvisioningFailed,
 	})
@@ -87,7 +87,7 @@ func TestPollingWithInstanceDeprovisioning(t *testing.T) {
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		Status:     service.InstanceStateDeprovisioning,
 	})
@@ -119,7 +119,7 @@ func TestPollingWithInstanceDeprovisioningFailed(t *testing.T) {
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		Status:     service.InstanceStateDeprovisioningFailed,
 	})

--- a/pkg/api/provision.go
+++ b/pkg/api/provision.go
@@ -285,7 +285,7 @@ func (s *server) provision(w http.ResponseWriter, r *http.Request) {
 		standardProvisioningParameters,
 	)
 
-	instance = &service.Instance{
+	instance = service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  provisioningRequest.ServiceID,
 		PlanID:     provisioningRequest.PlanID,

--- a/pkg/api/provision_test.go
+++ b/pkg/api/provision_test.go
@@ -129,7 +129,7 @@ func TestProvisioningWithExistingInstanceWithDifferentAttributes(
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	existingInstance := &service.Instance{
+	existingInstance := service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,
@@ -169,7 +169,7 @@ func TestProvisioningWithExistingInstanceWithSameAttributesAndFullyProvisioned(
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,
@@ -199,7 +199,7 @@ func TestProvisioningWithExistingInstanceWithSameAttributesAndNotFullyProvisione
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,

--- a/pkg/api/provision_test.go
+++ b/pkg/api/provision_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	fakeAsync "github.com/Azure/open-service-broker-azure/pkg/async/fake"
-	"github.com/Azure/open-service-broker-azure/pkg/crypto/noop"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/Azure/open-service-broker-azure/pkg/services/fake"
 	"github.com/stretchr/testify/assert"
@@ -133,14 +132,10 @@ func TestProvisioningWithExistingInstanceWithDifferentAttributes(
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,
-	}
-	err = existingInstance.SetProvisioningParameters(
-		&fake.ProvisioningParameters{
+		ProvisioningParameters: &fake.ProvisioningParameters{
 			SomeParameter: "foo",
 		},
-		noop.NewCodec(),
-	)
-	assert.Nil(t, err)
+	}
 	err = s.store.WriteInstance(existingInstance)
 	assert.Nil(t, err)
 	req, err := getProvisionRequest(

--- a/pkg/api/unbind.go
+++ b/pkg/api/unbind.go
@@ -94,7 +94,7 @@ func (s *server) unbind(w http.ResponseWriter, r *http.Request) {
 		// Now that we have a serviceManager, we can get empty objects of the
 		// correct types, so we can take a second pass at retrieving an instance
 		// and a binding from storage with more concrete details filled in.
-		instance, ok, err = s.store.GetInstance(
+		instance, _, err = s.store.GetInstance(
 			instanceID,
 			serviceManager.GetEmptyProvisioningParameters(),
 			serviceManager.GetEmptyUpdatingParameters(),
@@ -108,7 +108,7 @@ func (s *server) unbind(w http.ResponseWriter, r *http.Request) {
 			s.writeResponse(w, http.StatusInternalServerError, responseEmptyJSON)
 			return
 		}
-		binding, ok, err = s.store.GetBinding(
+		binding, _, err = s.store.GetBinding(
 			bindingID,
 			serviceManager.GetEmptyBindingParameters(),
 			serviceManager.GetEmptyBindingContext(),

--- a/pkg/api/unbind.go
+++ b/pkg/api/unbind.go
@@ -152,7 +152,7 @@ func (s *server) unbind(w http.ResponseWriter, r *http.Request) {
 // so we log that failure and kill the process. Barring such a failure, a nicely
 // formatted error message is logged.
 func (s *server) handleUnbindingError(
-	binding *service.Binding,
+	binding service.Binding,
 	e error,
 	msg string,
 	w http.ResponseWriter,

--- a/pkg/api/unbind.go
+++ b/pkg/api/unbind.go
@@ -126,11 +126,7 @@ func (s *server) unbind(w http.ResponseWriter, r *http.Request) {
 		// Starting here, if something goes wrong, we don't know what state service-
 		// specific code has left us in, so we'll attempt to record the error in
 		// the datastore.
-		err = serviceManager.Unbind(
-			instance.StandardProvisioningContext,
-			instance.ProvisioningContext,
-			binding.BindingContext,
-		)
+		err = serviceManager.Unbind(instance, binding.BindingContext)
 		if err != nil {
 			s.handleUnbindingError(
 				binding,

--- a/pkg/api/unbind_test.go
+++ b/pkg/api/unbind_test.go
@@ -65,7 +65,7 @@ func TestUnbindingFromInstanceThatDoesNotExist(t *testing.T) {
 	s.router.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, responseEmptyJSON, rr.Body.Bytes())
-	_, ok, err := s.store.GetBinding(bindingID)
+	_, ok, err := s.store.GetBinding(bindingID, nil, nil, nil)
 	assert.Nil(t, err)
 	assert.False(t, ok)
 }
@@ -105,7 +105,7 @@ func TestUnbindingFromInstanceThatExists(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, responseEmptyJSON, rr.Body.Bytes())
 	assert.True(t, unbindCalled)
-	_, ok, err := s.store.GetBinding(bindingID)
+	_, ok, err := s.store.GetBinding(bindingID, nil, nil, nil)
 	assert.Nil(t, err)
 	assert.False(t, ok)
 }

--- a/pkg/api/unbind_test.go
+++ b/pkg/api/unbind_test.go
@@ -30,7 +30,7 @@ func TestUnbindingWithInstanceIDDifferentFromBindingInstanceID(t *testing.T) {
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	bindingID := getDisposableBindingID()
-	err = s.store.WriteBinding(&service.Binding{
+	err = s.store.WriteBinding(service.Binding{
 		InstanceID: getDisposableInstanceID(),
 		BindingID:  bindingID,
 	})
@@ -51,7 +51,7 @@ func TestUnbindingFromInstanceThatDoesNotExist(t *testing.T) {
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
 	bindingID := getDisposableBindingID()
-	err = s.store.WriteBinding(&service.Binding{
+	err = s.store.WriteBinding(service.Binding{
 		InstanceID: instanceID,
 		BindingID:  bindingID,
 	})
@@ -84,13 +84,13 @@ func TestUnbindingFromInstanceThatExists(t *testing.T) {
 	}
 	instanceID := getDisposableInstanceID()
 	bindingID := getDisposableBindingID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,
 	})
 	assert.Nil(t, err)
-	err = s.store.WriteBinding(&service.Binding{
+	err = s.store.WriteBinding(service.Binding{
 		InstanceID: instanceID,
 		BindingID:  bindingID,
 	})

--- a/pkg/api/update_test.go
+++ b/pkg/api/update_test.go
@@ -107,7 +107,7 @@ func TestUpdatingWithExistingInstanceWithSameAttributesAndFullyProvisioned(
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,
@@ -137,7 +137,7 @@ func TestUpdatingWithExistingInstanceWithSameAttributesAndNotFullyProvisioned( /
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,
@@ -171,7 +171,7 @@ func TestKickOffNewAsyncUpdating(t *testing.T) {
 			return nil
 		}
 	instanceID := getDisposableInstanceID()
-	err = s.store.WriteInstance(&service.Instance{
+	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 		ServiceID:  fake.ServiceID,
 		PlanID:     fake.StandardPlanID,

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -58,7 +58,7 @@ func NewBroker(
 	defaultAzureResourceGroup string,
 ) (Broker, error) {
 	b := &broker{
-		store:       storage.NewStore(redisClient),
+		store:       storage.NewStore(redisClient, codec),
 		asyncEngine: async.NewEngine(redisClient),
 		codec:       codec,
 	}
@@ -117,7 +117,7 @@ func NewBroker(
 
 	b.apiServer, err = api.NewServer(
 		8080,
-		storage.NewStore(redisClient),
+		b.store,
 		b.asyncEngine,
 		b.codec,
 		authenticator,

--- a/pkg/broker/deprovision.go
+++ b/pkg/broker/deprovision.go
@@ -177,7 +177,7 @@ func (b *broker) handleDeprovisioningError(
 	e error,
 	msg string,
 ) error {
-	instance, ok := instanceOrInstanceID.(*service.Instance)
+	instance, ok := instanceOrInstanceID.(service.Instance)
 	if !ok {
 		instanceID := instanceOrInstanceID
 		if e == nil {

--- a/pkg/broker/deprovision.go
+++ b/pkg/broker/deprovision.go
@@ -118,13 +118,7 @@ func (b *broker) doDeprovisionStep(
 			`deprovisioner does not know how to process step "%s"`,
 		)
 	}
-	updatedProvisioningContext, err := step.Execute(
-		ctx,
-		instanceID,
-		plan,
-		instance.StandardProvisioningContext,
-		instance.ProvisioningContext,
-	)
+	updatedProvisioningContext, err := step.Execute(ctx, instance, plan)
 	if err != nil {
 		return b.handleDeprovisioningError(
 			instance,

--- a/pkg/broker/deprovision.go
+++ b/pkg/broker/deprovision.go
@@ -74,7 +74,7 @@ func (b *broker) doDeprovisionStep(
 	// Now that we have a serviceManager, we can get empty objects of the correct
 	// types, so we can take a second pass at retrieving an instance from storage
 	// with more concrete details filled in.
-	instance, ok, err = b.store.GetInstance(
+	instance, _, err = b.store.GetInstance(
 		instanceID,
 		serviceManager.GetEmptyProvisioningParameters(),
 		serviceManager.GetEmptyUpdatingParameters(),
@@ -88,12 +88,28 @@ func (b *broker) doDeprovisionStep(
 			"error loading persisted instance",
 		)
 	}
-	if !ok {
-		return b.handleDeprovisioningError(
+
+	// Retrieve a second copy of the instance from storage. Why? We're about to
+	// pass the instance off to module specific code. It's passed by value, so
+	// we'd like to imagine that the modules can only modify copies of the
+	// instance, but some of the fields of an instance are pointers and a copy of
+	// a pointer still points back to the original thing-- meaning modules could
+	// modify parts of the instance in unexpected ways. What we'll do is take the
+	// one part of the instance that we inted for modules to modify (provisioning
+	// context) and add that to this untouched copy and write the untouched copy
+	// back to storage.
+	instanceCopy, _, err := b.store.GetInstance(
+		instanceID,
+		serviceManager.GetEmptyProvisioningParameters(),
+		serviceManager.GetEmptyUpdatingParameters(),
+		serviceManager.GetEmptyProvisioningContext(),
+	)
+	if err != nil {
+		return b.handleProvisioningError(
 			instanceID,
 			stepName,
-			nil,
-			"instance does not exist in the data store",
+			err,
+			"error loading persisted instance",
 		)
 	}
 
@@ -127,11 +143,11 @@ func (b *broker) doDeprovisionStep(
 			"error executing deprovisioning step",
 		)
 	}
-	instance.ProvisioningContext = updatedProvisioningContext
+	instanceCopy.ProvisioningContext = updatedProvisioningContext
 	if nextStepName, ok := deprovisioner.GetNextStepName(step.GetName()); ok {
-		if err = b.store.WriteInstance(instance); err != nil {
+		if err = b.store.WriteInstance(instanceCopy); err != nil {
 			return b.handleDeprovisioningError(
-				instance,
+				instanceCopy,
 				stepName,
 				err,
 				"error persisting instance",
@@ -146,7 +162,7 @@ func (b *broker) doDeprovisionStep(
 		)
 		if err = b.asyncEngine.SubmitTask(task); err != nil {
 			return b.handleDeprovisioningError(
-				instance,
+				instanceCopy,
 				stepName,
 				err,
 				fmt.Sprintf(`error enqueing next step: "%s"`, nextStepName),
@@ -154,10 +170,10 @@ func (b *broker) doDeprovisionStep(
 		}
 	} else {
 		// No next step-- we're done deprovisioning!
-		_, err = b.store.DeleteInstance(instance.InstanceID)
+		_, err = b.store.DeleteInstance(instanceCopy.InstanceID)
 		if err != nil {
 			return b.handleDeprovisioningError(
-				instance,
+				instanceCopy,
 				stepName,
 				err,
 				"error deleting deprovisioned instance",

--- a/pkg/broker/provision.go
+++ b/pkg/broker/provision.go
@@ -74,7 +74,7 @@ func (b *broker) doProvisionStep(
 	// Now that we have a serviceManager, we can get empty objects of the correct
 	// types, so we can take a second pass at retrieving an instance from storage
 	// with more concrete details filled in.
-	instance, ok, err = b.store.GetInstance(
+	instance, _, err = b.store.GetInstance(
 		instanceID,
 		serviceManager.GetEmptyProvisioningParameters(),
 		serviceManager.GetEmptyUpdatingParameters(),
@@ -88,12 +88,28 @@ func (b *broker) doProvisionStep(
 			"error loading persisted instance",
 		)
 	}
-	if !ok {
+
+	// Retrieve a second copy of the instance from storage. Why? We're about to
+	// pass the instance off to module specific code. It's passed by value, so
+	// we'd like to imagine that the modules can only modify copies of the
+	// instance, but some of the fields of an instance are pointers and a copy of
+	// a pointer still points back to the original thing-- meaning modules could
+	// modify parts of the instance in unexpected ways. What we'll do is take the
+	// one part of the instance that we inted for modules to modify (provisioning
+	// context) and add that to this untouched copy and write the untouched copy
+	// back to storage.
+	instanceCopy, _, err := b.store.GetInstance(
+		instanceID,
+		serviceManager.GetEmptyProvisioningParameters(),
+		serviceManager.GetEmptyUpdatingParameters(),
+		serviceManager.GetEmptyProvisioningContext(),
+	)
+	if err != nil {
 		return b.handleProvisioningError(
 			instanceID,
 			stepName,
-			nil,
-			"instance does not exist in the data store",
+			err,
+			"error loading persisted instance",
 		)
 	}
 
@@ -127,11 +143,11 @@ func (b *broker) doProvisionStep(
 			"error executing provisioning step",
 		)
 	}
-	instance.ProvisioningContext = updatedProvisioningContext
+	instanceCopy.ProvisioningContext = updatedProvisioningContext
 	if nextStepName, ok := provisioner.GetNextStepName(step.GetName()); ok {
-		if err = b.store.WriteInstance(instance); err != nil {
+		if err = b.store.WriteInstance(instanceCopy); err != nil {
 			return b.handleProvisioningError(
-				instance,
+				instanceCopy,
 				stepName,
 				err,
 				"error persisting instance",
@@ -146,7 +162,7 @@ func (b *broker) doProvisionStep(
 		)
 		if err = b.asyncEngine.SubmitTask(task); err != nil {
 			return b.handleProvisioningError(
-				instance,
+				instanceCopy,
 				stepName,
 				err,
 				fmt.Sprintf(`error enqueing next step: "%s"`, nextStepName),
@@ -154,10 +170,10 @@ func (b *broker) doProvisionStep(
 		}
 	} else {
 		// No next step-- we're done provisioning!
-		instance.Status = service.InstanceStateProvisioned
-		if err = b.store.WriteInstance(instance); err != nil {
+		instanceCopy.Status = service.InstanceStateProvisioned
+		if err = b.store.WriteInstance(instanceCopy); err != nil {
 			return b.handleProvisioningError(
-				instance,
+				instanceCopy,
 				stepName,
 				err,
 				"error persisting instance",

--- a/pkg/broker/provision.go
+++ b/pkg/broker/provision.go
@@ -118,14 +118,7 @@ func (b *broker) doProvisionStep(
 			`provisioner does not know how to process step "%s"`,
 		)
 	}
-	updatedProvisioningContext, err := step.Execute(
-		ctx,
-		instanceID,
-		plan,
-		instance.StandardProvisioningContext,
-		instance.ProvisioningContext,
-		instance.ProvisioningParameters,
-	)
+	updatedProvisioningContext, err := step.Execute(ctx, instance, plan)
 	if err != nil {
 		return b.handleProvisioningError(
 			instance,

--- a/pkg/broker/provision.go
+++ b/pkg/broker/provision.go
@@ -188,7 +188,7 @@ func (b *broker) handleProvisioningError(
 	e error,
 	msg string,
 ) error {
-	instance, ok := instanceOrInstanceID.(*service.Instance)
+	instance, ok := instanceOrInstanceID.(service.Instance)
 	if !ok {
 		instanceID := instanceOrInstanceID
 		if e == nil {

--- a/pkg/broker/update.go
+++ b/pkg/broker/update.go
@@ -188,7 +188,7 @@ func (b *broker) handleUpdatingError(
 	e error,
 	msg string,
 ) error {
-	instance, ok := instanceOrInstanceID.(*service.Instance)
+	instance, ok := instanceOrInstanceID.(service.Instance)
 	if !ok {
 		instanceID := instanceOrInstanceID
 		if e == nil {

--- a/pkg/broker/update.go
+++ b/pkg/broker/update.go
@@ -136,11 +136,8 @@ func (b *broker) doUpdateStep(
 	}
 	updatedProvisioningContext, err := step.Execute(
 		ctx,
-		instanceID,
+		instance,
 		plan,
-		instance.StandardProvisioningContext,
-		instance.ProvisioningContext,
-		instance.UpdatingParameters,
 	)
 	if err != nil {
 		return b.handleUpdatingError(

--- a/pkg/service/binding.go
+++ b/pkg/service/binding.go
@@ -21,16 +21,14 @@ type Binding struct {
 
 // NewBindingFromJSON returns a new Binding unmarshalled from the provided JSON
 // []byte
-func NewBindingFromJSON(jsonBytes []byte) (*Binding, error) {
-	binding := &Binding{}
-	if err := json.Unmarshal(jsonBytes, binding); err != nil {
-		return nil, err
-	}
-	return binding, nil
+func NewBindingFromJSON(jsonBytes []byte) (Binding, error) {
+	binding := Binding{}
+	err := json.Unmarshal(jsonBytes, &binding)
+	return binding, err
 }
 
 // ToJSON returns a []byte containing a JSON representation of the instance
-func (b *Binding) ToJSON() ([]byte, error) {
+func (b Binding) ToJSON() ([]byte, error) {
 	return json.Marshal(b)
 }
 
@@ -54,7 +52,7 @@ func (b *Binding) SetBindingParameters(
 
 // GetBindingParameters decrypts the EncryptedBindingParameters field and
 // unmarshals the result into the provided bindingParameters object
-func (b *Binding) GetBindingParameters(
+func (b Binding) GetBindingParameters(
 	params BindingParameters,
 	codec crypto.Codec,
 ) error {
@@ -88,7 +86,7 @@ func (b *Binding) SetBindingContext(
 
 // GetBindingContext decrypts the EncryptedBindingContext field and unmarshals
 // the result into the provided bindingContext object
-func (b *Binding) GetBindingContext(
+func (b Binding) GetBindingContext(
 	context BindingContext,
 	codec crypto.Codec,
 ) error {
@@ -122,7 +120,7 @@ func (b *Binding) SetCredentials(
 
 // GetCredentials decrypts the EncryptedCredentials field and unmarshals the
 // result into the provided credentials object
-func (b *Binding) GetCredentials(
+func (b Binding) GetCredentials(
 	credentials Credentials,
 	codec crypto.Codec,
 ) error {

--- a/pkg/service/binding_test.go
+++ b/pkg/service/binding_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	testBinding     *Binding
+	testBinding     Binding
 	testBindingJSON []byte
 )
 
@@ -27,7 +27,7 @@ func init() {
 		panic(err)
 	}
 
-	testBinding = &Binding{
+	testBinding = Binding{
 		BindingID:                  bindingID,
 		InstanceID:                 instanceID,
 		EncryptedBindingParameters: encryptedBindingParameters,

--- a/pkg/service/deprovisioner.go
+++ b/pkg/service/deprovisioner.go
@@ -9,10 +9,8 @@ import (
 // deprovisioning step
 type DeprovisioningStepFunction func(
 	ctx context.Context,
-	instanceID string,
+	instance Instance,
 	plan Plan,
-	standardProvisioningContext StandardProvisioningContext,
-	provisioningContext ProvisioningContext,
 ) (ProvisioningContext, error)
 
 // DeprovisioningStep is an interface to be implemented by types that represent
@@ -21,10 +19,8 @@ type DeprovisioningStep interface {
 	GetName() string
 	Execute(
 		ctx context.Context,
-		instanceID string,
+		instance Instance,
 		plan Plan,
-		standardProvisioningContext StandardProvisioningContext,
-		provisioningContext ProvisioningContext,
 	) (ProvisioningContext, error)
 }
 
@@ -66,19 +62,15 @@ func (d *deprovisioningStep) GetName() string {
 // Execute executes a step
 func (d *deprovisioningStep) Execute(
 	ctx context.Context,
-	instanceID string,
+	instance Instance,
 	plan Plan,
-	standardProvisioningContext StandardProvisioningContext,
-	provisioningContext ProvisioningContext,
 ) (ProvisioningContext, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	return d.fn(
 		ctx,
-		instanceID,
+		instance,
 		plan,
-		standardProvisioningContext,
-		provisioningContext,
 	)
 }
 

--- a/pkg/service/instance.go
+++ b/pkg/service/instance.go
@@ -14,128 +14,140 @@ type Instance struct {
 	PlanID                          string                         `json:"planId"`                         // nolint: lll
 	StandardProvisioningParameters  StandardProvisioningParameters `json:"standardProvisioningParameters"` // nolint: lll
 	EncryptedProvisioningParameters []byte                         `json:"provisioningParameters"`         // nolint: lll
-	EncryptedUpdatingParameters     []byte                         `json:"updatingParameters"`             // nolint: lll
-	Status                          string                         `json:"status"`                         // nolint: lll
-	StatusReason                    string                         `json:"statusReason"`                   // nolint: lll
-	StandardProvisioningContext     StandardProvisioningContext    `json:"standardProvisioningContext"`    // nolint: lll
-	EncryptedProvisioningContext    []byte                         `json:"provisioningContext"`            // nolint: lll
-	Created                         time.Time                      `json:"created"`                        // nolint: lll
+	ProvisioningParameters          ProvisioningParameters         `json:"-"`
+	EncryptedUpdatingParameters     []byte                         `json:"updatingParameters"` // nolint: lll
+	UpdatingParameters              UpdatingParameters             `json:"-"`
+	Status                          string                         `json:"status"`                      // nolint: lll
+	StatusReason                    string                         `json:"statusReason"`                // nolint: lll
+	StandardProvisioningContext     StandardProvisioningContext    `json:"standardProvisioningContext"` // nolint: lll
+	EncryptedProvisioningContext    []byte                         `json:"provisioningContext"`         // nolint: lll
+	ProvisioningContext             ProvisioningContext            `json:"-"`
+	Created                         time.Time                      `json:"created"` // nolint: lll
 }
 
 // NewInstanceFromJSON returns a new Instance unmarshalled from the provided
 // JSON []byte
-func NewInstanceFromJSON(jsonBytes []byte) (Instance, error) {
-	instance := Instance{}
-	err := json.Unmarshal(jsonBytes, &instance)
-	return instance, err
+func NewInstanceFromJSON(
+	jsonBytes []byte,
+	pp ProvisioningParameters,
+	up UpdatingParameters,
+	pc ProvisioningContext,
+	codec crypto.Codec,
+) (Instance, error) {
+	instance := Instance{
+		ProvisioningParameters: pp,
+		UpdatingParameters:     up,
+		ProvisioningContext:    pc,
+	}
+	if err := json.Unmarshal(jsonBytes, &instance); err != nil {
+		return instance, err
+	}
+	return instance.decrypt(codec)
 }
 
 // ToJSON returns a []byte containing a JSON representation of the
 // instance
-func (i Instance) ToJSON() ([]byte, error) {
+func (i Instance) ToJSON(codec crypto.Codec) ([]byte, error) {
+	var err error
+	if i, err = i.encrypt(codec); err != nil {
+		return nil, err
+	}
 	return json.Marshal(i)
 }
 
-// SetProvisioningParameters marshals the provided provisioningParameters
-// object, encrypts the result, and stores it in the
-// EncryptedProvisioningParameters field
-func (i *Instance) SetProvisioningParameters(
-	params ProvisioningParameters,
-	codec crypto.Codec,
-) error {
-	jsonBytes, err := json.Marshal(params)
-	if err != nil {
-		return err
+func (i Instance) encrypt(codec crypto.Codec) (Instance, error) {
+	var err error
+	if i, err = i.encryptProvisioningParameters(codec); err != nil {
+		return i, err
 	}
-	ciphertext, err := codec.Encrypt(jsonBytes)
-	if err != nil {
-		return err
+	if i, err = i.encryptUpdatingParameters(codec); err != nil {
+		return i, err
 	}
-	i.EncryptedProvisioningParameters = ciphertext
-	return nil
+	return i.encryptProvisioningContext(codec)
 }
 
-// SetUpdatingParameters marshals the provided updatingParameters
-// object, encrypts the result, and stores it in the
-// EncryptedUpdatingParameters field
-func (i *Instance) SetUpdatingParameters(
-	params UpdatingParameters,
+func (i Instance) encryptProvisioningParameters(
 	codec crypto.Codec,
-) error {
-	jsonBytes, err := json.Marshal(params)
+) (Instance, error) {
+	jsonBytes, err := json.Marshal(i.ProvisioningParameters)
 	if err != nil {
-		return err
+		return i, err
 	}
-	ciphertext, err := codec.Encrypt(jsonBytes)
-	if err != nil {
-		return err
-	}
-	i.EncryptedUpdatingParameters = ciphertext
-	return nil
+	i.EncryptedProvisioningParameters, err = codec.Encrypt(jsonBytes)
+	return i, err
 }
 
-// GetProvisioningParameters decrypts the EncryptedProvisioningParameters field
-// and unmarshals the result into the provided provisioningParameters object
-func (i Instance) GetProvisioningParameters(
-	params ProvisioningParameters,
+func (i Instance) encryptUpdatingParameters(
 	codec crypto.Codec,
-) error {
-	if len(i.EncryptedProvisioningParameters) == 0 {
-		return nil
+) (Instance, error) {
+	jsonBytes, err := json.Marshal(i.UpdatingParameters)
+	if err != nil {
+		return i, err
+	}
+	i.EncryptedUpdatingParameters, err = codec.Encrypt(jsonBytes)
+	return i, err
+}
+
+func (i Instance) encryptProvisioningContext(
+	codec crypto.Codec,
+) (Instance, error) {
+	jsonBytes, err := json.Marshal(i.ProvisioningContext)
+	if err != nil {
+		return i, err
+	}
+	i.EncryptedProvisioningContext, err = codec.Encrypt(jsonBytes)
+	return i, err
+}
+
+func (i Instance) decrypt(codec crypto.Codec) (Instance, error) {
+	var err error
+	if i, err = i.decryptProvisioningParameters(codec); err != nil {
+		return i, err
+	}
+	if i, err = i.decryptUpdatingParameters(codec); err != nil {
+		return i, err
+	}
+	return i.decryptProvisioningContext(codec)
+}
+
+func (i Instance) decryptProvisioningParameters(
+	codec crypto.Codec,
+) (Instance, error) {
+	if len(i.EncryptedProvisioningParameters) == 0 ||
+		i.ProvisioningParameters == nil {
+		return i, nil
 	}
 	plaintext, err := codec.Decrypt(i.EncryptedProvisioningParameters)
 	if err != nil {
-		return err
+		return i, err
 	}
-	return json.Unmarshal(plaintext, params)
+	return i, json.Unmarshal(plaintext, i.ProvisioningParameters)
 }
 
-// GetUpdatingParameters decrypts the EncryptedUpdatingParameters field
-// and unmarshals the result into the provided updatingParameters object
-func (i Instance) GetUpdatingParameters(
-	params UpdatingParameters,
+func (i Instance) decryptUpdatingParameters(
 	codec crypto.Codec,
-) error {
-	if len(i.EncryptedUpdatingParameters) == 0 {
-		return nil
+) (Instance, error) {
+	if len(i.EncryptedUpdatingParameters) == 0 ||
+		i.UpdatingParameters == nil {
+		return i, nil
 	}
 	plaintext, err := codec.Decrypt(i.EncryptedUpdatingParameters)
 	if err != nil {
-		return err
+		return i, err
 	}
-	return json.Unmarshal(plaintext, params)
+	return i, json.Unmarshal(plaintext, i.UpdatingParameters)
 }
 
-// SetProvisioningContext marshals the provided provisioningContext object,
-// encrypts the result, and stores it in the EncrypredProvisioningContext field
-func (i *Instance) SetProvisioningContext(
-	context ProvisioningContext,
+func (i Instance) decryptProvisioningContext(
 	codec crypto.Codec,
-) error {
-	jsonBytes, err := json.Marshal(context)
-	if err != nil {
-		return err
-	}
-	ciphertext, err := codec.Encrypt(jsonBytes)
-	if err != nil {
-		return err
-	}
-	i.EncryptedProvisioningContext = ciphertext
-	return nil
-}
-
-// GetProvisioningContext decrypts the EncryptedProvisioningContext field and
-// unmarshals the result into the provided provisioningContext object
-func (i Instance) GetProvisioningContext(
-	context ProvisioningContext,
-	codec crypto.Codec,
-) error {
-	if len(i.EncryptedProvisioningContext) == 0 {
-		return nil
+) (Instance, error) {
+	if len(i.EncryptedProvisioningContext) == 0 ||
+		i.ProvisioningContext == nil {
+		return i, nil
 	}
 	plaintext, err := codec.Decrypt(i.EncryptedProvisioningContext)
 	if err != nil {
-		return err
+		return i, err
 	}
-	return json.Unmarshal(plaintext, context)
+	return i, json.Unmarshal(plaintext, i.ProvisioningContext)
 }

--- a/pkg/service/instance.go
+++ b/pkg/service/instance.go
@@ -24,17 +24,15 @@ type Instance struct {
 
 // NewInstanceFromJSON returns a new Instance unmarshalled from the provided
 // JSON []byte
-func NewInstanceFromJSON(jsonBytes []byte) (*Instance, error) {
-	instance := &Instance{}
-	if err := json.Unmarshal(jsonBytes, instance); err != nil {
-		return nil, err
-	}
-	return instance, nil
+func NewInstanceFromJSON(jsonBytes []byte) (Instance, error) {
+	instance := Instance{}
+	err := json.Unmarshal(jsonBytes, &instance)
+	return instance, err
 }
 
 // ToJSON returns a []byte containing a JSON representation of the
 // instance
-func (i *Instance) ToJSON() ([]byte, error) {
+func (i Instance) ToJSON() ([]byte, error) {
 	return json.Marshal(i)
 }
 
@@ -78,7 +76,7 @@ func (i *Instance) SetUpdatingParameters(
 
 // GetProvisioningParameters decrypts the EncryptedProvisioningParameters field
 // and unmarshals the result into the provided provisioningParameters object
-func (i *Instance) GetProvisioningParameters(
+func (i Instance) GetProvisioningParameters(
 	params ProvisioningParameters,
 	codec crypto.Codec,
 ) error {
@@ -94,7 +92,7 @@ func (i *Instance) GetProvisioningParameters(
 
 // GetUpdatingParameters decrypts the EncryptedUpdatingParameters field
 // and unmarshals the result into the provided updatingParameters object
-func (i *Instance) GetUpdatingParameters(
+func (i Instance) GetUpdatingParameters(
 	params UpdatingParameters,
 	codec crypto.Codec,
 ) error {
@@ -128,7 +126,7 @@ func (i *Instance) SetProvisioningContext(
 
 // GetProvisioningContext decrypts the EncryptedProvisioningContext field and
 // unmarshals the result into the provided provisioningContext object
-func (i *Instance) GetProvisioningContext(
+func (i Instance) GetProvisioningContext(
 	context ProvisioningContext,
 	codec crypto.Codec,
 ) error {

--- a/pkg/service/instance_test.go
+++ b/pkg/service/instance_test.go
@@ -23,10 +23,19 @@ func init() {
 	resourceGroup := "test-rg"
 	tagKey := "foo"
 	tagVal := "bar"
+	provisioningParameters := &ArbitraryType{
+		Foo: "bar",
+	}
 	encryptedProvisiongingParameters := []byte(`{"foo":"bar"}`)
-	encryptedUpdatingParameters := []byte(`{"foo":"bar"}`)
+	updatingParameters := &ArbitraryType{
+		Foo: "bat",
+	}
+	encryptedUpdatingParameters := []byte(`{"foo":"bat"}`)
 	statusReason := "in-progress"
-	encryptedProvisiongingContext := []byte(`{"baz":"bat"}`)
+	provisioningContext := &ArbitraryType{
+		Foo: "baz",
+	}
+	encryptedProvisiongingContext := []byte(`{"foo":"baz"}`)
 	created, err := time.Parse(time.RFC3339, "2016-07-22T10:11:55-04:00")
 	if err != nil {
 		panic(err)
@@ -42,16 +51,19 @@ func init() {
 			Tags:          map[string]string{tagKey: tagVal},
 		},
 		EncryptedProvisioningParameters: encryptedProvisiongingParameters,
+		ProvisioningParameters:          provisioningParameters,
 		EncryptedUpdatingParameters:     encryptedUpdatingParameters,
-		Status:       InstanceStateProvisioning,
-		StatusReason: statusReason,
+		UpdatingParameters:              updatingParameters,
+		Status:                          InstanceStateProvisioning,
+		StatusReason:                    statusReason,
 		StandardProvisioningContext: StandardProvisioningContext{
 			Location:      location,
 			ResourceGroup: resourceGroup,
 			Tags:          map[string]string{tagKey: tagVal},
 		},
 		EncryptedProvisioningContext: encryptedProvisiongingContext,
-		Created: created,
+		ProvisioningContext:          provisioningContext,
+		Created:                      created,
 	}
 
 	b64EncryptedProvisioningParameters := base64.StdEncoding.EncodeToString(
@@ -111,67 +123,94 @@ func init() {
 }
 
 func TestNewInstanceFromJSON(t *testing.T) {
-	instance, err := NewInstanceFromJSON(testInstanceJSON)
+	instance, err := NewInstanceFromJSON(
+		testInstanceJSON,
+		&ArbitraryType{},
+		&ArbitraryType{},
+		&ArbitraryType{},
+		noopCodec,
+	)
 	assert.Nil(t, err)
 	assert.Equal(t, testInstance, instance)
 }
 
 func TestInstanceToJSON(t *testing.T) {
-	json, err := testInstance.ToJSON()
+	json, err := testInstance.ToJSON(noopCodec)
 	assert.Nil(t, err)
 	assert.Equal(t, testInstanceJSON, json)
 }
 
-func TestSetProvisioningParametersOnInstance(t *testing.T) {
-	err := testInstance.SetProvisioningParameters(testArbitraryObject, noopCodec)
+func TestEncryptProvisioningParameters(t *testing.T) {
+	instance := Instance{
+		ProvisioningParameters: testArbitraryObject,
+	}
+	var err error
+	instance, err = instance.encryptProvisioningParameters(noopCodec)
 	assert.Nil(t, err)
 	assert.Equal(
 		t,
 		testArbitraryObjectJSON,
-		testInstance.EncryptedProvisioningParameters,
+		instance.EncryptedProvisioningParameters,
 	)
 }
 
-func TestSetUpdatingParametersOnInstance(t *testing.T) {
-	err := testInstance.SetUpdatingParameters(testArbitraryObject, noopCodec)
+func TestEncryptUpdatingParameters(t *testing.T) {
+	instance := Instance{
+		UpdatingParameters: testArbitraryObject,
+	}
+	var err error
+	instance, err = instance.encryptUpdatingParameters(noopCodec)
 	assert.Nil(t, err)
 	assert.Equal(
 		t,
 		testArbitraryObjectJSON,
-		testInstance.EncryptedUpdatingParameters,
+		instance.EncryptedUpdatingParameters,
 	)
 }
 
-func TestGetProvisioningParametersOnInstance(t *testing.T) {
-	testInstance.EncryptedProvisioningParameters = testArbitraryObjectJSON
-	pp := &ArbitraryType{}
-	err := testInstance.GetProvisioningParameters(pp, noopCodec)
-	assert.Nil(t, err)
-	assert.Equal(t, testArbitraryObject, pp)
-}
-
-func TestGetUpdatingParametersOnInstance(t *testing.T) {
-	testInstance.EncryptedUpdatingParameters = testArbitraryObjectJSON
-	up := &ArbitraryType{}
-	err := testInstance.GetUpdatingParameters(up, noopCodec)
-	assert.Nil(t, err)
-	assert.Equal(t, testArbitraryObject, up)
-}
-
-func TestSetProvisioningContextOnInstance(t *testing.T) {
-	err := testInstance.SetProvisioningContext(testArbitraryObject, noopCodec)
+func TestEncryptProvisioningContext(t *testing.T) {
+	instance := Instance{
+		ProvisioningContext: testArbitraryObject,
+	}
+	var err error
+	instance, err = instance.encryptProvisioningContext(noopCodec)
 	assert.Nil(t, err)
 	assert.Equal(
 		t,
-		testInstance.EncryptedProvisioningContext,
+		instance.EncryptedProvisioningContext,
 		testArbitraryObjectJSON,
 	)
 }
 
-func TestGetProvisioningContextOnInstance(t *testing.T) {
-	testInstance.EncryptedProvisioningContext = testArbitraryObjectJSON
-	pc := &ArbitraryType{}
-	err := testInstance.GetProvisioningContext(pc, noopCodec)
+func TestDecryptProvisioningParameters(t *testing.T) {
+	instance := Instance{
+		EncryptedProvisioningParameters: testArbitraryObjectJSON,
+		ProvisioningParameters:          &ArbitraryType{},
+	}
+	var err error
+	instance, err = instance.decryptProvisioningParameters(noopCodec)
 	assert.Nil(t, err)
-	assert.Equal(t, testArbitraryObject, pc)
+	assert.Equal(t, testArbitraryObject, instance.ProvisioningParameters)
+}
+
+func TestDecryptUpdatingParameters(t *testing.T) {
+	instance := Instance{
+		EncryptedUpdatingParameters: testArbitraryObjectJSON,
+		UpdatingParameters:          &ArbitraryType{},
+	}
+	var err error
+	instance, err = instance.decryptUpdatingParameters(noopCodec)
+	assert.Nil(t, err)
+	assert.Equal(t, testArbitraryObject, instance.UpdatingParameters)
+}
+
+func TestDecryptProvisioningContext(t *testing.T) {
+	instance := Instance{
+		EncryptedProvisioningContext: testArbitraryObjectJSON,
+		ProvisioningContext:          &ArbitraryType{},
+	}
+	var err error
+	instance, err = instance.decryptProvisioningContext(noopCodec)
+	assert.Nil(t, err)
+	assert.Equal(t, testArbitraryObject, instance.ProvisioningContext)
 }

--- a/pkg/service/instance_test.go
+++ b/pkg/service/instance_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	testInstance     *Instance
+	testInstance     Instance
 	testInstanceJSON []byte
 )
 
@@ -32,7 +32,7 @@ func init() {
 		panic(err)
 	}
 
-	testInstance = &Instance{
+	testInstance = Instance{
 		InstanceID: instanceID,
 		ServiceID:  serviceID,
 		PlanID:     planID,

--- a/pkg/service/provisioner.go
+++ b/pkg/service/provisioner.go
@@ -9,11 +9,8 @@ import (
 // provisioning step
 type ProvisioningStepFunction func(
 	ctx context.Context,
-	instanceID string,
+	instance Instance,
 	plan Plan,
-	standardProvisioningContext StandardProvisioningContext,
-	provisioningContext ProvisioningContext,
-	params ProvisioningParameters,
 ) (ProvisioningContext, error)
 
 // ProvisioningStep is an interface to be implemented by types that represent
@@ -22,11 +19,8 @@ type ProvisioningStep interface {
 	GetName() string
 	Execute(
 		ctx context.Context,
-		instanceID string,
+		instance Instance,
 		plan Plan,
-		standardProvisioningContext StandardProvisioningContext,
-		provisioningContext ProvisioningContext,
-		params ProvisioningParameters,
 	) (ProvisioningContext, error)
 }
 
@@ -68,21 +62,15 @@ func (p *provisioningStep) GetName() string {
 // Execute executes a step
 func (p *provisioningStep) Execute(
 	ctx context.Context,
-	instanceID string,
+	instance Instance,
 	plan Plan,
-	standardProvisioningContext StandardProvisioningContext,
-	provisioningContext ProvisioningContext,
-	params ProvisioningParameters,
 ) (ProvisioningContext, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	return p.fn(
 		ctx,
-		instanceID,
+		instance,
 		plan,
-		standardProvisioningContext,
-		provisioningContext,
-		params,
 	)
 }
 

--- a/pkg/service/service_manager.go
+++ b/pkg/service/service_manager.go
@@ -31,11 +31,7 @@ type ServiceManager interface { // nolint: golint
 	// returns an error if there is any problem
 	ValidateBindingParameters(BindingParameters) error
 	// Bind synchronously binds to a service
-	Bind(
-		StandardProvisioningContext,
-		ProvisioningContext,
-		BindingParameters,
-	) (BindingContext, Credentials, error)
+	Bind(Instance, BindingParameters) (BindingContext, Credentials, error)
 	// GetEmptyBindingContext returns an empty instance of a module-specific
 	// bindingContext
 	GetEmptyBindingContext() BindingContext
@@ -43,7 +39,7 @@ type ServiceManager interface { // nolint: golint
 	// credentials
 	GetEmptyCredentials() Credentials
 	// Unbind synchronously unbinds from a service
-	Unbind(StandardProvisioningContext, ProvisioningContext, BindingContext) error
+	Unbind(Instance, BindingContext) error
 	// GetDeprovisioner returns a deprovisioner that defines the steps a module
 	// must execute asynchronously to deprovision a service
 	GetDeprovisioner(Plan) (Deprovisioner, error)

--- a/pkg/service/updater.go
+++ b/pkg/service/updater.go
@@ -9,11 +9,8 @@ import (
 // updating step
 type UpdatingStepFunction func(
 	ctx context.Context,
-	instanceID string,
+	instance Instance,
 	plan Plan,
-	standardProvisioningContext StandardProvisioningContext,
-	provisioningContext ProvisioningContext,
-	params UpdatingParameters,
 ) (ProvisioningContext, error)
 
 // UpdatingStep is an interface to be implemented by types that represent
@@ -22,11 +19,8 @@ type UpdatingStep interface {
 	GetName() string
 	Execute(
 		ctx context.Context,
-		instanceID string,
+		instance Instance,
 		plan Plan,
-		standardProvisioningContext StandardProvisioningContext,
-		provisioningContext ProvisioningContext,
-		params UpdatingParameters,
 	) (ProvisioningContext, error)
 }
 
@@ -68,21 +62,15 @@ func (u *updatingStep) GetName() string {
 // Execute executes a step
 func (u *updatingStep) Execute(
 	ctx context.Context,
-	instanceID string,
+	instance Instance,
 	plan Plan,
-	standardProvisioningContext StandardProvisioningContext,
-	provisioningContext ProvisioningContext,
-	params UpdatingParameters,
 ) (ProvisioningContext, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	return u.fn(
 		ctx,
-		instanceID,
+		instance,
 		plan,
-		standardProvisioningContext,
-		provisioningContext,
-		params,
 	)
 }
 

--- a/pkg/services/aci/bind.go
+++ b/pkg/services/aci/bind.go
@@ -16,7 +16,7 @@ func (s *serviceManager) ValidateBindingParameters(
 
 func (s *serviceManager) Bind(
 	instance service.Instance,
-	bindingParameters service.BindingParameters,
+	_ service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
 	pc, ok := instance.ProvisioningContext.(*aciProvisioningContext)
 	if !ok {

--- a/pkg/services/aci/bind.go
+++ b/pkg/services/aci/bind.go
@@ -15,14 +15,13 @@ func (s *serviceManager) ValidateBindingParameters(
 }
 
 func (s *serviceManager) Bind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingParameters service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
-	pc, ok := provisioningContext.(*aciProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*aciProvisioningContext)
 	if !ok {
 		return nil, nil, fmt.Errorf(
-			"error casting provisioningContext as *aciProvisioningContext",
+			"error casting instance.ProvisioningContext as *aciProvisioningContext",
 		)
 	}
 

--- a/pkg/services/aci/deprovision.go
+++ b/pkg/services/aci/deprovision.go
@@ -18,20 +18,18 @@ func (s *serviceManager) GetDeprovisioner(
 
 func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*aciProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*aciProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *aciProvisioningContext",
+			"error casting instance.ProvisioningContext as *aciProvisioningContext",
 		)
 	}
 	if err := s.armDeployer.Delete(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting ARM deployment: %s", err)
 	}
@@ -40,20 +38,18 @@ func (s *serviceManager) deleteARMDeployment(
 
 func (s *serviceManager) deleteACIServer(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*aciProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*aciProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *aciProvisioningContext",
+			"error casting instance.ProvisioningContext as *aciProvisioningContext",
 		)
 	}
 	if err := s.aciManager.DeleteACI(
 		pc.ContainerName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting key vault: %s", err)
 	}

--- a/pkg/services/aci/provision.go
+++ b/pkg/services/aci/provision.go
@@ -40,7 +40,7 @@ func (s *serviceManager) GetProvisioner(
 func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
-	plan service.Plan,
+	_ service.Plan,
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*aciProvisioningContext)
 	if !ok {
@@ -56,7 +56,7 @@ func (s *serviceManager) preProvision(
 func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
-	plan service.Plan,
+	_ service.Plan,
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*aciProvisioningContext)
 	if !ok {

--- a/pkg/services/aci/provision.go
+++ b/pkg/services/aci/provision.go
@@ -39,16 +39,13 @@ func (s *serviceManager) GetProvisioner(
 
 func (s *serviceManager) preProvision(
 	_ context.Context,
-	_ string, // instanceID
-	_ service.Plan,
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
+	instance service.Instance,
+	plan service.Plan,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*aciProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*aciProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *aciProvisioningContext",
+			"error casting instance.ProvisioningContext as *aciProvisioningContext",
 		)
 	}
 	pc.ARMDeploymentName = uuid.NewV4().String()
@@ -58,30 +55,27 @@ func (s *serviceManager) preProvision(
 
 func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
-	_ string, // instanceID
-	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	provisioningParameters service.ProvisioningParameters,
+	instance service.Instance,
+	plan service.Plan,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*aciProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*aciProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *aciProvisioningContext",
+			"error casting instance.ProvisioningContext as *aciProvisioningContext",
 		)
 	}
-	pp, ok := provisioningParameters.(*ProvisioningParameters)
+	pp, ok := instance.ProvisioningParameters.(*ProvisioningParameters)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningParameters as " +
+			"error casting instance.ProvisioningParameters as " +
 				"*aci.ProvisioningParameters",
 		)
 	}
 
 	outputs, err := s.armDeployer.Deploy(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
-		standardProvisioningContext.Location,
+		instance.StandardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.Location,
 		armTemplateBytes,
 		pp, // Go template params
 		map[string]interface{}{ // ARM template params
@@ -90,7 +84,7 @@ func (s *serviceManager) deployARMTemplate(
 			"cpuCores":   pp.NumberCores,
 			"memoryInGb": fmt.Sprintf("%f", pp.Memory),
 		},
-		standardProvisioningContext.Tags,
+		instance.StandardProvisioningContext.Tags,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error deploying ARM template: %s", err)

--- a/pkg/services/aci/unbind.go
+++ b/pkg/services/aci/unbind.go
@@ -5,8 +5,7 @@ import (
 )
 
 func (s *serviceManager) Unbind(
-	_ service.StandardProvisioningContext,
-	_ service.ProvisioningContext,
+	_ service.Instance,
 	_ service.BindingContext,
 ) error {
 	return nil

--- a/pkg/services/cosmosdb/bind.go
+++ b/pkg/services/cosmosdb/bind.go
@@ -15,14 +15,14 @@ func (s *serviceManager) ValidateBindingParameters(
 }
 
 func (s *serviceManager) Bind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingParameters service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
-	pc, ok := provisioningContext.(*cosmosdbProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*cosmosdbProvisioningContext)
 	if !ok {
 		return nil, nil, fmt.Errorf(
-			"error casting provisioningContext as *cosmosdbProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*cosmosdbProvisioningContext",
 		)
 	}
 	if pc.DatabaseKind == databaseKindMongoDB {

--- a/pkg/services/cosmosdb/bind.go
+++ b/pkg/services/cosmosdb/bind.go
@@ -16,7 +16,7 @@ func (s *serviceManager) ValidateBindingParameters(
 
 func (s *serviceManager) Bind(
 	instance service.Instance,
-	bindingParameters service.BindingParameters,
+	_ service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
 	pc, ok := instance.ProvisioningContext.(*cosmosdbProvisioningContext)
 	if !ok {

--- a/pkg/services/cosmosdb/deprovision.go
+++ b/pkg/services/cosmosdb/deprovision.go
@@ -21,20 +21,19 @@ func (s *serviceManager) GetDeprovisioner(
 
 func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*cosmosdbProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*cosmosdbProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *cosmosdbProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*cosmosdbProvisioningContext",
 		)
 	}
 	if err := s.armDeployer.Delete(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting ARM deployment: %s", err)
 	}
@@ -43,20 +42,19 @@ func (s *serviceManager) deleteARMDeployment(
 
 func (s *serviceManager) deleteCosmosDBServer(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*cosmosdbProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*cosmosdbProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *cosmosdbProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*cosmosdbProvisioningContext",
 		)
 	}
 	if err := s.cosmosdbManager.DeleteDatabaseAccount(
 		pc.DatabaseAccountName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting cosmosdb server: %s", err)
 	}

--- a/pkg/services/cosmosdb/unbind.go
+++ b/pkg/services/cosmosdb/unbind.go
@@ -5,8 +5,7 @@ import (
 )
 
 func (s *serviceManager) Unbind(
-	_ service.StandardProvisioningContext,
-	_ service.ProvisioningContext,
+	_ service.Instance,
 	_ service.BindingContext,
 ) error {
 	return nil

--- a/pkg/services/eventhubs/bind.go
+++ b/pkg/services/eventhubs/bind.go
@@ -15,14 +15,14 @@ func (s *serviceManager) ValidateBindingParameters(
 }
 
 func (s *serviceManager) Bind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingParameters service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
-	pc, ok := provisioningContext.(*eventHubProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*eventHubProvisioningContext)
 	if !ok {
 		return nil, nil, fmt.Errorf(
-			"error casting provisioningContext as eventHubProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"eventHubProvisioningContext",
 		)
 	}
 

--- a/pkg/services/eventhubs/bind.go
+++ b/pkg/services/eventhubs/bind.go
@@ -16,7 +16,7 @@ func (s *serviceManager) ValidateBindingParameters(
 
 func (s *serviceManager) Bind(
 	instance service.Instance,
-	bindingParameters service.BindingParameters,
+	_ service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
 	pc, ok := instance.ProvisioningContext.(*eventHubProvisioningContext)
 	if !ok {

--- a/pkg/services/eventhubs/deprovision.go
+++ b/pkg/services/eventhubs/deprovision.go
@@ -18,20 +18,19 @@ func (s *serviceManager) GetDeprovisioner(
 
 func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*eventHubProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*eventHubProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *eventHubProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*eventHubProvisioningContext",
 		)
 	}
 	if err := s.armDeployer.Delete(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting ARM deployment: %s", err)
 	}
@@ -40,19 +39,18 @@ func (s *serviceManager) deleteARMDeployment(
 
 func (s *serviceManager) deleteNamespace(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*eventHubProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*eventHubProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *eventHubProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*eventHubProvisioningContext",
 		)
 	}
 	if err := s.eventHubManager.DeleteNamespace(
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 		pc.EventHubNamespace,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting event hub namespace: %s", err)

--- a/pkg/services/eventhubs/provision.go
+++ b/pkg/services/eventhubs/provision.go
@@ -27,16 +27,14 @@ func (s *serviceManager) GetProvisioner(
 
 func (s *serviceManager) preProvision(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*eventHubProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*eventHubProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *eventHubProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*eventHubProvisioningContext",
 		)
 	}
 	pc.ARMDeploymentName = uuid.NewV4().String()
@@ -47,22 +45,20 @@ func (s *serviceManager) preProvision(
 
 func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	plan service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*eventHubProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*eventHubProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *eventHubProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*eventHubProvisioningContext",
 		)
 	}
 	outputs, err := s.armDeployer.Deploy(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
-		standardProvisioningContext.Location,
+		instance.StandardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.Location,
 		armTemplateBytes,
 		nil, // Go template params
 		map[string]interface{}{ // ARM template params
@@ -70,7 +66,7 @@ func (s *serviceManager) deployARMTemplate(
 			"eventHubNamespace": pc.EventHubNamespace,
 			"eventHubSku":       plan.GetProperties().Extended["eventHubSku"],
 		},
-		standardProvisioningContext.Tags,
+		instance.StandardProvisioningContext.Tags,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error deploying ARM template: %s", err)

--- a/pkg/services/eventhubs/unbind.go
+++ b/pkg/services/eventhubs/unbind.go
@@ -5,8 +5,7 @@ import (
 )
 
 func (s *serviceManager) Unbind(
-	_ service.StandardProvisioningContext,
-	_ service.ProvisioningContext,
+	_ service.Instance,
 	_ service.BindingContext,
 ) error {
 	return nil

--- a/pkg/services/fake/fake.go
+++ b/pkg/services/fake/fake.go
@@ -97,13 +97,10 @@ func (s *ServiceManager) GetProvisioner(
 
 func (s *ServiceManager) provision(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	return provisioningContext, nil
+	return instance.ProvisioningContext, nil
 }
 
 // ValidateUpdatingParameters validates the provided updatingParameters

--- a/pkg/services/fake/fake.go
+++ b/pkg/services/fake/fake.go
@@ -140,26 +140,24 @@ func (s *ServiceManager) ValidateBindingParameters(
 
 // Bind synchronously binds to a service
 func (s *ServiceManager) Bind(
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingParameters service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
 	return s.BindBehavior(
-		standardProvisioningContext,
-		provisioningContext,
+		instance.StandardProvisioningContext,
+		instance.ProvisioningContext,
 		bindingParameters,
 	)
 }
 
 // Unbind synchronously unbinds from a service
 func (s *ServiceManager) Unbind(
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingContext service.BindingContext,
 ) error {
 	return s.UnbindBehavior(
-		standardProvisioningContext,
-		provisioningContext,
+		instance.StandardProvisioningContext,
+		instance.ProvisioningContext,
 		bindingContext,
 	)
 }

--- a/pkg/services/fake/fake.go
+++ b/pkg/services/fake/fake.go
@@ -176,12 +176,10 @@ func (s *ServiceManager) GetDeprovisioner(
 
 func (s *ServiceManager) deprovision(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	return provisioningContext, nil
+	return instance.ProvisioningContext, nil
 }
 
 func defaultProvisioningValidationBehavior(

--- a/pkg/services/fake/fake.go
+++ b/pkg/services/fake/fake.go
@@ -121,13 +121,10 @@ func (s *ServiceManager) GetUpdater(service.Plan) (service.Updater, error) {
 
 func (s *ServiceManager) update(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.UpdatingParameters,
 ) (service.ProvisioningContext, error) {
-	return provisioningContext, nil
+	return instance.ProvisioningContext, nil
 }
 
 // ValidateBindingParameters validates the provided bindingParameters and

--- a/pkg/services/keyvault/bind.go
+++ b/pkg/services/keyvault/bind.go
@@ -16,7 +16,7 @@ func (s *serviceManager) ValidateBindingParameters(
 
 func (s *serviceManager) Bind(
 	instance service.Instance,
-	bindingParameters service.BindingParameters,
+	_ service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
 	pc, ok := instance.ProvisioningContext.(*keyvaultProvisioningContext)
 	if !ok {

--- a/pkg/services/keyvault/bind.go
+++ b/pkg/services/keyvault/bind.go
@@ -15,14 +15,14 @@ func (s *serviceManager) ValidateBindingParameters(
 }
 
 func (s *serviceManager) Bind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingParameters service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
-	pc, ok := provisioningContext.(*keyvaultProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*keyvaultProvisioningContext)
 	if !ok {
 		return nil, nil, fmt.Errorf(
-			"error casting provisioningContext as *keyvaultProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*keyvaultProvisioningContext",
 		)
 	}
 

--- a/pkg/services/keyvault/deprovision.go
+++ b/pkg/services/keyvault/deprovision.go
@@ -21,20 +21,19 @@ func (s *serviceManager) GetDeprovisioner(
 
 func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*keyvaultProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*keyvaultProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *keyvaultProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*keyvaultProvisioningContext",
 		)
 	}
 	if err := s.armDeployer.Delete(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting ARM deployment: %s", err)
 	}
@@ -43,20 +42,19 @@ func (s *serviceManager) deleteARMDeployment(
 
 func (s *serviceManager) deleteKeyVaultServer(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*keyvaultProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*keyvaultProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *keyvaultProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*keyvaultProvisioningContext",
 		)
 	}
 	if err := s.keyvaultManager.DeleteVault(
 		pc.KeyVaultName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting key vault: %s", err)
 	}

--- a/pkg/services/keyvault/unbind.go
+++ b/pkg/services/keyvault/unbind.go
@@ -5,8 +5,7 @@ import (
 )
 
 func (s *serviceManager) Unbind(
-	_ service.StandardProvisioningContext,
-	_ service.ProvisioningContext,
+	_ service.Instance,
 	_ service.BindingContext,
 ) error {
 	return nil

--- a/pkg/services/mysqldb/bind.go
+++ b/pkg/services/mysqldb/bind.go
@@ -17,7 +17,7 @@ func (s *serviceManager) ValidateBindingParameters(
 
 func (s *serviceManager) Bind(
 	instance service.Instance,
-	bindingParameters service.BindingParameters,
+	_ service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
 	pc, ok := instance.ProvisioningContext.(*mysqlProvisioningContext)
 	if !ok {

--- a/pkg/services/mysqldb/bind.go
+++ b/pkg/services/mysqldb/bind.go
@@ -16,14 +16,13 @@ func (s *serviceManager) ValidateBindingParameters(
 }
 
 func (s *serviceManager) Bind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingParameters service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
-	pc, ok := provisioningContext.(*mysqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*mysqlProvisioningContext)
 	if !ok {
 		return nil, nil, fmt.Errorf(
-			"error casting provisioningContext as *mysqlProvisioningContext",
+			"error casting instance.ProvisioningContext as *mysqlProvisioningContext",
 		)
 	}
 

--- a/pkg/services/mysqldb/deprovision.go
+++ b/pkg/services/mysqldb/deprovision.go
@@ -12,29 +12,24 @@ func (s *serviceManager) GetDeprovisioner(
 ) (service.Deprovisioner, error) {
 	return service.NewDeprovisioner(
 		service.NewDeprovisioningStep("deleteARMDeployment", s.deleteARMDeployment),
-		service.NewDeprovisioningStep(
-			"deleteMySQLServer",
-			s.deleteMySQLServer,
-		),
+		service.NewDeprovisioningStep("deleteMySQLServer", s.deleteMySQLServer),
 	)
 }
 
 func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*mysqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*mysqlProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *mysqlProvisioningContext",
+			"error casting instance.ProvisioningContext as *mysqlProvisioningContext",
 		)
 	}
 	if err := s.armDeployer.Delete(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting ARM deployment: %s", err)
 	}
@@ -43,20 +38,18 @@ func (s *serviceManager) deleteARMDeployment(
 
 func (s *serviceManager) deleteMySQLServer(
 	_ context.Context,
-	_ string, // instanceID
-	_ service.Plan, // planID
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
+	_ service.Plan,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*mysqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*mysqlProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *mysqlProvisioningContext",
+			"error casting instance.ProvisioningContext as *mysqlProvisioningContext",
 		)
 	}
 	if err := s.mysqlManager.DeleteServer(
 		pc.ServerName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting mysql server: %s", err)
 	}

--- a/pkg/services/mysqldb/provision.go
+++ b/pkg/services/mysqldb/provision.go
@@ -44,22 +44,20 @@ func (s *serviceManager) GetProvisioner(
 
 func (s *serviceManager) preProvision(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	provisioningParameters service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*mysqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*mysqlProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *mysqlProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*mysqlProvisioningContext",
 		)
 	}
-	pp, ok := provisioningParameters.(*ProvisioningParameters)
+	pp, ok := instance.ProvisioningParameters.(*ProvisioningParameters)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningParameters as " +
+			"error casting instance.ProvisioningParameters as " +
 				"*mysql.ProvisioningParameters",
 		)
 	}
@@ -81,16 +79,14 @@ func (s *serviceManager) preProvision(
 
 func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
-	_ string, //instanceID
+	instance service.Instance,
 	plan service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*mysqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*mysqlProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *mysqlProvisioningContext",
+			"error casting instance.ProvisioningContext " +
+				"as *mysqlProvisioningContext",
 		)
 	}
 	var sslEnforcement string
@@ -101,8 +97,8 @@ func (s *serviceManager) deployARMTemplate(
 	}
 	outputs, err := s.armDeployer.Deploy(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
-		standardProvisioningContext.Location,
+		instance.StandardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.Location,
 		armTemplateBytes,
 		nil, // Go template params
 		map[string]interface{}{ // ARM template params
@@ -116,7 +112,7 @@ func (s *serviceManager) deployARMTemplate(
 			"skuSizeMB":      plan.GetProperties().Extended["skuSizeMB"],
 			"sslEnforcement": sslEnforcement,
 		},
-		standardProvisioningContext.Tags,
+		instance.StandardProvisioningContext.Tags,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error deploying ARM template: %s", err)

--- a/pkg/services/mysqldb/unbind.go
+++ b/pkg/services/mysqldb/unbind.go
@@ -7,14 +7,13 @@ import (
 )
 
 func (s *serviceManager) Unbind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingContext service.BindingContext,
 ) error {
-	pc, ok := provisioningContext.(*mysqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*mysqlProvisioningContext)
 	if !ok {
 		return fmt.Errorf(
-			"error casting provisioningContext as *mysqlProvisioningContext",
+			"error casting instance.ProvisioningContext as *mysqlProvisioningContext",
 		)
 	}
 	bc, ok := bindingContext.(*mysqlBindingContext)

--- a/pkg/services/postgresqldb/bind.go
+++ b/pkg/services/postgresqldb/bind.go
@@ -18,7 +18,7 @@ func (s *serviceManager) ValidateBindingParameters(
 
 func (s *serviceManager) Bind(
 	instance service.Instance,
-	bindingParameters service.BindingParameters,
+	_ service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
 	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {

--- a/pkg/services/postgresqldb/bind.go
+++ b/pkg/services/postgresqldb/bind.go
@@ -17,14 +17,14 @@ func (s *serviceManager) ValidateBindingParameters(
 }
 
 func (s *serviceManager) Bind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingParameters service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
-	pc, ok := provisioningContext.(*postgresqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
 		return nil, nil, fmt.Errorf(
-			"error casting provisioningContext as *postgresqlProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*postgresqlProvisioningContext",
 		)
 	}
 

--- a/pkg/services/postgresqldb/deprovision.go
+++ b/pkg/services/postgresqldb/deprovision.go
@@ -21,20 +21,19 @@ func (s *serviceManager) GetDeprovisioner(
 
 func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*postgresqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *postgresqlProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*postgresqlProvisioningContext",
 		)
 	}
 	if err := s.armDeployer.Delete(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting ARM deployment: %s", err)
 	}
@@ -43,20 +42,19 @@ func (s *serviceManager) deleteARMDeployment(
 
 func (s *serviceManager) deletePostgreSQLServer(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*postgresqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *postgresqlProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*postgresqlProvisioningContext",
 		)
 	}
 	if err := s.postgresqlManager.DeleteServer(
 		pc.ServerName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting postgresql server: %s", err)
 	}

--- a/pkg/services/postgresqldb/provision.go
+++ b/pkg/services/postgresqldb/provision.go
@@ -47,22 +47,20 @@ func (s *serviceManager) GetProvisioner(
 
 func (s *serviceManager) preProvision(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	provisioningParameters service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*postgresqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *postgresqlProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*postgresqlProvisioningContext",
 		)
 	}
-	pp, ok := provisioningParameters.(*ProvisioningParameters)
+	pp, ok := instance.ProvisioningParameters.(*ProvisioningParameters)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningParameters as " +
+			"error casting instance.ProvisioningParameters as " +
 				"*postgresql.ProvisioningParameters",
 		)
 	}
@@ -84,16 +82,14 @@ func (s *serviceManager) preProvision(
 
 func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	plan service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*postgresqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *postgresqlProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*postgresqlProvisioningContext",
 		)
 	}
 	var sslEnforcement string
@@ -104,8 +100,8 @@ func (s *serviceManager) deployARMTemplate(
 	}
 	outputs, err := s.armDeployer.Deploy(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
-		standardProvisioningContext.Location,
+		instance.StandardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.Location,
 		armTemplateBytes,
 		nil, // Go template params
 		map[string]interface{}{ // ARM template params
@@ -118,7 +114,7 @@ func (s *serviceManager) deployARMTemplate(
 				Extended["skuCapacityDTU"],
 			"sslEnforcement": sslEnforcement,
 		},
-		standardProvisioningContext.Tags,
+		instance.StandardProvisioningContext.Tags,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error deploying ARM template: %s", err)
@@ -138,16 +134,14 @@ func (s *serviceManager) deployARMTemplate(
 
 func (s *serviceManager) setupDatabase(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*postgresqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *postgresqlProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*postgresqlProvisioningContext",
 		)
 	}
 
@@ -204,22 +198,20 @@ func (s *serviceManager) setupDatabase(
 
 func (s *serviceManager) createExtensions(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	provisioningParameters service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*postgresqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *postgresqlProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*postgresqlProvisioningContext",
 		)
 	}
-	pp, ok := provisioningParameters.(*ProvisioningParameters)
+	pp, ok := instance.ProvisioningParameters.(*ProvisioningParameters)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningParameters as " +
+			"error casting instance.ProvisioningParameters as " +
 				"*postgresql.ProvisioningParameters",
 		)
 	}

--- a/pkg/services/postgresqldb/unbind.go
+++ b/pkg/services/postgresqldb/unbind.go
@@ -7,14 +7,14 @@ import (
 )
 
 func (s *serviceManager) Unbind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingContext service.BindingContext,
 ) error {
-	pc, ok := provisioningContext.(*postgresqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
 		return fmt.Errorf(
-			"error casting provisioningContext as *postgresqlProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*postgresqlProvisioningContext",
 		)
 	}
 	bc, ok := bindingContext.(*postgresqlBindingContext)

--- a/pkg/services/rediscache/bind.go
+++ b/pkg/services/rediscache/bind.go
@@ -16,7 +16,7 @@ func (s *serviceManager) ValidateBindingParameters(
 
 func (s *serviceManager) Bind(
 	instance service.Instance,
-	bindingParameters service.BindingParameters,
+	_ service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
 	pc, ok := instance.ProvisioningContext.(*redisProvisioningContext)
 	if !ok {

--- a/pkg/services/rediscache/bind.go
+++ b/pkg/services/rediscache/bind.go
@@ -15,14 +15,13 @@ func (s *serviceManager) ValidateBindingParameters(
 }
 
 func (s *serviceManager) Bind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingParameters service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
-	pc, ok := provisioningContext.(*redisProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*redisProvisioningContext)
 	if !ok {
 		return nil, nil, fmt.Errorf(
-			"error casting provisioningContext as *redisProvisioningContext",
+			"error casting instance.ProvisioningContext as *redisProvisioningContext",
 		)
 	}
 

--- a/pkg/services/rediscache/deprovision.go
+++ b/pkg/services/rediscache/deprovision.go
@@ -18,20 +18,18 @@ func (s *serviceManager) GetDeprovisioner(
 
 func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*redisProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*redisProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *redisProvisioningContext",
+			"error casting instance.ProvisioningContext as *redisProvisioningContext",
 		)
 	}
 	if err := s.armDeployer.Delete(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting ARM deployment: %s", err)
 	}
@@ -40,20 +38,18 @@ func (s *serviceManager) deleteARMDeployment(
 
 func (s *serviceManager) deleteRedisServer(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*redisProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*redisProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *redisProvisioningContext",
+			"error casting instance.ProvisioningContext as *redisProvisioningContext",
 		)
 	}
 	if err := s.redisManager.DeleteServer(
 		pc.ServerName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting redis server: %s", err)
 	}

--- a/pkg/services/rediscache/unbind.go
+++ b/pkg/services/rediscache/unbind.go
@@ -5,8 +5,7 @@ import (
 )
 
 func (s *serviceManager) Unbind(
-	_ service.StandardProvisioningContext,
-	_ service.ProvisioningContext,
+	_ service.Instance,
 	_ service.BindingContext,
 ) error {
 	return nil

--- a/pkg/services/search/bind.go
+++ b/pkg/services/search/bind.go
@@ -16,7 +16,7 @@ func (s *serviceManager) ValidateBindingParameters(
 
 func (s *serviceManager) Bind(
 	instance service.Instance,
-	bindingParameters service.BindingParameters,
+	_ service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
 	pc, ok := instance.ProvisioningContext.(*searchProvisioningContext)
 	if !ok {

--- a/pkg/services/search/bind.go
+++ b/pkg/services/search/bind.go
@@ -15,14 +15,13 @@ func (s *serviceManager) ValidateBindingParameters(
 }
 
 func (s *serviceManager) Bind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingParameters service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
-	pc, ok := provisioningContext.(*searchProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*searchProvisioningContext)
 	if !ok {
 		return nil, nil, fmt.Errorf(
-			"error casting provisioningContext as searchProvisioningContext",
+			"error casting instance.ProvisioningContext as searchProvisioningContext",
 		)
 	}
 

--- a/pkg/services/search/deprovision.go
+++ b/pkg/services/search/deprovision.go
@@ -18,20 +18,18 @@ func (s *serviceManager) GetDeprovisioner(
 
 func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*searchProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*searchProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as searchProvisioningContext",
+			"error casting instance.ProvisioningContext as searchProvisioningContext",
 		)
 	}
 	if err := s.armDeployer.Delete(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting ARM deployment: %s", err)
 	}
@@ -40,20 +38,18 @@ func (s *serviceManager) deleteARMDeployment(
 
 func (s *serviceManager) deleteAzureSearch(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*searchProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*searchProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as searchProvisioningContext",
+			"error casting instance.ProvisioningContext as searchProvisioningContext",
 		)
 	}
 	if err := s.searchManager.DeleteServer(
 		pc.ServiceName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting Azure Search: %s", err)
 	}

--- a/pkg/services/search/provision.go
+++ b/pkg/services/search/provision.go
@@ -27,16 +27,14 @@ func (s *serviceManager) GetProvisioner(
 
 func (s *serviceManager) preProvision(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*searchProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*searchProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *searchProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*searchProvisioningContext",
 		)
 	}
 	pc.ARMDeploymentName = uuid.NewV4().String()
@@ -46,29 +44,27 @@ func (s *serviceManager) preProvision(
 
 func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	plan service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*searchProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*searchProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *searchProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*searchProvisioningContext",
 		)
 	}
 	outputs, err := s.armDeployer.Deploy(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
-		standardProvisioningContext.Location,
+		instance.StandardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.Location,
 		armTemplateBytes,
 		nil, // Go template params
 		map[string]interface{}{ // ARM template params
 			"searchServiceName": pc.ServiceName,
 			"searchServiceSku":  plan.GetProperties().Extended["searchServiceSku"],
 		},
-		standardProvisioningContext.Tags,
+		instance.StandardProvisioningContext.Tags,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error deploying ARM template: %s", err)

--- a/pkg/services/search/unbind.go
+++ b/pkg/services/search/unbind.go
@@ -3,8 +3,7 @@ package search
 import "github.com/Azure/open-service-broker-azure/pkg/service"
 
 func (s *serviceManager) Unbind(
-	_ service.StandardProvisioningContext,
-	_ service.ProvisioningContext,
+	_ service.Instance,
 	_ service.BindingContext,
 ) error {
 	return nil

--- a/pkg/services/servicebus/bind.go
+++ b/pkg/services/servicebus/bind.go
@@ -15,14 +15,14 @@ func (s *serviceManager) ValidateBindingParameters(
 }
 
 func (s *serviceManager) Bind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingParameters service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
-	pc, ok := provisioningContext.(*serviceBusProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*serviceBusProvisioningContext)
 	if !ok {
 		return nil, nil, fmt.Errorf(
-			"error casting provisioningContext as serviceBusProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"serviceBusProvisioningContext",
 		)
 	}
 

--- a/pkg/services/servicebus/bind.go
+++ b/pkg/services/servicebus/bind.go
@@ -16,7 +16,7 @@ func (s *serviceManager) ValidateBindingParameters(
 
 func (s *serviceManager) Bind(
 	instance service.Instance,
-	bindingParameters service.BindingParameters,
+	_ service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
 	pc, ok := instance.ProvisioningContext.(*serviceBusProvisioningContext)
 	if !ok {

--- a/pkg/services/servicebus/deprovision.go
+++ b/pkg/services/servicebus/deprovision.go
@@ -18,20 +18,19 @@ func (s *serviceManager) GetDeprovisioner(
 
 func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*serviceBusProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*serviceBusProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *serviceBusProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*serviceBusProvisioningContext",
 		)
 	}
 	if err := s.armDeployer.Delete(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting ARM deployment: %s", err)
 	}
@@ -40,20 +39,19 @@ func (s *serviceManager) deleteARMDeployment(
 
 func (s *serviceManager) deleteNamespace(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*serviceBusProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*serviceBusProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *serviceBusProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*serviceBusProvisioningContext",
 		)
 	}
 	if err := s.serviceBusManager.DeleteNamespace(
 		pc.ServiceBusNamespaceName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting service bus namespace: %s", err)
 	}

--- a/pkg/services/servicebus/unbind.go
+++ b/pkg/services/servicebus/unbind.go
@@ -5,8 +5,7 @@ import (
 )
 
 func (s *serviceManager) Unbind(
-	_ service.StandardProvisioningContext,
-	_ service.ProvisioningContext,
+	_ service.Instance,
 	_ service.BindingContext,
 ) error {
 	return nil

--- a/pkg/services/sqldb/bind.go
+++ b/pkg/services/sqldb/bind.go
@@ -17,14 +17,13 @@ func (s *serviceManager) ValidateBindingParameters(
 }
 
 func (s *serviceManager) Bind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingParameters service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
-	pc, ok := provisioningContext.(*mssqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*mssqlProvisioningContext)
 	if !ok {
 		return nil, nil, fmt.Errorf(
-			"error casting provisioningContext as *mssqlProvisioningContext",
+			"error casting instance.ProvisioningContext as *mssqlProvisioningContext",
 		)
 	}
 

--- a/pkg/services/sqldb/bind.go
+++ b/pkg/services/sqldb/bind.go
@@ -18,7 +18,7 @@ func (s *serviceManager) ValidateBindingParameters(
 
 func (s *serviceManager) Bind(
 	instance service.Instance,
-	bindingParameters service.BindingParameters,
+	_ service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
 	pc, ok := instance.ProvisioningContext.(*mssqlProvisioningContext)
 	if !ok {

--- a/pkg/services/sqldb/deprovision.go
+++ b/pkg/services/sqldb/deprovision.go
@@ -11,10 +11,7 @@ func (s *serviceManager) GetDeprovisioner(
 	service.Plan,
 ) (service.Deprovisioner, error) {
 	return service.NewDeprovisioner(
-		service.NewDeprovisioningStep(
-			"deleteARMDeployment",
-			s.deleteARMDeployment,
-		),
+		service.NewDeprovisioningStep("deleteARMDeployment", s.deleteARMDeployment),
 		service.NewDeprovisioningStep(
 			"deleteMsSQLServerOrDatabase",
 			s.deleteMsSQLServerOrDatabase,
@@ -24,15 +21,13 @@ func (s *serviceManager) GetDeprovisioner(
 
 func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*mssqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*mssqlProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *mssqlProvisioningContext",
+			"error casting instance.ProvisioningContext as *mssqlProvisioningContext",
 		)
 	}
 	var err error
@@ -40,7 +35,7 @@ func (s *serviceManager) deleteARMDeployment(
 		// new server scenario
 		err = s.armDeployer.Delete(
 			pc.ARMDeploymentName,
-			standardProvisioningContext.ResourceGroup,
+			instance.StandardProvisioningContext.ResourceGroup,
 		)
 	} else {
 		// exisiting server scenario
@@ -66,15 +61,13 @@ func (s *serviceManager) deleteARMDeployment(
 
 func (s *serviceManager) deleteMsSQLServerOrDatabase(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*mssqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*mssqlProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as *mssqlProvisioningContext",
+			"error casting instance.ProvisioningContext as *mssqlProvisioningContext",
 		)
 	}
 
@@ -82,7 +75,7 @@ func (s *serviceManager) deleteMsSQLServerOrDatabase(
 		// new server scenario
 		if err := s.mssqlManager.DeleteServer(
 			pc.ServerName,
-			standardProvisioningContext.ResourceGroup,
+			instance.StandardProvisioningContext.ResourceGroup,
 		); err != nil {
 			return pc, fmt.Errorf("error deleting mssql server: %s", err)
 		}

--- a/pkg/services/sqldb/provision.go
+++ b/pkg/services/sqldb/provision.go
@@ -47,22 +47,19 @@ func (s *serviceManager) GetProvisioner(
 
 func (s *serviceManager) preProvision(
 	_ context.Context,
-	_ string, // instanceID
-	_ service.Plan, // planID
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	provisioningParameters service.ProvisioningParameters,
+	instance service.Instance,
+	_ service.Plan,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*mssqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*mssqlProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *mssqlProvisioningContext",
+			"error casting instance.ProvisioningContext as *mssqlProvisioningContext",
 		)
 	}
-	pp, ok := provisioningParameters.(*ProvisioningParameters)
+	pp, ok := instance.ProvisioningParameters.(*ProvisioningParameters)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningParameters as " +
+			"error casting instance.ProvisioningParameters as " +
 				"*mssql.ProvisioningParameters",
 		)
 	}
@@ -114,22 +111,19 @@ func (s *serviceManager) preProvision(
 
 func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	plan service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	provisioningParameters service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*mssqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*mssqlProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *mssqlProvisioningContext",
+			"error casting instance.ProvisioningContext as *mssqlProvisioningContext",
 		)
 	}
-	pp, ok := provisioningParameters.(*ProvisioningParameters)
+	pp, ok := instance.ProvisioningParameters.(*ProvisioningParameters)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningParameters as " +
+			"error casting instance.ProvisioningParameters as " +
 				"*mssql.ProvisioningParameters",
 		)
 	}
@@ -137,8 +131,8 @@ func (s *serviceManager) deployARMTemplate(
 		// new server scenario
 		outputs, err := s.armDeployer.Deploy(
 			pc.ARMDeploymentName,
-			standardProvisioningContext.ResourceGroup,
-			standardProvisioningContext.Location,
+			instance.StandardProvisioningContext.ResourceGroup,
+			instance.StandardProvisioningContext.Location,
 			armTemplateNewServerBytes,
 			nil, // Go template params
 			map[string]interface{}{ // ARM template params
@@ -152,7 +146,7 @@ func (s *serviceManager) deployARMTemplate(
 				"maxSizeBytes": plan.GetProperties().
 					Extended["maxSizeBytes"],
 			},
-			standardProvisioningContext.Tags,
+			instance.StandardProvisioningContext.Tags,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("error deploying ARM template: %s", err)
@@ -191,7 +185,7 @@ func (s *serviceManager) deployARMTemplate(
 				"maxSizeBytes": plan.GetProperties().
 					Extended["maxSizeBytes"],
 			},
-			standardProvisioningContext.Tags,
+			instance.StandardProvisioningContext.Tags,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("error deploying ARM template: %s", err)

--- a/pkg/services/sqldb/unbind.go
+++ b/pkg/services/sqldb/unbind.go
@@ -7,14 +7,13 @@ import (
 )
 
 func (s *serviceManager) Unbind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingContext service.BindingContext,
 ) error {
-	pc, ok := provisioningContext.(*mssqlProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*mssqlProvisioningContext)
 	if !ok {
 		return fmt.Errorf(
-			"error casting provisioningContext as *mssqlProvisioningContext",
+			"error casting instance.ProvisioningContext as *mssqlProvisioningContext",
 		)
 	}
 	bc, ok := bindingContext.(*mssqlBindingContext)

--- a/pkg/services/storage/bind.go
+++ b/pkg/services/storage/bind.go
@@ -16,7 +16,7 @@ func (s *serviceManager) ValidateBindingParameters(
 
 func (s *serviceManager) Bind(
 	instance service.Instance,
-	bindingParameters service.BindingParameters,
+	_ service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
 	pc, ok := instance.ProvisioningContext.(*storageProvisioningContext)
 	if !ok {

--- a/pkg/services/storage/bind.go
+++ b/pkg/services/storage/bind.go
@@ -15,14 +15,14 @@ func (s *serviceManager) ValidateBindingParameters(
 }
 
 func (s *serviceManager) Bind(
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
+	instance service.Instance,
 	bindingParameters service.BindingParameters,
 ) (service.BindingContext, service.Credentials, error) {
-	pc, ok := provisioningContext.(*storageProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*storageProvisioningContext)
 	if !ok {
 		return nil, nil, fmt.Errorf(
-			"error casting provisioningContext as storageProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"storageProvisioningContext",
 		)
 	}
 

--- a/pkg/services/storage/deprovision.go
+++ b/pkg/services/storage/deprovision.go
@@ -21,20 +21,19 @@ func (s *serviceManager) GetDeprovisioner(
 
 func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*storageProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*storageProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as storageProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"storageProvisioningContext",
 		)
 	}
 	if err := s.armDeployer.Delete(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting ARM deployment: %s", err)
 	}
@@ -43,20 +42,19 @@ func (s *serviceManager) deleteARMDeployment(
 
 func (s *serviceManager) deleteStorageAccount(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*storageProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*storageProvisioningContext)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting provisioningContext as storageProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"storageProvisioningContext",
 		)
 	}
 	if err := s.storageManager.DeleteStorageAccount(
 		pc.StorageAccountName,
-		standardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting storage account: %s", err)
 	}

--- a/pkg/services/storage/provision.go
+++ b/pkg/services/storage/provision.go
@@ -47,16 +47,14 @@ func (s *serviceManager) GetProvisioner(
 
 func (s *serviceManager) preProvision(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	plan service.Plan,
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*storageProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*storageProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *storageProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*storageProvisioningContext",
 		)
 	}
 	pc.ARMDeploymentName = uuid.NewV4().String()
@@ -80,16 +78,14 @@ func (s *serviceManager) preProvision(
 
 func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	plan service.Plan,
-	standardProvisioningContext service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*storageProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*storageProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *storageProvisioningContext",
+			"error casting instance.ProvisioningContext as " +
+				"*storageProvisioningContext",
 		)
 	}
 	storeKind, ok := plan.GetProperties().Extended[kindKey].(storageKind)
@@ -111,12 +107,12 @@ func (s *serviceManager) deployARMTemplate(
 	}
 	outputs, err := s.armDeployer.Deploy(
 		pc.ARMDeploymentName,
-		standardProvisioningContext.ResourceGroup,
-		standardProvisioningContext.Location,
+		instance.StandardProvisioningContext.ResourceGroup,
+		instance.StandardProvisioningContext.Location,
 		armTemplateBytes,
 		nil, // Go template params
 		armTemplateParameters, // ARM template params
-		standardProvisioningContext.Tags,
+		instance.StandardProvisioningContext.Tags,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error deploying ARM template: %s", err)
@@ -135,16 +131,14 @@ func (s *serviceManager) deployARMTemplate(
 
 func (s *serviceManager) createBlobContainer(
 	_ context.Context,
-	_ string, // instanceID
+	instance service.Instance,
 	_ service.Plan,
-	_ service.StandardProvisioningContext,
-	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
-	pc, ok := provisioningContext.(*storageProvisioningContext)
+	pc, ok := instance.ProvisioningContext.(*storageProvisioningContext)
 	if !ok {
 		return nil, errors.New(
-			"error casting provisioningContext as *storageProvisioningContext",
+			"error casting instance.ProvisioningContext " +
+				"as *storageProvisioningContext",
 		)
 	}
 

--- a/pkg/services/storage/unbind.go
+++ b/pkg/services/storage/unbind.go
@@ -5,8 +5,7 @@ import (
 )
 
 func (s *serviceManager) Unbind(
-	_ service.StandardProvisioningContext,
-	_ service.ProvisioningContext,
+	_ service.Instance,
 	_ service.BindingContext,
 ) error {
 	return nil

--- a/pkg/storage/memory/store.go
+++ b/pkg/storage/memory/store.go
@@ -19,18 +19,18 @@ func NewStore() storage.Store {
 	}
 }
 
-func (s *store) WriteInstance(instance *service.Instance) error {
-	s.instances[instance.InstanceID] = *instance
+func (s *store) WriteInstance(instance service.Instance) error {
+	s.instances[instance.InstanceID] = instance
 	return nil
 }
 
 func (s *store) GetInstance(instanceID string) (
-	*service.Instance,
+	service.Instance,
 	bool,
 	error,
 ) {
 	instance, ok := s.instances[instanceID]
-	return &instance, ok, nil
+	return instance, ok, nil
 }
 
 func (s *store) DeleteInstance(instanceID string) (bool, error) {
@@ -42,14 +42,14 @@ func (s *store) DeleteInstance(instanceID string) (bool, error) {
 	return true, nil
 }
 
-func (s *store) WriteBinding(binding *service.Binding) error {
-	s.bindings[binding.BindingID] = *binding
+func (s *store) WriteBinding(binding service.Binding) error {
+	s.bindings[binding.BindingID] = binding
 	return nil
 }
 
-func (s *store) GetBinding(bindingID string) (*service.Binding, bool, error) {
+func (s *store) GetBinding(bindingID string) (service.Binding, bool, error) {
 	binding, ok := s.bindings[bindingID]
-	return &binding, ok, nil
+	return binding, ok, nil
 }
 
 func (s *store) DeleteBinding(bindingID string) (bool, error) {

--- a/pkg/storage/memory/store.go
+++ b/pkg/storage/memory/store.go
@@ -1,36 +1,52 @@
 package memory
 
 import (
+	"github.com/Azure/open-service-broker-azure/pkg/crypto"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/Azure/open-service-broker-azure/pkg/storage"
 )
 
 type store struct {
-	instances map[string]service.Instance
+	codec     crypto.Codec
+	instances map[string][]byte
 	bindings  map[string]service.Binding
 }
 
 // NewStore returns a new memory-based implementation of the storage.Store used
 // for testing
-func NewStore() storage.Store {
+func NewStore(codec crypto.Codec) storage.Store {
 	return &store{
-		instances: make(map[string]service.Instance),
+		codec:     codec,
+		instances: make(map[string][]byte),
 		bindings:  make(map[string]service.Binding),
 	}
 }
 
 func (s *store) WriteInstance(instance service.Instance) error {
-	s.instances[instance.InstanceID] = instance
+	json, err := instance.ToJSON(s.codec)
+	if err != nil {
+		return err
+	}
+	s.instances[instance.InstanceID] = json
 	return nil
 }
 
-func (s *store) GetInstance(instanceID string) (
+func (s *store) GetInstance(
+	instanceID string,
+	pp service.ProvisioningParameters,
+	up service.UpdatingParameters,
+	pc service.ProvisioningContext,
+) (
 	service.Instance,
 	bool,
 	error,
 ) {
-	instance, ok := s.instances[instanceID]
-	return instance, ok, nil
+	json, ok := s.instances[instanceID]
+	if !ok {
+		return service.Instance{}, false, nil
+	}
+	instance, err := service.NewInstanceFromJSON(json, pp, up, pc, s.codec)
+	return instance, err == nil, err
 }
 
 func (s *store) DeleteInstance(instanceID string) (bool, error) {

--- a/pkg/storage/memory/store.go
+++ b/pkg/storage/memory/store.go
@@ -9,7 +9,7 @@ import (
 type store struct {
 	codec     crypto.Codec
 	instances map[string][]byte
-	bindings  map[string]service.Binding
+	bindings  map[string][]byte
 }
 
 // NewStore returns a new memory-based implementation of the storage.Store used
@@ -18,7 +18,7 @@ func NewStore(codec crypto.Codec) storage.Store {
 	return &store{
 		codec:     codec,
 		instances: make(map[string][]byte),
-		bindings:  make(map[string]service.Binding),
+		bindings:  make(map[string][]byte),
 	}
 }
 
@@ -59,13 +59,26 @@ func (s *store) DeleteInstance(instanceID string) (bool, error) {
 }
 
 func (s *store) WriteBinding(binding service.Binding) error {
-	s.bindings[binding.BindingID] = binding
+	json, err := binding.ToJSON(s.codec)
+	if err != nil {
+		return err
+	}
+	s.bindings[binding.BindingID] = json
 	return nil
 }
 
-func (s *store) GetBinding(bindingID string) (service.Binding, bool, error) {
-	binding, ok := s.bindings[bindingID]
-	return binding, ok, nil
+func (s *store) GetBinding(
+	bindingID string,
+	bp service.BindingParameters,
+	bc service.BindingContext,
+	cr service.Credentials,
+) (service.Binding, bool, error) {
+	json, ok := s.bindings[bindingID]
+	if !ok {
+		return service.Binding{}, false, nil
+	}
+	binding, err := service.NewBindingFromJSON(json, bp, bc, cr, s.codec)
+	return binding, err == nil, err
 }
 
 func (s *store) DeleteBinding(bindingID string) (bool, error) {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/open-service-broker-azure/pkg/crypto/noop"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/go-redis/redis"
 	uuid "github.com/satori/go.uuid"
@@ -14,7 +15,7 @@ var (
 	redisClient = redis.NewClient(&redis.Options{
 		Addr: "redis:6379",
 	})
-	testStore = NewStore(redisClient)
+	testStore = NewStore(redisClient, noop.NewCodec())
 )
 
 func TestWriteInstance(t *testing.T) {
@@ -38,7 +39,7 @@ func TestGetNonExistingInstance(t *testing.T) {
 	strCmd := redisClient.Get(instanceID)
 	assert.Equal(t, redis.Nil, strCmd.Err())
 	// Try to retrieve the non-existing instance
-	_, ok, err := testStore.GetInstance(instanceID)
+	_, ok, err := testStore.GetInstance(instanceID, nil, nil, nil)
 	// Assert that the retrieval failed
 	assert.False(t, ok)
 	assert.Nil(t, err)
@@ -50,7 +51,7 @@ func TestGetExistingInstance(t *testing.T) {
 	statCmd := redisClient.Set(instanceID, getInstanceJSON(instanceID), 0)
 	assert.Nil(t, statCmd.Err())
 	// Retrieve the instance
-	instance, ok, err := testStore.GetInstance(instanceID)
+	instance, ok, err := testStore.GetInstance(instanceID, nil, nil, nil)
 	// Assert that the retrieval was successful
 	assert.True(t, ok)
 	assert.Nil(t, err)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -105,7 +105,7 @@ func TestGetNonExistingBinding(t *testing.T) {
 	strCmd := redisClient.Get(bindingID)
 	assert.Equal(t, redis.Nil, strCmd.Err())
 	// Try to retrieve the non-existing binding
-	_, ok, err := testStore.GetBinding(bindingID)
+	_, ok, err := testStore.GetBinding(bindingID, nil, nil, nil)
 	// Assert that the retrieval failed
 	assert.False(t, ok)
 	assert.Nil(t, err)
@@ -117,7 +117,7 @@ func TestGetExistingBinding(t *testing.T) {
 	statCmd := redisClient.Set(bindingID, getBindingJSON(bindingID), 0)
 	assert.Nil(t, statCmd.Err())
 	// Retrieve the binding
-	binding, ok, err := testStore.GetBinding(bindingID)
+	binding, ok, err := testStore.GetBinding(bindingID, nil, nil, nil)
 	// Assert that the retrieval was successful
 	assert.True(t, ok)
 	assert.Nil(t, err)

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -23,7 +23,7 @@ func TestWriteInstance(t *testing.T) {
 	strCmd := redisClient.Get(instanceID)
 	assert.Equal(t, redis.Nil, strCmd.Err())
 	// Store the instance
-	err := testStore.WriteInstance(&service.Instance{
+	err := testStore.WriteInstance(service.Instance{
 		InstanceID: instanceID,
 	})
 	assert.Nil(t, err)
@@ -54,10 +54,7 @@ func TestGetExistingInstance(t *testing.T) {
 	// Assert that the retrieval was successful
 	assert.True(t, ok)
 	assert.Nil(t, err)
-	// Asset that instance is not nil before using
-	if assert.NotNil(t, instance, "instance should not be nil") {
-		assert.Equal(t, instanceID, instance.InstanceID)
-	}
+	assert.Equal(t, instanceID, instance.InstanceID)
 }
 
 func TestDeleteNonExistingInstance(t *testing.T) {
@@ -92,7 +89,7 @@ func TestWriteBinding(t *testing.T) {
 	strCmd := redisClient.Get(bindingID)
 	assert.Equal(t, redis.Nil, strCmd.Err())
 	// Store the binding
-	err := testStore.WriteBinding(&service.Binding{
+	err := testStore.WriteBinding(service.Binding{
 		BindingID: bindingID,
 	})
 	assert.Nil(t, err)
@@ -123,10 +120,7 @@ func TestGetExistingBinding(t *testing.T) {
 	// Assert that the retrieval was successful
 	assert.True(t, ok)
 	assert.Nil(t, err)
-	// Assert that binding is not nil before using
-	if assert.NotNil(t, binding, "binding should not be nil") {
-		assert.Equal(t, bindingID, binding.BindingID)
-	}
+	assert.Equal(t, bindingID, binding.BindingID)
 }
 
 func TestDeleteNonExistingBinding(t *testing.T) {


### PR DESCRIPTION
This relates to #124 

__TL;DR__: @jeremyrickard I apologize profoundly for the size of this PR. The most sane way to get through this review is to probably just walk through the changes together.

Read on for a summary of the changes, if you care to.

The function signatures for provisioning, updating, binding, unbinding, and deprovisioning steps, have already been refactored a number of times as this codebase continues to evolve toward a stable state. #124 will call for even more modifications to those signatures to start including not just the details of a given instance (as context, params, etc.) in the argument list, but _also_ the details for a _related_ instance. Those signatures are going to start to be a bit unwieldy-- as if they aren't already. To remedy this and to reduce the frequency of future changes to these signatures, the main goal of this PR is to start passing around `service.Instance` objects where previously we passed around only _pieces_ of these objects (like service ID, plan ID, context, and params, as separate argument).

There are consequences to that decision. First and foremost, we need to code defensively to prevent badly behaving or poorly coded modules from modifying instances in unexpected or undesirable ways. As such, there's a lot of emphasis in this PR on reduced use of pointers to instances, combined with a few other bits of defensive coding to prevent any unwanted changes to an instance from being written back to storage.

Another consequence is that for modules to receive instances as function parameters, they need to be able to retrieve the constituent parts from those instances. For example, they need to be able to access context, parameters, etc. These, however, are encrypted fields. Previously, encryption and decryption of those field occurred just-in-time via various getter and setter functions. These functions required an appropriate codec to be provided as an argument. Requiring modules to deal with these kind of concerns and extra "moving parts" (like the codec) complicates module code in undesirable ways. (This is a cross-cutting concern and shouldn't be the responsibility of a module that is meant to just provide service-specific logic.) So, this necessitated a refactoring of encryption/decryption that pushes more of the crypto burden onto the storage layer. Encryption now occurs as part of marshaling and decryption occurs as part of unmarshaling. (There are opportunities to clean this up even further from the state this PR leaves things in. Despite the size of this PR, I've truly attempted to do the minimum that I could get away with while still getting the results I wanted. There _will_ be follow-ups, but they'll be small by comparison.)

Lastly, note that altho this is related to #124, I believe these changes represent general improvements that I would like to see merged regardless of whatever happens with #124, which is a POC or spike of sorts. This is why the merge target for this PR is master and _not_ the feature branch we're using for #124.

If our feature branch needs a difficult rebase because of this... I volunteer as tribute.