### PR TITLE
make storage know how to deal with service-specific types

### DIFF
--- a/cmd/compliance-test-broker/compliance-test-broker.go
+++ b/cmd/compliance-test-broker/compliance-test-broker.go
@@ -37,7 +37,7 @@ func main() {
 	noopCodec := noop.NewCodec()
 	server, err := api.NewServer(
 		8080,
-		memoryStorage.NewStore(noopCodec),
+		memoryStorage.NewStore(fakeCatalog, noopCodec),
 		fakeAsync.NewEngine(),
 		noopCodec,
 		authenticator,

--- a/pkg/api/bind_test.go
+++ b/pkg/api/bind_test.go
@@ -34,7 +34,7 @@ func TestBindingWithInstanceThatIsNotFullyProvisioned(t *testing.T) {
 	planID := getDisposablePlanID()
 	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
-		ServiceID:  getDisposableServiceID(),
+		ServiceID:  fake.ServiceID,
 		PlanID:     planID,
 		Status:     service.InstanceStateProvisioning,
 	})
@@ -55,11 +55,10 @@ func TestBindingWithServiceIDDifferentFromInstanceServiceID(t *testing.T) {
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	planID := getDisposablePlanID()
 	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
-		ServiceID:  getDisposableServiceID(),
-		PlanID:     planID,
+		ServiceID:  fake.ServiceID,
+		PlanID:     fake.StandardPlanID,
 		Status:     service.InstanceStateProvisioned,
 	})
 	assert.Nil(t, err)
@@ -68,7 +67,7 @@ func TestBindingWithServiceIDDifferentFromInstanceServiceID(t *testing.T) {
 		getDisposableBindingID(),
 		&BindingRequest{
 			ServiceID: getDisposableServiceID(),
-			PlanID:    planID,
+			PlanID:    fake.StandardPlanID,
 		},
 	)
 	assert.Nil(t, err)
@@ -82,11 +81,10 @@ func TestBindingWithPlanIDDifferentFromInstancePlanID(t *testing.T) {
 	s, _, err := getTestServer("", "")
 	assert.Nil(t, err)
 	instanceID := getDisposableInstanceID()
-	serviceID := getDisposableServiceID()
 	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
-		ServiceID:  serviceID,
-		PlanID:     getDisposablePlanID(),
+		ServiceID:  fake.ServiceID,
+		PlanID:     fake.StandardPlanID,
 		Status:     service.InstanceStateProvisioned,
 	})
 	assert.Nil(t, err)
@@ -94,7 +92,7 @@ func TestBindingWithPlanIDDifferentFromInstancePlanID(t *testing.T) {
 		instanceID,
 		getDisposableBindingID(),
 		&BindingRequest{
-			ServiceID: serviceID,
+			ServiceID: fake.ServiceID,
 			PlanID:    getDisposablePlanID(),
 		},
 	)
