### PR TITLE
Firewall rule parameterization

### DIFF
--- a/contrib/k8s/examples/mysqldb-instance.yaml
+++ b/contrib/k8s/examples/mysqldb-instance.yaml
@@ -9,3 +9,5 @@ spec:
   parameters:
     location: eastus
     resourceGroup: demo
+    firewallStartIPAddress: "0.0.0.0"
+    firewallEndIPAddress: "255.255.255.255"

--- a/contrib/k8s/examples/postgresqldb-instance.yaml
+++ b/contrib/k8s/examples/postgresqldb-instance.yaml
@@ -12,3 +12,5 @@ spec:
     extensions:
     - uuid-ossp
     - postgis
+    firewallStartIPAddress: "0.0.0.0"
+    firewallEndIPAddress: "255.255.255.255"

--- a/contrib/k8s/examples/sqldb-instance.yaml
+++ b/contrib/k8s/examples/sqldb-instance.yaml
@@ -9,3 +9,5 @@ spec:
   parameters:
     location: eastus
     resourceGroup: demo
+    firewallStartIPAddress: "0.0.0.0"
+    firewallEndIPAddress: "255.255.255.255"

--- a/pkg/services/mysqldb/arm_template.go
+++ b/pkg/services/mysqldb/arm_template.go
@@ -60,7 +60,7 @@ var armTemplateBytes = []byte(`
 			"type": "string",
 			"minLength": 1,
 			"maxLength": 15,
-			"defaultValue": "255.255.255.255"
+			"defaultValue": "0.0.0.0"
 		},
 		"sslEnforcement": {
 			"type": "string",

--- a/pkg/services/mysqldb/provision.go
+++ b/pkg/services/mysqldb/provision.go
@@ -69,7 +69,7 @@ func (s *serviceManager) ValidateProvisioningParameters(
 	if bytes.Compare(startBytes, endBytes) > 0 {
 		return service.NewValidationError(
 			"firewallEndIPAddress",
-			fmt.Sprintf(`invalid value: "%s". firewallEndIPAddress must be 
+			fmt.Sprintf(`invalid value: "%s". must be 
 				greater than or equal to firewallStartIPAddress`, pp.FirewallIPEnd),
 		)
 	}

--- a/pkg/services/mysqldb/provision.go
+++ b/pkg/services/mysqldb/provision.go
@@ -36,13 +36,13 @@ func (s *serviceManager) ValidateProvisioningParameters(
 		if pp.FirewallIPStart == "" {
 			return service.NewValidationError(
 				"firewallStartIPAddress",
-				fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPStart),
+				"must be set when firewallEndIPAddress is set",
 			)
 		}
 		if pp.FirewallIPEnd == "" {
 			return service.NewValidationError(
 				"firewallEndIPAddress",
-				fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
+				"must be set when firewallStartIPAddress is set",
 			)
 		}
 	}
@@ -50,14 +50,14 @@ func (s *serviceManager) ValidateProvisioningParameters(
 	if pp.FirewallIPStart != "" && startIP == nil {
 		return service.NewValidationError(
 			"firewallStartIPAddress",
-			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPStart),
+			fmt.Sprintf(`invalid value: "%s"`, pp.FirewallIPStart),
 		)
 	}
 	endIP := net.ParseIP(pp.FirewallIPEnd)
 	if pp.FirewallIPEnd != "" && endIP == nil {
 		return service.NewValidationError(
 			"firewallEndIPAddress",
-			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
+			fmt.Sprintf(`invalid value: "%s"`, pp.FirewallIPEnd),
 		)
 	}
 	//The net.IP.To4 method returns a 4 byte representation of an IPv4 address.
@@ -69,7 +69,8 @@ func (s *serviceManager) ValidateProvisioningParameters(
 	if bytes.Compare(startBytes, endBytes) > 0 {
 		return service.NewValidationError(
 			"firewallEndIPAddress",
-			fmt.Sprintf(`invalid option: "%s"`, pp.SSLEnforcement),
+			fmt.Sprintf(`invalid value: "%s". firewallEndIPAddress must be 
+				greater than or equal to firewallStartIPAddress`, pp.FirewallIPEnd),
 		)
 	}
 	return nil

--- a/pkg/services/mysqldb/provision.go
+++ b/pkg/services/mysqldb/provision.go
@@ -157,6 +157,13 @@ func (s *serviceManager) deployARMTemplate(
 				"as *mysqlProvisioningContext",
 		)
 	}
+	pp, ok := instance.ProvisioningParameters.(*ProvisioningParameters)
+	if !ok {
+		return nil, errors.New(
+			"error casting provisioningParameters as " +
+				"*mysql.ProvisioningParameters",
+		)
+	}
 	armTemplateParameters := buildARMTemplateParameters(plan, pc, pp)
 	outputs, err := s.armDeployer.Deploy(
 		pc.ARMDeploymentName,

--- a/pkg/services/mysqldb/provision_test.go
+++ b/pkg/services/mysqldb/provision_test.go
@@ -52,3 +52,15 @@ func TestValidateInvalidIP(t *testing.T) {
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.NotNil(t, error)
 }
+
+func TestValidateIncompleteIP(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{
+		FirewallIPStart: "192.168.",
+	}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, error)
+}

--- a/pkg/services/mysqldb/provision_test.go
+++ b/pkg/services/mysqldb/provision_test.go
@@ -1,0 +1,44 @@
+package mysqldb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateGoodFirewallConfig(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{
+		FirewallIPStart: "192.168.86.1",
+		FirewallIPEnd:   "192.168.86.100",
+	}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.Nil(t, error)
+}
+
+func TestValidateMissingEndFirewallConfig(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{
+		FirewallIPStart: "192.168.86.1",
+	}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, error)
+}
+
+func TestValidateInvalidIP(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{
+		FirewallIPStart: "decafbad",
+	}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, error)
+}

--- a/pkg/services/mysqldb/provision_test.go
+++ b/pkg/services/mysqldb/provision_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestValidateNoFirewallConfig(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.Nil(t, error)
+}
+
 func TestValidateGoodFirewallConfig(t *testing.T) {
 
 	sm := &serviceManager{}

--- a/pkg/services/mysqldb/provision_test.go
+++ b/pkg/services/mysqldb/provision_test.go
@@ -3,64 +3,73 @@ package mysqldb
 import (
 	"testing"
 
+	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateNoFirewallConfig(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.Nil(t, error)
 }
 
 func TestValidateGoodFirewallConfig(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{
 		FirewallIPStart: "192.168.86.1",
 		FirewallIPEnd:   "192.168.86.100",
 	}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.Nil(t, error)
 }
 
 func TestValidateMissingEndFirewallConfig(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{
 		FirewallIPStart: "192.168.86.1",
 	}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.NotNil(t, error)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallEndIPAddress")
+}
+
+func TestValidateMissingStartFirewallConfig(t *testing.T) {
+	sm := &serviceManager{}
+	pp := &ProvisioningParameters{
+		FirewallIPEnd: "192.168.86.200",
+	}
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, error)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallStartIPAddress")
 }
 
 func TestValidateInvalidIP(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{
 		FirewallIPStart: "decafbad",
+		FirewallIPEnd:   "192.168.86.200",
 	}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.NotNil(t, error)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallStartIPAddress")
 }
 
 func TestValidateIncompleteIP(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{
 		FirewallIPStart: "192.168.",
+		FirewallIPEnd:   "192.168.86.200",
 	}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.NotNil(t, error)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallStartIPAddress")
 }

--- a/pkg/services/mysqldb/types.go
+++ b/pkg/services/mysqldb/types.go
@@ -4,7 +4,9 @@ import "github.com/Azure/open-service-broker-azure/pkg/service"
 
 // ProvisioningParameters encapsulates MySQL-specific provisioning options
 type ProvisioningParameters struct {
-	SSLEnforcement string `json:"sslEnforcement"`
+	SSLEnforcement  string `json:"sslEnforcement"`
+	FirewallIPStart string `json:"firewallStartIpAddress"`
+	FirewallIPEnd   string `json:"firewallEndIpAddress"`
 }
 
 type mysqlProvisioningContext struct {

--- a/pkg/services/mysqldb/types.go
+++ b/pkg/services/mysqldb/types.go
@@ -5,8 +5,8 @@ import "github.com/Azure/open-service-broker-azure/pkg/service"
 // ProvisioningParameters encapsulates MySQL-specific provisioning options
 type ProvisioningParameters struct {
 	SSLEnforcement  string `json:"sslEnforcement"`
-	FirewallIPStart string `json:"firewallStartIpAddress"`
-	FirewallIPEnd   string `json:"firewallEndIpAddress"`
+	FirewallIPStart string `json:"firewallStartIPAddress"`
+	FirewallIPEnd   string `json:"firewallEndIPAddress"`
 }
 
 type mysqlProvisioningContext struct {

--- a/pkg/services/postgresqldb/arm_template.go
+++ b/pkg/services/postgresqldb/arm_template.go
@@ -61,7 +61,7 @@ var armTemplateBytes = []byte(`
 			"type": "string",
 			"minLength": 1,
 			"maxLength": 15,
-			"defaultValue": "255.255.255.255"
+			"defaultValue": "0.0.0.0"
 		},
 		"sslEnforcement": {
 			"type": "string",

--- a/pkg/services/postgresqldb/provision.go
+++ b/pkg/services/postgresqldb/provision.go
@@ -1,9 +1,11 @@
 package postgresqldb
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/Azure/open-service-broker-azure/pkg/generate"
@@ -31,6 +33,39 @@ func (s *serviceManager) ValidateProvisioningParameters(
 			fmt.Sprintf(`invalid sslEnforcement option: "%s"`, pp.SSLEnforcement),
 		)
 	}
+
+	startIP := net.ParseIP(pp.FirewallIPStart)
+	if pp.FirewallIPStart != "" && net.ParseIP(pp.FirewallIPStart) == nil {
+		return service.NewValidationError(
+			"firewallStartIpAddress",
+			fmt.Sprintf(`invalid firewallStartIpAddress option: "%s"`, pp.FirewallIPStart),
+		)
+	}
+
+	endIP := net.ParseIP(pp.FirewallIPEnd)
+	if pp.FirewallIPEnd != "" && net.ParseIP(pp.FirewallIPEnd) == nil {
+		return service.NewValidationError(
+			"firewallEndIpAddress",
+			fmt.Sprintf(`invalid firewallEndIpAddress option: "%s"`, pp.FirewallIPEnd),
+		)
+	}
+
+	if startIP != nil && endIP == nil {
+		return service.NewValidationError(
+			"firewallEndIpAddress",
+			fmt.Sprintf(`invalid firewallEndIpAddress option: "%s"`, pp.FirewallIPEnd),
+		)
+	}
+
+	startBytes := startIP.To4()
+	endBytes := endIP.To4()
+	if bytes.Compare(startBytes, endBytes) > 0 {
+		return service.NewValidationError(
+			"firewallEndIpAddress",
+			fmt.Sprintf(`invalid firewallEndIpAddress option: "%s"`, pp.SSLEnforcement),
+		)
+	}
+
 	return nil
 }
 
@@ -66,6 +101,7 @@ func (s *serviceManager) preProvision(
 				"*postgresql.ProvisioningParameters",
 		)
 	}
+
 	pc.ARMDeploymentName = uuid.NewV4().String()
 	pc.ServerName = uuid.NewV4().String()
 	pc.AdministratorLoginPassword = generate.NewPassword()
@@ -82,42 +118,67 @@ func (s *serviceManager) preProvision(
 	return pc, nil
 }
 
+func buildARMTemplateParameters(
+	plan service.Plan,
+	provisioningContext *postgresqlProvisioningContext,
+	provisioningParameters *ProvisioningParameters,
+) map[string]interface{} {
+	var sslEnforcement string
+	if provisioningContext.EnforceSSL {
+		sslEnforcement = "Enabled"
+	} else {
+		sslEnforcement = "Disabled"
+	}
+	p := map[string]interface{}{ // ARM template params
+		"administratorLoginPassword": provisioningContext.AdministratorLoginPassword,
+		"serverName":                 provisioningContext.ServerName,
+		"databaseName":               provisioningContext.DatabaseName,
+		"skuName":                    plan.GetProperties().Extended["skuName"],
+		"skuTier":                    plan.GetProperties().Extended["skuTier"],
+		"skuCapacityDTU": plan.GetProperties().
+			Extended["skuCapacityDTU"],
+		"sslEnforcement": sslEnforcement,
+	}
+	//Only include these if they are not empty. ARM Deployer will fail
+	//if the values included are not valid IPV4 addresses (i.e. empty string wil fail)
+	if provisioningParameters.FirewallIPStart != "" {
+		p["firewallStartIpAddress"] = provisioningParameters.FirewallIPStart
+	}
+	if provisioningParameters.FirewallIPEnd != "" {
+		p["firewallEndIpAddress"] = provisioningParameters.FirewallIPEnd
+	}
+	return p
+}
+
 func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	_ string, // instanceID
 	plan service.Plan,
 	standardProvisioningContext service.StandardProvisioningContext,
 	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
+	provisioningParameters service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
+	pp, ok := provisioningParameters.(*ProvisioningParameters)
+	if !ok {
+		return nil, errors.New(
+			"error casting provisioningParameters as " +
+				"*postgresql.ProvisioningParameters",
+		)
+	}
 	pc, ok := provisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
 		return nil, errors.New(
 			"error casting provisioningContext as *postgresqlProvisioningContext",
 		)
 	}
-	var sslEnforcement string
-	if pc.EnforceSSL {
-		sslEnforcement = "Enabled"
-	} else {
-		sslEnforcement = "Disabled"
-	}
+	armTemplateParameters := buildARMTemplateParameters(plan, pc, pp)
 	outputs, err := s.armDeployer.Deploy(
 		pc.ARMDeploymentName,
 		standardProvisioningContext.ResourceGroup,
 		standardProvisioningContext.Location,
 		armTemplateBytes,
 		nil, // Go template params
-		map[string]interface{}{ // ARM template params
-			"administratorLoginPassword": pc.AdministratorLoginPassword,
-			"serverName":                 pc.ServerName,
-			"databaseName":               pc.DatabaseName,
-			"skuName":                    plan.GetProperties().Extended["skuName"],
-			"skuTier":                    plan.GetProperties().Extended["skuTier"],
-			"skuCapacityDTU": plan.GetProperties().
-				Extended["skuCapacityDTU"],
-			"sslEnforcement": sslEnforcement,
-		},
+		armTemplateParameters,
 		standardProvisioningContext.Tags,
 	)
 	if err != nil {
@@ -142,7 +203,7 @@ func (s *serviceManager) setupDatabase(
 	_ service.Plan,
 	_ service.StandardProvisioningContext,
 	provisioningContext service.ProvisioningContext,
-	_ service.ProvisioningParameters,
+	provisioningParameters service.ProvisioningParameters,
 ) (service.ProvisioningContext, error) {
 	pc, ok := provisioningContext.(*postgresqlProvisioningContext)
 	if !ok {

--- a/pkg/services/postgresqldb/provision.go
+++ b/pkg/services/postgresqldb/provision.go
@@ -70,7 +70,7 @@ func (s *serviceManager) ValidateProvisioningParameters(
 	if bytes.Compare(startBytes, endBytes) > 0 {
 		return service.NewValidationError(
 			"firewallEndIPAddress",
-			fmt.Sprintf(`invalid value: "%s". firewallEndIPAddress must be 
+			fmt.Sprintf(`invalid value: "%s". must be 
 				greater than or equal to firewallStartIPAddress`, pp.FirewallIPEnd),
 		)
 	}

--- a/pkg/services/postgresqldb/provision.go
+++ b/pkg/services/postgresqldb/provision.go
@@ -37,13 +37,13 @@ func (s *serviceManager) ValidateProvisioningParameters(
 		if pp.FirewallIPStart == "" {
 			return service.NewValidationError(
 				"firewallStartIPAddress",
-				fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPStart),
+				"must be set when firewallEndIPAddress is set",
 			)
 		}
 		if pp.FirewallIPEnd == "" {
 			return service.NewValidationError(
 				"firewallEndIPAddress",
-				fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
+				"must be set when firewallStartIPAddress is set",
 			)
 		}
 	}
@@ -51,14 +51,14 @@ func (s *serviceManager) ValidateProvisioningParameters(
 	if pp.FirewallIPStart != "" && startIP == nil {
 		return service.NewValidationError(
 			"firewallStartIPAddress",
-			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPStart),
+			fmt.Sprintf(`invalid value: "%s"`, pp.FirewallIPStart),
 		)
 	}
 	endIP := net.ParseIP(pp.FirewallIPEnd)
 	if pp.FirewallIPEnd != "" && endIP == nil {
 		return service.NewValidationError(
 			"firewallEndIPAddress",
-			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
+			fmt.Sprintf(`invalid value: "%s"`, pp.FirewallIPEnd),
 		)
 	}
 	//The net.IP.To4 method returns a 4 byte representation of an IPv4 address.
@@ -70,7 +70,8 @@ func (s *serviceManager) ValidateProvisioningParameters(
 	if bytes.Compare(startBytes, endBytes) > 0 {
 		return service.NewValidationError(
 			"firewallEndIPAddress",
-			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
+			fmt.Sprintf(`invalid value: "%s". firewallEndIPAddress must be 
+				greater than or equal to firewallStartIPAddress`, pp.FirewallIPEnd),
 		)
 	}
 	return nil

--- a/pkg/services/postgresqldb/provision.go
+++ b/pkg/services/postgresqldb/provision.go
@@ -160,6 +160,13 @@ func (s *serviceManager) deployARMTemplate(
 				"*postgresqlProvisioningContext",
 		)
 	}
+	pp, ok := instance.ProvisioningParameters.(*ProvisioningParameters)
+	if !ok {
+		return nil, errors.New(
+			"error casting provisioningParameters as " +
+				"*postgresql.ProvisioningParameters",
+		)
+	}
 	armTemplateParameters := buildARMTemplateParameters(plan, pc, pp)
 	outputs, err := s.armDeployer.Deploy(
 		pc.ARMDeploymentName,

--- a/pkg/services/postgresqldb/provision.go
+++ b/pkg/services/postgresqldb/provision.go
@@ -30,42 +30,49 @@ func (s *serviceManager) ValidateProvisioningParameters(
 		sslEnforcement != "disabled" {
 		return service.NewValidationError(
 			"sslEnforcement",
-			fmt.Sprintf(`invalid sslEnforcement option: "%s"`, pp.SSLEnforcement),
+			fmt.Sprintf(`invalid option: "%s"`, pp.SSLEnforcement),
 		)
 	}
-
+	if pp.FirewallIPStart != "" || pp.FirewallIPEnd != "" {
+		if pp.FirewallIPStart == "" {
+			return service.NewValidationError(
+				"firewallStartIPAddress",
+				fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPStart),
+			)
+		}
+		if pp.FirewallIPEnd == "" {
+			return service.NewValidationError(
+				"firewallEndIPAddress",
+				fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
+			)
+		}
+	}
 	startIP := net.ParseIP(pp.FirewallIPStart)
-	if pp.FirewallIPStart != "" && net.ParseIP(pp.FirewallIPStart) == nil {
+	if pp.FirewallIPStart != "" && startIP == nil {
 		return service.NewValidationError(
-			"firewallStartIpAddress",
-			fmt.Sprintf(`invalid firewallStartIpAddress option: "%s"`, pp.FirewallIPStart),
+			"firewallStartIPAddress",
+			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPStart),
 		)
 	}
-
 	endIP := net.ParseIP(pp.FirewallIPEnd)
-	if pp.FirewallIPEnd != "" && net.ParseIP(pp.FirewallIPEnd) == nil {
+	if pp.FirewallIPEnd != "" && endIP == nil {
 		return service.NewValidationError(
-			"firewallEndIpAddress",
-			fmt.Sprintf(`invalid firewallEndIpAddress option: "%s"`, pp.FirewallIPEnd),
+			"firewallEndIPAddress",
+			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
 		)
 	}
-
-	if startIP != nil && endIP == nil {
-		return service.NewValidationError(
-			"firewallEndIpAddress",
-			fmt.Sprintf(`invalid firewallEndIpAddress option: "%s"`, pp.FirewallIPEnd),
-		)
-	}
-
+	//The net.IP.To4 method returns a 4 byte representation of an IPv4 address.
+	//Once converted,comparing two IP addresses can be done by using the
+	//bytes. Compare function. Per the ARM template documentation,
+	//startIP must be <= endIP.
 	startBytes := startIP.To4()
 	endBytes := endIP.To4()
 	if bytes.Compare(startBytes, endBytes) > 0 {
 		return service.NewValidationError(
-			"firewallEndIpAddress",
-			fmt.Sprintf(`invalid firewallEndIpAddress option: "%s"`, pp.SSLEnforcement),
+			"firewallEndIPAddress",
+			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
 		)
 	}
-
 	return nil
 }
 
@@ -137,8 +144,9 @@ func buildARMTemplateParameters(
 			Extended["skuCapacityDTU"],
 		"sslEnforcement": sslEnforcement,
 	}
-	//Only include these if they are not empty. ARM Deployer will fail
-	//if the values included are not valid IPV4 addresses (i.e. empty string wil fail)
+	//Only include these if they are not empty.
+	//ARM Deployer will fail if the values included are not
+	//valid IPV4 addresses (i.e. empty string wil fail)
 	if provisioningParameters.FirewallIPStart != "" {
 		p["firewallStartIpAddress"] = provisioningParameters.FirewallIPStart
 	}

--- a/pkg/services/postgresqldb/provision_test.go
+++ b/pkg/services/postgresqldb/provision_test.go
@@ -52,3 +52,15 @@ func TestValidateInvalidIP(t *testing.T) {
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.NotNil(t, error)
 }
+
+func TestValidateIncompleteIP(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{
+		FirewallIPStart: "192.168.",
+	}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, error)
+}

--- a/pkg/services/postgresqldb/provision_test.go
+++ b/pkg/services/postgresqldb/provision_test.go
@@ -1,0 +1,44 @@
+package postgresqldb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateGoodFirewallConfig(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{
+		FirewallIPStart: "192.168.86.1",
+		FirewallIPEnd:   "192.168.86.100",
+	}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.Nil(t, error)
+}
+
+func TestValidateMissingEndFirewallConfig(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{
+		FirewallIPStart: "192.168.86.1",
+	}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, error)
+}
+
+func TestValidateInvalidIP(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{
+		FirewallIPStart: "decafbad",
+	}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, error)
+}