@@ -146,6 +144,7 @@ func TestBindingWithExistingBindingWithDifferentInstanceID(
 	err = s.store.WriteBinding(service.Binding{
 		InstanceID: getDisposableInstanceID(),
 		BindingID:  bindingID,
+		ServiceID:  fake.ServiceID,
 	})
 	assert.Nil(t, err)
 	req, err := getBindingRequest(
@@ -177,6 +176,7 @@ func TestBindingWithExistingBindingWithDifferentParameters(
 	existingBinding := service.Binding{
 		InstanceID: instanceID,
 		BindingID:  bindingID,
+		ServiceID:  fake.ServiceID,
 		BindingParameters: &fake.BindingParameters{
 			SomeParameter: "foo",
 		},
@@ -216,6 +216,7 @@ func TestBindingWithExistingBoundBindingWithSameAttributes(
 	err = s.store.WriteBinding(service.Binding{
 		InstanceID: instanceID,
 		BindingID:  bindingID,
+		ServiceID:  fake.ServiceID,
 		Status:     service.BindingStateBound,
 	})
 	assert.Nil(t, err)
@@ -248,6 +249,7 @@ func TestBindingWithExistingFailedBindingWithSameAttributes(
 	err = s.store.WriteBinding(service.Binding{
 		InstanceID: instanceID,
 		BindingID:  bindingID,
+		ServiceID:  fake.ServiceID,
 		Status:     service.BindingStateBindingFailed,
 	})
 	assert.Nil(t, err)

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -59,7 +59,7 @@ func getTestServer(
 	noopCodec := noop.NewCodec()
 	s, err := NewServer(
 		8080,
-		memoryStorage.NewStore(noopCodec),
+		memoryStorage.NewStore(fakeCatalog, noopCodec),
 		fakeAsync.NewEngine(),
 		noopCodec,
 		always.NewAuthenticator(),

--- a/pkg/api/deprovision.go
+++ b/pkg/api/deprovision.go
@@ -42,7 +42,7 @@ func (s *server) deprovision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	instance, ok, err := s.store.GetInstance(instanceID, nil, nil, nil)
+	instance, ok, err := s.store.GetInstance(instanceID)
 	if err != nil {
 		logFields["error"] = err
 		log.WithFields(logFields).Error(
@@ -107,24 +107,6 @@ func (s *server) deprovision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	serviceManager := svc.GetServiceManager()
-
-	// Now that we have a serviceManager, we can get empty objects of the correct
-	// types, so we can take a second pass at retrieving an instance from storage
-	// with more concrete details filled in.
-	instance, _, err = s.store.GetInstance(
-		instanceID,
-		serviceManager.GetEmptyProvisioningParameters(),
-		serviceManager.GetEmptyUpdatingParameters(),
-		serviceManager.GetEmptyProvisioningContext(),
-	)
-	if err != nil {
-		logFields["error"] = err
-		log.WithFields(logFields).Error(
-			"pre-deprovisioning error: error retrieving instance by id",
-		)
-		s.writeResponse(w, http.StatusInternalServerError, responseEmptyJSON)
-		return
-	}
 
 	deprovisioner, err := serviceManager.GetDeprovisioner(plan)
 	if err != nil {

--- a/pkg/api/poll.go
+++ b/pkg/api/poll.go
@@ -49,7 +49,7 @@ func (s *server) poll(
 
 	logFields["operation"] = operation
 
-	instance, ok, err := s.store.GetInstance(instanceID, nil, nil, nil)
+	instance, ok, err := s.store.GetInstance(instanceID)
 	if err != nil {
 		logFields["error"] = err
 		log.WithFields(logFields).Error(

--- a/pkg/api/poll_test.go
+++ b/pkg/api/poll_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Azure/open-service-broker-azure/pkg/service"
+	"github.com/Azure/open-service-broker-azure/pkg/services/fake"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,6 +39,7 @@ func TestPollingWithInstanceProvisioning(t *testing.T) {
 	instanceID := getDisposableInstanceID()
 	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
+		ServiceID:  fake.ServiceID,
 		Status:     service.InstanceStateProvisioning,
 	})
 	assert.Nil(t, err)
@@ -55,6 +57,7 @@ func TestPollingWithInstanceProvisioned(t *testing.T) {
 	instanceID := getDisposableInstanceID()
 	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
+		ServiceID:  fake.ServiceID,
 		Status:     service.InstanceStateProvisioned,
 	})
 	assert.Nil(t, err)
@@ -72,6 +75,7 @@ func TestPollingWithInstanceProvisioningFailed(t *testing.T) {
 	instanceID := getDisposableInstanceID()
 	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
+		ServiceID:  fake.ServiceID,
 		Status:     service.InstanceStateProvisioningFailed,
 	})
 	assert.Nil(t, err)
@@ -89,6 +93,7 @@ func TestPollingWithInstanceDeprovisioning(t *testing.T) {
 	instanceID := getDisposableInstanceID()
 	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
+		ServiceID:  fake.ServiceID,
 		Status:     service.InstanceStateDeprovisioning,
 	})
 	assert.Nil(t, err)
@@ -121,6 +126,7 @@ func TestPollingWithInstanceDeprovisioningFailed(t *testing.T) {
 	instanceID := getDisposableInstanceID()
 	err = s.store.WriteInstance(service.Instance{
 		InstanceID: instanceID,
+		ServiceID:  fake.ServiceID,
 		Status:     service.InstanceStateDeprovisioningFailed,
 	})
 	assert.Nil(t, err)

--- a/pkg/api/provision.go
+++ b/pkg/api/provision.go
@@ -171,12 +171,7 @@ func (s *server) provision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	instance, ok, err := s.store.GetInstance(
-		instanceID,
-		serviceManager.GetEmptyProvisioningParameters(),
-		serviceManager.GetEmptyUpdatingParameters(),
-		serviceManager.GetEmptyProvisioningContext(),
-	)
+	instance, ok, err := s.store.GetInstance(instanceID)
 	if err != nil {
 		logFields["error"] = err
 		log.WithFields(logFields).Error(

--- a/pkg/api/unbind.go
+++ b/pkg/api/unbind.go
@@ -20,7 +20,7 @@ func (s *server) unbind(w http.ResponseWriter, r *http.Request) {
 
 	log.WithFields(logFields).Debug("received unbinding request")
 
-	binding, ok, err := s.store.GetBinding(bindingID, nil, nil, nil)
+	binding, ok, err := s.store.GetBinding(bindingID)
 	if err != nil {
 		logFields["error"] = err
 		log.WithFields(logFields).Error(
@@ -50,7 +50,7 @@ func (s *server) unbind(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	instance, ok, err := s.store.GetInstance(instanceID, nil, nil, nil)
+	instance, ok, err := s.store.GetInstance(instanceID)
 	if err != nil {
 		logFields["error"] = err
 		log.WithFields(logFields).Error(
@@ -90,38 +90,6 @@ func (s *server) unbind(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		serviceManager := svc.GetServiceManager()
-
-		// Now that we have a serviceManager, we can get empty objects of the
-		// correct types, so we can take a second pass at retrieving an instance
-		// and a binding from storage with more concrete details filled in.
-		instance, _, err = s.store.GetInstance(
-			instanceID,
-			serviceManager.GetEmptyProvisioningParameters(),
-			serviceManager.GetEmptyUpdatingParameters(),
-			serviceManager.GetEmptyProvisioningContext(),
-		)
-		if err != nil {
-			logFields["error"] = err
-			log.WithFields(logFields).Error(
-				"pre-unbinding error: error retrieving instance by id",
-			)
-			s.writeResponse(w, http.StatusInternalServerError, responseEmptyJSON)
-			return
-		}
-		binding, _, err = s.store.GetBinding(
-			bindingID,
-			serviceManager.GetEmptyBindingParameters(),
-			serviceManager.GetEmptyBindingContext(),
-			serviceManager.GetEmptyCredentials(),
-		)
-		if err != nil {
-			logFields["error"] = err
-			log.WithFields(logFields).Error(
-				"pre-unbinding error: error retrieving binding by id",
-			)
-			s.writeResponse(w, http.StatusInternalServerError, responseEmptyJSON)
-			return
-		}
 
 		// Starting here, if something goes wrong, we don't know what state service-
 		// specific code has left us in, so we'll attempt to record the error in

--- a/pkg/api/unbind_test.go
+++ b/pkg/api/unbind_test.go
@@ -33,6 +33,7 @@ func TestUnbindingWithInstanceIDDifferentFromBindingInstanceID(t *testing.T) {
 	err = s.store.WriteBinding(service.Binding{
 		InstanceID: getDisposableInstanceID(),
 		BindingID:  bindingID,
+		ServiceID:  fake.ServiceID,
 	})
 	assert.Nil(t, err)
 	req, err := getUnbindingRequest(
@@ -54,6 +55,7 @@ func TestUnbindingFromInstanceThatDoesNotExist(t *testing.T) {
 	err = s.store.WriteBinding(service.Binding{
 		InstanceID: instanceID,
 		BindingID:  bindingID,
+		ServiceID:  fake.ServiceID,
 	})
 	assert.Nil(t, err)
 	req, err := getUnbindingRequest(
@@ -65,7 +67,7 @@ func TestUnbindingFromInstanceThatDoesNotExist(t *testing.T) {
 	s.router.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, responseEmptyJSON, rr.Body.Bytes())
-	_, ok, err := s.store.GetBinding(bindingID, nil, nil, nil)
+	_, ok, err := s.store.GetBinding(bindingID)
 	assert.Nil(t, err)
 	assert.False(t, ok)
 }
@@ -93,6 +95,7 @@ func TestUnbindingFromInstanceThatExists(t *testing.T) {
 	err = s.store.WriteBinding(service.Binding{
 		InstanceID: instanceID,
 		BindingID:  bindingID,
+		ServiceID:  fake.ServiceID,
 	})
 	assert.Nil(t, err)
 	req, err := getUnbindingRequest(
@@ -105,7 +108,7 @@ func TestUnbindingFromInstanceThatExists(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, responseEmptyJSON, rr.Body.Bytes())
 	assert.True(t, unbindCalled)
-	_, ok, err := s.store.GetBinding(bindingID, nil, nil, nil)
+	_, ok, err := s.store.GetBinding(bindingID)
 	assert.Nil(t, err)
 	assert.False(t, ok)
 }

--- a/pkg/api/update.go
+++ b/pkg/api/update.go
@@ -130,12 +130,7 @@ func (s *server) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	instance, ok, err := s.store.GetInstance(
-		instanceID,
-		serviceManager.GetEmptyProvisioningParameters(),
-		serviceManager.GetEmptyUpdatingParameters(),
-		serviceManager.GetEmptyProvisioningContext(),
-	)
+	instance, ok, err := s.store.GetInstance(instanceID)
 	if err != nil {
 		logFields["error"] = err
 		log.WithFields(logFields).Error(

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -57,12 +57,6 @@ func NewBroker(
 	defaultAzureLocation string,
 	defaultAzureResourceGroup string,
 ) (Broker, error) {
-	b := &broker{
-		store:       storage.NewStore(redisClient, codec),
-		asyncEngine: async.NewEngine(redisClient),
-		codec:       codec,
-	}
-
 	// Consolidate the catalogs from all the individual modules into a single
 	// catalog. Check as we go along to make sure that no two modules provide
 	// services having the same ID.
@@ -94,7 +88,13 @@ func NewBroker(
 			}
 		}
 	}
-	b.catalog = service.NewCatalog(services)
+	catalog := service.NewCatalog(services)
+	b := &broker{
+		store:       storage.NewStore(redisClient, catalog, codec),
+		asyncEngine: async.NewEngine(redisClient),
+		codec:       codec,
+		catalog:     catalog,
+	}
 
 	err := b.asyncEngine.RegisterJob("provisionStep", b.doProvisionStep)
 	if err != nil {

--- a/pkg/broker/deprovision.go
+++ b/pkg/broker/deprovision.go
@@ -24,7 +24,7 @@ func (b *broker) doDeprovisionStep(
 	if !ok {
 		return errors.New(`missing required argument "instanceID"`)
 	}
-	instance, ok, err := b.store.GetInstance(instanceID, nil, nil, nil)
+	instance, ok, err := b.store.GetInstance(instanceID)
 	if err != nil {
 		return b.handleDeprovisioningError(
 			instanceID,
@@ -71,24 +71,6 @@ func (b *broker) doDeprovisionStep(
 	}
 	serviceManager := svc.GetServiceManager()
 
-	// Now that we have a serviceManager, we can get empty objects of the correct
-	// types, so we can take a second pass at retrieving an instance from storage
-	// with more concrete details filled in.
-	instance, _, err = b.store.GetInstance(
-		instanceID,
-		serviceManager.GetEmptyProvisioningParameters(),
-		serviceManager.GetEmptyUpdatingParameters(),
-		serviceManager.GetEmptyProvisioningContext(),
-	)
-	if err != nil {
-		return b.handleDeprovisioningError(
-			instanceID,
-			stepName,
-			err,
-			"error loading persisted instance",
-		)
-	}
-
 	// Retrieve a second copy of the instance from storage. Why? We're about to
 	// pass the instance off to module specific code. It's passed by value, so
 	// we'd like to imagine that the modules can only modify copies of the
@@ -98,12 +80,7 @@ func (b *broker) doDeprovisionStep(
 	// one part of the instance that we inted for modules to modify (provisioning
 	// context) and add that to this untouched copy and write the untouched copy
 	// back to storage.
-	instanceCopy, _, err := b.store.GetInstance(
-		instanceID,
-		serviceManager.GetEmptyProvisioningParameters(),
-		serviceManager.GetEmptyUpdatingParameters(),
-		serviceManager.GetEmptyProvisioningContext(),
-	)
+	instanceCopy, _, err := b.store.GetInstance(instanceID)
 	if err != nil {
 		return b.handleProvisioningError(
 			instanceID,

--- a/pkg/broker/provision.go
+++ b/pkg/broker/provision.go
@@ -24,7 +24,7 @@ func (b *broker) doProvisionStep(
 	if !ok {
 		return errors.New(`missing required argument "instanceID"`)
 	}
-	instance, ok, err := b.store.GetInstance(instanceID, nil, nil, nil)
+	instance, ok, err := b.store.GetInstance(instanceID)
 	if err != nil {
 		return b.handleProvisioningError(
 			instanceID,
@@ -71,24 +71,6 @@ func (b *broker) doProvisionStep(
 	}
 	serviceManager := svc.GetServiceManager()
 
-	// Now that we have a serviceManager, we can get empty objects of the correct
-	// types, so we can take a second pass at retrieving an instance from storage
-	// with more concrete details filled in.
-	instance, _, err = b.store.GetInstance(
-		instanceID,
-		serviceManager.GetEmptyProvisioningParameters(),
-		serviceManager.GetEmptyUpdatingParameters(),
-		serviceManager.GetEmptyProvisioningContext(),
-	)
-	if err != nil {
-		return b.handleProvisioningError(
-			instanceID,
-			stepName,
-			err,
-			"error loading persisted instance",
-		)
-	}
-
 	// Retrieve a second copy of the instance from storage. Why? We're about to
 	// pass the instance off to module specific code. It's passed by value, so
 	// we'd like to imagine that the modules can only modify copies of the
@@ -98,12 +80,7 @@ func (b *broker) doProvisionStep(
 	// one part of the instance that we inted for modules to modify (provisioning
 	// context) and add that to this untouched copy and write the untouched copy
 	// back to storage.
-	instanceCopy, _, err := b.store.GetInstance(
-		instanceID,
-		serviceManager.GetEmptyProvisioningParameters(),
-		serviceManager.GetEmptyUpdatingParameters(),
-		serviceManager.GetEmptyProvisioningContext(),
-	)
+	instanceCopy, _, err := b.store.GetInstance(instanceID)
 	if err != nil {
 		return b.handleProvisioningError(
 			instanceID,

--- a/pkg/broker/update.go
+++ b/pkg/broker/update.go
@@ -24,7 +24,7 @@ func (b *broker) doUpdateStep(
 	if !ok {
 		return errors.New(`missing required argument "instanceID"`)
 	}
-	instance, ok, err := b.store.GetInstance(instanceID, nil, nil, nil)
+	instance, ok, err := b.store.GetInstance(instanceID)
 	if err != nil {
 		return b.handleUpdatingError(
 			instanceID,
@@ -71,24 +71,6 @@ func (b *broker) doUpdateStep(
 	}
 	serviceManager := svc.GetServiceManager()
 
-	// Now that we have a serviceManager, we can get empty objects of the correct
-	// types, so we can take a second pass at retrieving an instance from storage
-	// with more concrete details filled in.
-	instance, _, err = b.store.GetInstance(
-		instanceID,
-		serviceManager.GetEmptyProvisioningParameters(),
-		serviceManager.GetEmptyUpdatingParameters(),
-		serviceManager.GetEmptyProvisioningContext(),
-	)
-	if err != nil {
-		return b.handleUpdatingError(
-			instanceID,
-			stepName,
-			err,
-			"error loading persisted instance",
-		)
-	}
-
 	// Retrieve a second copy of the instance from storage. Why? We're about to
 	// pass the instance off to module specific code. It's passed by value, so
 	// we'd like to imagine that the modules can only modify copies of the
@@ -98,12 +80,7 @@ func (b *broker) doUpdateStep(
 	// one part of the instance that we inted for modules to modify (provisioning
 	// context) and add that to this untouched copy and write the untouched copy
 	// back to storage.
-	instanceCopy, _, err := b.store.GetInstance(
-		instanceID,
-		serviceManager.GetEmptyProvisioningParameters(),
-		serviceManager.GetEmptyUpdatingParameters(),
-		serviceManager.GetEmptyProvisioningContext(),
-	)
+	instanceCopy, _, err := b.store.GetInstance(instanceID)
 	if err != nil {
 		return b.handleProvisioningError(
 			instanceID,

--- a/pkg/service/binding.go
+++ b/pkg/service/binding.go
@@ -11,6 +11,7 @@ import (
 type Binding struct {
 	BindingID                  string            `json:"bindingId"`
 	InstanceID                 string            `json:"instanceId"`
+	ServiceID                  string            `json:"serviceId"`
 	EncryptedBindingParameters []byte            `json:"bindingParameters"`
 	BindingParameters          BindingParameters `json:"-"`
 	Status                     string            `json:"status"`

--- a/pkg/service/binding_test.go
+++ b/pkg/service/binding_test.go
@@ -18,6 +18,7 @@ var (
 func init() {
 	bindingID := "test-binding-id"
 	instanceID := "test-instance-id"
+	serviceID := "test-service-id"
 	encryptedBindingParameters := []byte(`{"foo":"bar"}`)
 	bindingParameters := &ArbitraryType{
 		Foo: "bar",
@@ -39,6 +40,7 @@ func init() {
 	testBinding = Binding{
 		BindingID:                  bindingID,
 		InstanceID:                 instanceID,
+		ServiceID:                  serviceID,
 		EncryptedBindingParameters: encryptedBindingParameters,
 		BindingParameters:          bindingParameters,
 		Status:                     BindingStateBound,
@@ -64,6 +66,7 @@ func init() {
 		`{
 			"bindingId":"%s",
 			"instanceId":"%s",
+			"serviceId":"%s",
 			"bindingParameters":"%s",
 			"status":"%s",
 			"statusReason":"%s",
@@ -73,6 +76,7 @@ func init() {
 		}`,
 		bindingID,
 		instanceID,
+		serviceID,
 		b64EncryptedBindingParameters,
 		BindingStateBound,
 		statusReason,

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1,65 +1,90 @@
 package storage
 
 import (
-	"fmt"
+	"log"
 	"testing"
 
 	"github.com/Azure/open-service-broker-azure/pkg/crypto/noop"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
+	"github.com/Azure/open-service-broker-azure/pkg/services/fake"
 	"github.com/go-redis/redis"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
+	noopCodec   = noop.NewCodec()
 	redisClient = redis.NewClient(&redis.Options{
 		Addr: "redis:6379",
 	})
-	testStore = NewStore(redisClient, noop.NewCodec())
+	fakeServiceManager service.ServiceManager
+	testStore          Store
 )
 
+func init() {
+	var err error
+	fakeModule, err := fake.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fakeCatalog, err := fakeModule.GetCatalog()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fakeServiceManager = fakeModule.ServiceManager
+	testStore = NewStore(
+		redisClient,
+		fakeCatalog,
+		noopCodec,
+	)
+}
+
 func TestWriteInstance(t *testing.T) {
-	instanceID := getDisposableInstanceID()
+	instance := getTestInstance()
 	// First assert that the instance doesn't exist in Redis
-	strCmd := redisClient.Get(instanceID)
+	strCmd := redisClient.Get(instance.InstanceID)
 	assert.Equal(t, redis.Nil, strCmd.Err())
 	// Store the instance
-	err := testStore.WriteInstance(service.Instance{
-		InstanceID: instanceID,
-	})
+	err := testStore.WriteInstance(instance)
 	assert.Nil(t, err)
 	// Assert that the instance is now in Redis
-	strCmd = redisClient.Get(instanceID)
+	strCmd = redisClient.Get(instance.InstanceID)
 	assert.Nil(t, strCmd.Err())
 }
 
 func TestGetNonExistingInstance(t *testing.T) {
-	instanceID := getDisposableInstanceID()
+	instanceID := uuid.NewV4().String()
 	// First assert that the instance doesn't exist in Redis
 	strCmd := redisClient.Get(instanceID)
 	assert.Equal(t, redis.Nil, strCmd.Err())
 	// Try to retrieve the non-existing instance
-	_, ok, err := testStore.GetInstance(instanceID, nil, nil, nil)
+	_, ok, err := testStore.GetInstance(instanceID)
 	// Assert that the retrieval failed
 	assert.False(t, ok)
 	assert.Nil(t, err)
 }
 
 func TestGetExistingInstance(t *testing.T) {
-	instanceID := getDisposableInstanceID()
+	instance := getTestInstance()
 	// First ensure the instance exists in Redis
-	statCmd := redisClient.Set(instanceID, getInstanceJSON(instanceID), 0)
+	json, err := instance.ToJSON(noopCodec)
+	assert.Nil(t, err)
+	statCmd := redisClient.Set(instance.InstanceID, json, 0)
 	assert.Nil(t, statCmd.Err())
 	// Retrieve the instance
-	instance, ok, err := testStore.GetInstance(instanceID, nil, nil, nil)
+	retrievedInstance, ok, err := testStore.GetInstance(instance.InstanceID)
 	// Assert that the retrieval was successful
-	assert.True(t, ok)
 	assert.Nil(t, err)
-	assert.Equal(t, instanceID, instance.InstanceID)
+	assert.True(t, ok)
+	// Blank out a few fields before we compare
+	retrievedInstance.EncryptedProvisioningParameters = nil
+	retrievedInstance.EncryptedUpdatingParameters = nil
+	retrievedInstance.EncryptedProvisioningContext = nil
+	assert.Equal(t, instance, retrievedInstance)
 }
 
 func TestDeleteNonExistingInstance(t *testing.T) {
-	instanceID := getDisposableInstanceID()
+	instanceID := uuid.NewV4().String()
 	// First assert that the instance doesn't exist in Redis
 	strCmd := redisClient.Get(instanceID)
 	assert.Equal(t, redis.Nil, strCmd.Err())
@@ -71,61 +96,67 @@ func TestDeleteNonExistingInstance(t *testing.T) {
 }
 
 func TestDeleteExistingInstance(t *testing.T) {
-	instanceID := getDisposableInstanceID()
+	instance := getTestInstance()
 	// First ensure the instance exists in Redis
-	statCmd := redisClient.Set(instanceID, getInstanceJSON(instanceID), 0)
+	json, err := instance.ToJSON(noopCodec)
+	assert.Nil(t, err)
+	statCmd := redisClient.Set(instance.InstanceID, json, 0)
 	assert.Nil(t, statCmd.Err())
 	// Delete the instance
-	ok, err := testStore.DeleteInstance(instanceID)
+	ok, err := testStore.DeleteInstance(instance.InstanceID)
 	// Assert that the delete was successful
 	assert.True(t, ok)
 	assert.Nil(t, err)
-	strCmd := redisClient.Get(instanceID)
+	strCmd := redisClient.Get(instance.InstanceID)
 	assert.Equal(t, redis.Nil, strCmd.Err())
 }
 
 func TestWriteBinding(t *testing.T) {
-	bindingID := getDisposableBindingID()
+	binding := getTestBinding()
 	// First assert that the binding doesn't exist in Redis
-	strCmd := redisClient.Get(bindingID)
+	strCmd := redisClient.Get(binding.BindingID)
 	assert.Equal(t, redis.Nil, strCmd.Err())
 	// Store the binding
-	err := testStore.WriteBinding(service.Binding{
-		BindingID: bindingID,
-	})
+	err := testStore.WriteBinding(binding)
 	assert.Nil(t, err)
 	// Assert that the binding is now in Redis
-	strCmd = redisClient.Get(bindingID)
+	strCmd = redisClient.Get(binding.BindingID)
 	assert.Nil(t, strCmd.Err())
 }
 
 func TestGetNonExistingBinding(t *testing.T) {
-	bindingID := getDisposableBindingID()
+	bindingID := uuid.NewV4().String()
 	// First assert that the binding doesn't exist in Redis
 	strCmd := redisClient.Get(bindingID)
 	assert.Equal(t, redis.Nil, strCmd.Err())
 	// Try to retrieve the non-existing binding
-	_, ok, err := testStore.GetBinding(bindingID, nil, nil, nil)
+	_, ok, err := testStore.GetBinding(bindingID)
 	// Assert that the retrieval failed
 	assert.False(t, ok)
 	assert.Nil(t, err)
 }
 
 func TestGetExistingBinding(t *testing.T) {
-	bindingID := getDisposableBindingID()
+	binding := getTestBinding()
 	// First ensure the binding exists in Redis
-	statCmd := redisClient.Set(bindingID, getBindingJSON(bindingID), 0)
+	json, err := binding.ToJSON(noopCodec)
+	assert.Nil(t, err)
+	statCmd := redisClient.Set(binding.BindingID, json, 0)
 	assert.Nil(t, statCmd.Err())
 	// Retrieve the binding
-	binding, ok, err := testStore.GetBinding(bindingID, nil, nil, nil)
+	retrievedBinding, ok, err := testStore.GetBinding(binding.BindingID)
 	// Assert that the retrieval was successful
 	assert.True(t, ok)
 	assert.Nil(t, err)
-	assert.Equal(t, bindingID, binding.BindingID)
+	// Blank out a few fields before we compare
+	retrievedBinding.EncryptedBindingParameters = nil
+	retrievedBinding.EncryptedBindingContext = nil
+	retrievedBinding.EncryptedCredentials = nil
+	assert.Equal(t, binding, retrievedBinding)
 }
 
 func TestDeleteNonExistingBinding(t *testing.T) {
-	bindingID := getDisposableBindingID()
+	bindingID := uuid.NewV4().String()
 	// First assert that the binding doesn't exist in Redis
 	strCmd := redisClient.Get(bindingID)
 	assert.Equal(t, redis.Nil, strCmd.Err())
@@ -137,31 +168,53 @@ func TestDeleteNonExistingBinding(t *testing.T) {
 }
 
 func TestDeleteExistingBinding(t *testing.T) {
-	bindingID := getDisposableBindingID()
+	binding := getTestBinding()
 	// First ensure the binding exists in Redis
-	statCmd := redisClient.Set(bindingID, getBindingJSON(bindingID), 0)
+	json, err := binding.ToJSON(noopCodec)
+	assert.Nil(t, err)
+	statCmd := redisClient.Set(binding.BindingID, json, 0)
 	assert.Nil(t, statCmd.Err())
 	// Delete the binding
-	ok, err := testStore.DeleteBinding(bindingID)
+	ok, err := testStore.DeleteBinding(binding.BindingID)
 	// Assert that the delete was successful
 	assert.True(t, ok)
 	assert.Nil(t, err)
-	strCmd := redisClient.Get(bindingID)
+	strCmd := redisClient.Get(binding.BindingID)
 	assert.Equal(t, redis.Nil, strCmd.Err())
 }
 
-func getInstanceJSON(instanceID string) string {
-	return fmt.Sprintf(`{"instanceId":"%s"}`, instanceID)
+func getTestInstance() service.Instance {
+	return service.Instance{
+		InstanceID: uuid.NewV4().String(),
+		ServiceID:  fake.ServiceID,
+		PlanID:     fake.StandardPlanID,
+		StandardProvisioningParameters: service.StandardProvisioningParameters{
+			Location:      "eastus",
+			ResourceGroup: "test",
+			Tags:          map[string]string{"foo": "bar"},
+		},
+		ProvisioningParameters: fakeServiceManager.GetEmptyProvisioningParameters(),
+		UpdatingParameters:     fakeServiceManager.GetEmptyUpdatingParameters(),
+		Status:                 service.InstanceStateProvisioned,
+		StatusReason:           "",
+		StandardProvisioningContext: service.StandardProvisioningContext{
+			Location:      "eastus",
+			ResourceGroup: "test",
+			Tags:          map[string]string{"foo": "bar"},
+		},
+		ProvisioningContext: fakeServiceManager.GetEmptyProvisioningContext(),
+	}
 }
 
-func getBindingJSON(bindingID string) string {
-	return fmt.Sprintf(`{"bindingId":"%s"}`, bindingID)
-}
-
-func getDisposableInstanceID() string {
-	return uuid.NewV4().String()
-}
-
-func getDisposableBindingID() string {
-	return uuid.NewV4().String()
+func getTestBinding() service.Binding {
+	return service.Binding{
+		BindingID:         uuid.NewV4().String(),
+		InstanceID:        uuid.NewV4().String(),
+		ServiceID:         fake.ServiceID,
+		BindingParameters: fakeServiceManager.GetEmptyBindingParameters(),
+		Status:            service.BindingStateBound,
+		StatusReason:      "",
+		BindingContext:    fakeServiceManager.GetEmptyBindingContext(),
+		Credentials:       fakeServiceManager.GetEmptyCredentials(),
+	}
 }


### PR DESCRIPTION
Fixes #151 

There are probably other improvements that can follow on the heels of this one, but this moves us, incrementally, in a positive direction with fewer DRY exceptions.