--- a/pkg/services/postgresqldb/provision_test.go
+++ b/pkg/services/postgresqldb/provision_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestValidateNoFirewallConfig(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.Nil(t, error)
+}
+
 func TestValidateGoodFirewallConfig(t *testing.T) {
 
 	sm := &serviceManager{}

--- a/pkg/services/postgresqldb/provision_test.go
+++ b/pkg/services/postgresqldb/provision_test.go
@@ -3,64 +3,73 @@ package postgresqldb
 import (
 	"testing"
 
+	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateNoFirewallConfig(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.Nil(t, error)
 }
 
 func TestValidateGoodFirewallConfig(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{
 		FirewallIPStart: "192.168.86.1",
 		FirewallIPEnd:   "192.168.86.100",
 	}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.Nil(t, error)
 }
 
 func TestValidateMissingEndFirewallConfig(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{
 		FirewallIPStart: "192.168.86.1",
 	}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.NotNil(t, error)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallEndIPAddress")
+}
+
+func TestValidateMissingStartFirewallConfig(t *testing.T) {
+	sm := &serviceManager{}
+	pp := &ProvisioningParameters{
+		FirewallIPEnd: "192.168.86.200",
+	}
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, error)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallStartIPAddress")
 }
 
 func TestValidateInvalidIP(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{
 		FirewallIPStart: "decafbad",
+		FirewallIPEnd:   "192.168.86.200",
 	}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.NotNil(t, error)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallStartIPAddress")
 }
 
 func TestValidateIncompleteIP(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{
 		FirewallIPStart: "192.168.",
+		FirewallIPEnd:   "192.168.86.200",
 	}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.NotNil(t, error)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallStartIPAddress")
 }

--- a/pkg/services/postgresqldb/types.go
+++ b/pkg/services/postgresqldb/types.go
@@ -6,8 +6,8 @@ import "github.com/Azure/open-service-broker-azure/pkg/service"
 type ProvisioningParameters struct {
 	SSLEnforcement  string   `json:"sslEnforcement"`
 	Extensions      []string `json:"extensions"`
-	FirewallIPStart string   `json:"firewallStartIpAddress"`
-	FirewallIPEnd   string   `json:"firewallEndIpAddress"`
+	FirewallIPStart string   `json:"firewallStartIPAddress"`
+	FirewallIPEnd   string   `json:"firewallEndIPAddress"`
 }
 
 type postgresqlProvisioningContext struct {

--- a/pkg/services/postgresqldb/types.go
+++ b/pkg/services/postgresqldb/types.go
@@ -4,8 +4,10 @@ import "github.com/Azure/open-service-broker-azure/pkg/service"
 
 // ProvisioningParameters encapsulates PostgreSQL-specific provisioning options
 type ProvisioningParameters struct {
-	SSLEnforcement string   `json:"sslEnforcement"`
-	Extensions     []string `json:"extensions"`
+	SSLEnforcement  string   `json:"sslEnforcement"`
+	Extensions      []string `json:"extensions"`
+	FirewallIPStart string   `json:"firewallStartIpAddress"`
+	FirewallIPEnd   string   `json:"firewallEndIpAddress"`
 }
 
 type postgresqlProvisioningContext struct {

--- a/pkg/services/sqldb/arm_template_new_server.go
+++ b/pkg/services/sqldb/arm_template_new_server.go
@@ -51,7 +51,7 @@ var armTemplateNewServerBytes = []byte(`
 			"type": "string",
 			"minLength": 1,
 			"maxLength": 15,
-			"defaultValue": "255.255.255.255"
+			"defaultValue": "0.0.0.0"
 		},
 		"tags": {
 			"type": "object"

--- a/pkg/services/sqldb/provision.go
+++ b/pkg/services/sqldb/provision.go
@@ -72,7 +72,7 @@ func (s *serviceManager) ValidateProvisioningParameters(
 	if bytes.Compare(startBytes, endBytes) > 0 {
 		return service.NewValidationError(
 			"firewallEndIPAddress",
-			fmt.Sprintf(`invalid value: "%s". firewallEndIPAddress must be 
+			fmt.Sprintf(`invalid value: "%s". must be 
 				greater than or equal to firewallStartIPAddress`, pp.FirewallIPEnd),
 		)
 	}

--- a/pkg/services/sqldb/provision.go
+++ b/pkg/services/sqldb/provision.go
@@ -35,39 +35,46 @@ func (s *serviceManager) ValidateProvisioningParameters(
 			)
 		}
 	}
-
+	if pp.FirewallIPStart != "" || pp.FirewallIPEnd != "" {
+		if pp.FirewallIPStart == "" {
+			return service.NewValidationError(
+				"firewallStartIPAddress",
+				fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPStart),
+			)
+		}
+		if pp.FirewallIPEnd == "" {
+			return service.NewValidationError(
+				"firewallEndIPAddress",
+				fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
+			)
+		}
+	}
 	startIP := net.ParseIP(pp.FirewallIPStart)
-	if pp.FirewallIPStart != "" && net.ParseIP(pp.FirewallIPStart) == nil {
+	if pp.FirewallIPStart != "" && startIP == nil {
 		return service.NewValidationError(
-			"firewallStartIpAddress",
-			fmt.Sprintf(`invalid firewallStartIpAddress option: "%s"`, pp.FirewallIPStart),
+			"firewallStartIPAddress",
+			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPStart),
 		)
 	}
-
 	endIP := net.ParseIP(pp.FirewallIPEnd)
-	if pp.FirewallIPEnd != "" && net.ParseIP(pp.FirewallIPEnd) == nil {
+	if pp.FirewallIPEnd != "" && endIP == nil {
 		return service.NewValidationError(
-			"firewallEndIpAddress",
-			fmt.Sprintf(`invalid firewallEndIpAddress option: "%s"`, pp.FirewallIPEnd),
+			"firewallEndIPAddress",
+			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
 		)
 	}
-
-	if startIP != nil && endIP == nil {
-		return service.NewValidationError(
-			"firewallEndIpAddress",
-			fmt.Sprintf(`invalid firewallEndIpAddress option: "%s"`, pp.FirewallIPEnd),
-		)
-	}
-
+	//The net.IP.To4 method returns a 4 byte representation of an IPv4 address.
+	//Once converted,comparing two IP addresses can be done by using the
+	//bytes. Compare function. Per the ARM template documentation,
+	//startIP must be <= endIP.
 	startBytes := startIP.To4()
 	endBytes := endIP.To4()
 	if bytes.Compare(startBytes, endBytes) > 0 {
 		return service.NewValidationError(
 			"firewallEndIpAddress",
-			fmt.Sprintf(`invalid firewallEndIpAddress option: "%s"`, pp.FirewallIPEnd),
+			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
 		)
 	}
-
 	return nil
 }
 
@@ -160,8 +167,9 @@ func buildARMTemplateParameters(
 		"maxSizeBytes": plan.GetProperties().
 			Extended["maxSizeBytes"],
 	}
-	//Only include these if they are not empty. ARM Deployer will fail
-	//if the values included are not valid IPV4 addresses (i.e. empty string wil fail)
+	//Only include these if they are not empty.
+	//ARM Deployer will fail if the values included are not
+	//valid IPV4 addresses (i.e. empty string wil fail)
 	if provisioningParameters.FirewallIPStart != "" {
 		p["firewallStartIpAddress"] = provisioningParameters.FirewallIPStart
 	}

--- a/pkg/services/sqldb/provision.go
+++ b/pkg/services/sqldb/provision.go
@@ -39,13 +39,13 @@ func (s *serviceManager) ValidateProvisioningParameters(
 		if pp.FirewallIPStart == "" {
 			return service.NewValidationError(
 				"firewallStartIPAddress",
-				fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPStart),
+				"must be set when firewallEndIPAddress is set",
 			)
 		}
 		if pp.FirewallIPEnd == "" {
 			return service.NewValidationError(
 				"firewallEndIPAddress",
-				fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
+				"must be set when firewallStartIPAddress is set",
 			)
 		}
 	}
@@ -53,14 +53,14 @@ func (s *serviceManager) ValidateProvisioningParameters(
 	if pp.FirewallIPStart != "" && startIP == nil {
 		return service.NewValidationError(
 			"firewallStartIPAddress",
-			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPStart),
+			fmt.Sprintf(`invalid value: "%s"`, pp.FirewallIPStart),
 		)
 	}
 	endIP := net.ParseIP(pp.FirewallIPEnd)
 	if pp.FirewallIPEnd != "" && endIP == nil {
 		return service.NewValidationError(
 			"firewallEndIPAddress",
-			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
+			fmt.Sprintf(`invalid value: "%s"`, pp.FirewallIPEnd),
 		)
 	}
 	//The net.IP.To4 method returns a 4 byte representation of an IPv4 address.
@@ -71,8 +71,9 @@ func (s *serviceManager) ValidateProvisioningParameters(
 	endBytes := endIP.To4()
 	if bytes.Compare(startBytes, endBytes) > 0 {
 		return service.NewValidationError(
-			"firewallEndIpAddress",
-			fmt.Sprintf(`invalid option: "%s"`, pp.FirewallIPEnd),
+			"firewallEndIPAddress",
+			fmt.Sprintf(`invalid value: "%s". firewallEndIPAddress must be 
+				greater than or equal to firewallStartIPAddress`, pp.FirewallIPEnd),
 		)
 	}
 	return nil

--- a/pkg/services/sqldb/provision_test.go
+++ b/pkg/services/sqldb/provision_test.go
@@ -1,0 +1,44 @@
+package sqldb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateGoodFirewallConfig(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{
+		FirewallIPStart: "192.168.86.1",
+		FirewallIPEnd:   "192.168.86.100",
+	}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.Nil(t, error)
+}
+
+func TestValidateMissingEndFirewallConfig(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{
+		FirewallIPStart: "192.168.86.1",
+	}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, error)
+}
+
+func TestValidateInvalidIP(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{
+		FirewallIPStart: "decafbad",
+	}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, error)
+}

--- a/pkg/services/sqldb/provision_test.go
+++ b/pkg/services/sqldb/provision_test.go
@@ -52,3 +52,15 @@ func TestValidateInvalidIP(t *testing.T) {
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.NotNil(t, error)
 }
+
+func TestValidateIncompleteIP(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{
+		FirewallIPStart: "192.168.",
+	}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, error)
+}

--- a/pkg/services/sqldb/provision_test.go
+++ b/pkg/services/sqldb/provision_test.go
@@ -3,6 +3,7 @@ package sqldb
 import (
 	"testing"
 
+	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,37 +31,51 @@ func TestValidateGoodFirewallConfig(t *testing.T) {
 }
 
 func TestValidateMissingEndFirewallConfig(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{
 		FirewallIPStart: "192.168.86.1",
 	}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.NotNil(t, error)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallEndIPAddress")
+}
+
+func TestValidateMissingStartFirewallConfig(t *testing.T) {
+	sm := &serviceManager{}
+	pp := &ProvisioningParameters{
+		FirewallIPEnd: "192.168.86.200",
+	}
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.NotNil(t, error)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallStartIPAddress")
 }
 
 func TestValidateInvalidIP(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{
 		FirewallIPStart: "decafbad",
+		FirewallIPEnd:   "192.168.86.200",
 	}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.NotNil(t, error)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallStartIPAddress")
 }
 
 func TestValidateIncompleteIP(t *testing.T) {
-
 	sm := &serviceManager{}
-
 	pp := &ProvisioningParameters{
 		FirewallIPStart: "192.168.",
+		FirewallIPEnd:   "192.168.86.200",
 	}
-
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.NotNil(t, error)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallStartIPAddress")
 }

--- a/pkg/services/sqldb/provision_test.go
+++ b/pkg/services/sqldb/provision_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestValidateNoFirewallConfig(t *testing.T) {
+
+	sm := &serviceManager{}
+
+	pp := &ProvisioningParameters{}
+
+	error := sm.ValidateProvisioningParameters(pp)
+	assert.Nil(t, error)
+}
+
 func TestValidateGoodFirewallConfig(t *testing.T) {
 
 	sm := &serviceManager{}

--- a/pkg/services/sqldb/types.go
+++ b/pkg/services/sqldb/types.go
@@ -5,8 +5,8 @@ import "github.com/Azure/open-service-broker-azure/pkg/service"
 // ProvisioningParameters encapsulates MSSQL-specific provisioning options
 type ProvisioningParameters struct {
 	ServerName      string `json:"server"`
-	FirewallIPStart string `json:"firewallStartIpAddress"`
-	FirewallIPEnd   string `json:"firewallEndIpAddress"`
+	FirewallIPStart string `json:"firewallStartIPAddress"`
+	FirewallIPEnd   string `json:"firewallEndIPAddress"`
 }
 
 type mssqlProvisioningContext struct {

--- a/pkg/services/sqldb/types.go
+++ b/pkg/services/sqldb/types.go
@@ -4,7 +4,9 @@ import "github.com/Azure/open-service-broker-azure/pkg/service"
 
 // ProvisioningParameters encapsulates MSSQL-specific provisioning options
 type ProvisioningParameters struct {
-	ServerName string `json:"server"`
+	ServerName      string `json:"server"`
+	FirewallIPStart string `json:"firewallStartIpAddress"`
+	FirewallIPEnd   string `json:"firewallEndIpAddress"`
 }
 
 type mssqlProvisioningContext struct {

--- a/tests/lifecycle/mssql_cases_test.go
+++ b/tests/lifecycle/mssql_cases_test.go
@@ -141,9 +141,12 @@ func getMssqlCases(
 			standardProvisioningContext: service.StandardProvisioningContext{
 				Location: "southcentralus",
 			},
-			provisioningParameters: &sqldb.ProvisioningParameters{},
-			bindingParameters:      &sqldb.BindingParameters{},
-			testCredentials:        testMsSQLCreds(),
+			provisioningParameters: &sqldb.ProvisioningParameters{
+				FirewallIPStart: "0.0.0.0",
+				FirewallIPEnd:   "255.255.255.0",
+			},
+			bindingParameters: &sqldb.BindingParameters{},
+			testCredentials:   testMsSQLCreds(),
 		},
 		{ // existing server scenario
 			module:      sqldb.New(armDeployer, msSQLManager, msSQLConfig),

--- a/tests/lifecycle/mssql_cases_test.go
+++ b/tests/lifecycle/mssql_cases_test.go
@@ -143,7 +143,7 @@ func getMssqlCases(
 			},
 			provisioningParameters: &sqldb.ProvisioningParameters{
 				FirewallIPStart: "0.0.0.0",
-				FirewallIPEnd:   "255.255.255.0",
+				FirewallIPEnd:   "255.255.255.255",
 			},
 			bindingParameters: &sqldb.BindingParameters{},
 			testCredentials:   testMsSQLCreds(),

--- a/tests/lifecycle/mysql_cases_test.go
+++ b/tests/lifecycle/mysql_cases_test.go
@@ -28,7 +28,7 @@ func getMysqlCases(
 			},
 			provisioningParameters: &mysqldb.ProvisioningParameters{
 				FirewallIPStart: "0.0.0.0",
-				FirewallIPEnd:   "255.255.255.0",
+				FirewallIPEnd:   "255.255.255.255",
 			},
 			bindingParameters: &mysqldb.BindingParameters{},
 		},

--- a/tests/lifecycle/mysql_cases_test.go
+++ b/tests/lifecycle/mysql_cases_test.go
@@ -26,8 +26,11 @@ func getMysqlCases(
 			standardProvisioningContext: service.StandardProvisioningContext{
 				Location: "southcentralus",
 			},
-			provisioningParameters: &mysqldb.ProvisioningParameters{},
-			bindingParameters:      &mysqldb.BindingParameters{},
+			provisioningParameters: &mysqldb.ProvisioningParameters{
+				FirewallIPStart: "0.0.0.0",
+				FirewallIPEnd:   "255.255.255.0",
+			},
+			bindingParameters: &mysqldb.BindingParameters{},
 		},
 	}, nil
 }

--- a/tests/lifecycle/postgresql_cases_test.go
+++ b/tests/lifecycle/postgresql_cases_test.go
@@ -28,7 +28,7 @@ func getPostgresqlCases(
 			},
 			provisioningParameters: &postgresqldb.ProvisioningParameters{
 				FirewallIPStart: "0.0.0.0",
-				FirewallIPEnd:   "255.255.255.0",
+				FirewallIPEnd:   "255.255.255.255",
 				Extensions: []string{
 					"uuid-ossp",
 					"postgis",

--- a/tests/lifecycle/postgresql_cases_test.go
+++ b/tests/lifecycle/postgresql_cases_test.go
@@ -27,6 +27,8 @@ func getPostgresqlCases(
 				Location: "southcentralus",
 			},
 			provisioningParameters: &postgresqldb.ProvisioningParameters{
+				FirewallIPStart: "0.0.0.0",
+				FirewallIPEnd:   "255.255.255.0",
 				Extensions: []string{
 					"uuid-ossp",
 					"postgis",


### PR DESCRIPTION
Refactor to support allowing firewall rules.
Fixes: #146

Changes to suport optional parameters to allow specifying start
and end IP address for firewall rules on MySQL, PostgreSQL and
MSSQL. Previously, this defaulted to allow any connection. This
isn't ecure in practice, so allowing the customer to specify desired
rules. Also changed the default to 0.0.0.0 for both, which results in
only Azure internal addresses. Added some parameter validation
for the firewall values as well:

* Valid IPV4 addresses
* Start <= End

Extracted a method to build the arm template parameter map. Providing
empty strings is invalid for the ARM template, so only including
when non-empty.

Added parameters to the lifecycle tests to allow running them
from local machines (will need ao enhance the charts in helm-charts)

Added some tests.