### PR TITLE
Ref instances

### DIFF
--- a/pkg/broker/deprovision.go
+++ b/pkg/broker/deprovision.go
@@ -111,7 +111,14 @@ func (b *broker) doDeprovisionStep(
 			`deprovisioner does not know how to process step "%s"`,
 		)
 	}
-	updatedProvisioningContext, err := step.Execute(ctx, instance, plan)
+	updatedProvisioningContext, err := step.Execute(
+		ctx,
+		instance,
+		plan,
+		// TODO: Still need to come up with a way of finding a related instance
+		// (if applicable).
+		service.Instance{},
+	)
 	if err != nil {
 		return b.handleDeprovisioningError(
 			instance,

--- a/pkg/broker/provision.go
+++ b/pkg/broker/provision.go
@@ -111,7 +111,14 @@ func (b *broker) doProvisionStep(
 			`provisioner does not know how to process step "%s"`,
 		)
 	}
-	updatedProvisioningContext, err := step.Execute(ctx, instance, plan)
+	updatedProvisioningContext, err := step.Execute(
+		ctx,
+		instance,
+		plan,
+		// TODO: Still need to come up with a way of finding a related instance
+		// (if applicable).
+		service.Instance{},
+	)
 	if err != nil {
 		return b.handleProvisioningError(
 			instance,

--- a/pkg/service/deprovisioner.go
+++ b/pkg/service/deprovisioner.go
@@ -11,6 +11,7 @@ type DeprovisioningStepFunction func(
 	ctx context.Context,
 	instance Instance,
 	plan Plan,
+	refInstance Instance,
 ) (ProvisioningContext, error)
 
 // DeprovisioningStep is an interface to be implemented by types that represent
@@ -21,6 +22,7 @@ type DeprovisioningStep interface {
 		ctx context.Context,
 		instance Instance,
 		plan Plan,
+		refInstance Instance,
 	) (ProvisioningContext, error)
 }
 
@@ -64,6 +66,7 @@ func (d *deprovisioningStep) Execute(
 	ctx context.Context,
 	instance Instance,
 	plan Plan,
+	refInstance Instance,
 ) (ProvisioningContext, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -71,6 +74,7 @@ func (d *deprovisioningStep) Execute(
 		ctx,
 		instance,
 		plan,
+		refInstance,
 	)
 }
 

--- a/pkg/service/provisioner.go
+++ b/pkg/service/provisioner.go
@@ -11,6 +11,7 @@ type ProvisioningStepFunction func(
 	ctx context.Context,
 	instance Instance,
 	plan Plan,
+	refInstance Instance,
 ) (ProvisioningContext, error)
 
 // ProvisioningStep is an interface to be implemented by types that represent
@@ -21,6 +22,7 @@ type ProvisioningStep interface {
 		ctx context.Context,
 		instance Instance,
 		plan Plan,
+		refInstance Instance,
 	) (ProvisioningContext, error)
 }
 
@@ -64,6 +66,7 @@ func (p *provisioningStep) Execute(
 	ctx context.Context,
 	instance Instance,
 	plan Plan,
+	refInstance Instance,
 ) (ProvisioningContext, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -71,6 +74,7 @@ func (p *provisioningStep) Execute(
 		ctx,
 		instance,
 		plan,
+		refInstance,
 	)
 }
 

--- a/pkg/services/aci/deprovision.go
+++ b/pkg/services/aci/deprovision.go
@@ -20,6 +20,7 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*aciProvisioningContext)
 	if !ok {
@@ -40,6 +41,7 @@ func (s *serviceManager) deleteACIServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*aciProvisioningContext)
 	if !ok {

--- a/pkg/services/aci/provision.go
+++ b/pkg/services/aci/provision.go
@@ -41,6 +41,7 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*aciProvisioningContext)
 	if !ok {
@@ -57,6 +58,7 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*aciProvisioningContext)
 	if !ok {

--- a/pkg/services/cosmosdb/deprovision.go
+++ b/pkg/services/cosmosdb/deprovision.go
@@ -23,6 +23,7 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*cosmosdbProvisioningContext)
 	if !ok {
@@ -44,6 +45,7 @@ func (s *serviceManager) deleteCosmosDBServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*cosmosdbProvisioningContext)
 	if !ok {

--- a/pkg/services/cosmosdb/provision.go
+++ b/pkg/services/cosmosdb/provision.go
@@ -30,6 +30,7 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*cosmosdbProvisioningContext)
 	if !ok {
@@ -47,6 +48,7 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*cosmosdbProvisioningContext)
 	if !ok {

--- a/pkg/services/eventhubs/deprovision.go
+++ b/pkg/services/eventhubs/deprovision.go
@@ -20,6 +20,7 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*eventHubProvisioningContext)
 	if !ok {
@@ -41,6 +42,7 @@ func (s *serviceManager) deleteNamespace(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*eventHubProvisioningContext)
 	if !ok {

--- a/pkg/services/eventhubs/provision.go
+++ b/pkg/services/eventhubs/provision.go
@@ -29,6 +29,7 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*eventHubProvisioningContext)
 	if !ok {
@@ -47,6 +48,7 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*eventHubProvisioningContext)
 	if !ok {

--- a/pkg/services/fake/fake.go
+++ b/pkg/services/fake/fake.go
@@ -99,6 +99,7 @@ func (s *ServiceManager) provision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	return instance.ProvisioningContext, nil
 }
@@ -173,6 +174,7 @@ func (s *ServiceManager) deprovision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	return instance.ProvisioningContext, nil
 }

--- a/pkg/services/keyvault/deprovision.go
+++ b/pkg/services/keyvault/deprovision.go
@@ -23,6 +23,7 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*keyvaultProvisioningContext)
 	if !ok {
@@ -44,6 +45,7 @@ func (s *serviceManager) deleteKeyVaultServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*keyvaultProvisioningContext)
 	if !ok {

--- a/pkg/services/keyvault/provision.go
+++ b/pkg/services/keyvault/provision.go
@@ -53,6 +53,7 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*keyvaultProvisioningContext)
 	if !ok {
@@ -70,6 +71,7 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*keyvaultProvisioningContext)
 	if !ok {

--- a/pkg/services/mysqldb/deprovision.go
+++ b/pkg/services/mysqldb/deprovision.go
@@ -20,6 +20,7 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*mysqlProvisioningContext)
 	if !ok {
@@ -40,6 +41,7 @@ func (s *serviceManager) deleteMySQLServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*mysqlProvisioningContext)
 	if !ok {

--- a/pkg/services/mysqldb/provision.go
+++ b/pkg/services/mysqldb/provision.go
@@ -89,6 +89,7 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*mysqlProvisioningContext)
 	if !ok {
@@ -158,6 +159,7 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*mysqlProvisioningContext)
 	if !ok {

--- a/pkg/services/postgresqldb/deprovision.go
+++ b/pkg/services/postgresqldb/deprovision.go
@@ -23,6 +23,7 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
@@ -44,6 +45,7 @@ func (s *serviceManager) deletePostgreSQLServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {

--- a/pkg/services/postgresqldb/provision.go
+++ b/pkg/services/postgresqldb/provision.go
@@ -92,6 +92,7 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
@@ -161,6 +162,7 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
@@ -206,6 +208,7 @@ func (s *serviceManager) setupDatabase(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {
@@ -270,6 +273,7 @@ func (s *serviceManager) createExtensions(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*postgresqlProvisioningContext)
 	if !ok {

--- a/pkg/services/rediscache/deprovision.go
+++ b/pkg/services/rediscache/deprovision.go
@@ -20,6 +20,7 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*redisProvisioningContext)
 	if !ok {
@@ -40,6 +41,7 @@ func (s *serviceManager) deleteRedisServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*redisProvisioningContext)
 	if !ok {

--- a/pkg/services/rediscache/provision.go
+++ b/pkg/services/rediscache/provision.go
@@ -29,6 +29,7 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*redisProvisioningContext)
 	if !ok {
@@ -45,6 +46,7 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*redisProvisioningContext)
 	if !ok {

--- a/pkg/services/search/deprovision.go
+++ b/pkg/services/search/deprovision.go
@@ -20,6 +20,7 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*searchProvisioningContext)
 	if !ok {
@@ -40,6 +41,7 @@ func (s *serviceManager) deleteAzureSearch(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*searchProvisioningContext)
 	if !ok {

--- a/pkg/services/search/provision.go
+++ b/pkg/services/search/provision.go
@@ -29,6 +29,7 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*searchProvisioningContext)
 	if !ok {
@@ -46,6 +47,7 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*searchProvisioningContext)
 	if !ok {

--- a/pkg/services/servicebus/deprovision.go
+++ b/pkg/services/servicebus/deprovision.go
@@ -20,6 +20,7 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*serviceBusProvisioningContext)
 	if !ok {
@@ -41,6 +42,7 @@ func (s *serviceManager) deleteNamespace(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*serviceBusProvisioningContext)
 	if !ok {

--- a/pkg/services/servicebus/provision.go
+++ b/pkg/services/servicebus/provision.go
@@ -29,6 +29,7 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*serviceBusProvisioningContext)
 	if !ok {
@@ -46,6 +47,7 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*serviceBusProvisioningContext)
 	if !ok {

--- a/pkg/services/sqldb/deprovision.go
+++ b/pkg/services/sqldb/deprovision.go
@@ -23,6 +23,7 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*mssqlProvisioningContext)
 	if !ok {
@@ -44,6 +45,7 @@ func (s *serviceManager) deleteMsSQLServerOrDatabase(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*mssqlProvisioningContext)
 	if !ok {

--- a/pkg/services/sqldb/provision.go
+++ b/pkg/services/sqldb/provision.go
@@ -93,6 +93,7 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*mssqlProvisioningContext)
 	if !ok {
@@ -141,6 +142,7 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*mssqlProvisioningContext)
 	if !ok {

--- a/pkg/services/storage/deprovision.go
+++ b/pkg/services/storage/deprovision.go
@@ -23,6 +23,7 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*storageProvisioningContext)
 	if !ok {
@@ -44,6 +45,7 @@ func (s *serviceManager) deleteStorageAccount(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*storageProvisioningContext)
 	if !ok {

--- a/pkg/services/storage/provision.go
+++ b/pkg/services/storage/provision.go
@@ -49,6 +49,7 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*storageProvisioningContext)
 	if !ok {
@@ -80,6 +81,7 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*storageProvisioningContext)
 	if !ok {
@@ -133,6 +135,7 @@ func (s *serviceManager) createBlobContainer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
+	_ service.Instance, // Reference instance
 ) (service.ProvisioningContext, error) {
 	pc, ok := instance.ProvisioningContext.(*storageProvisioningContext)
 	if !ok {

--- a/tests/lifecycle/test_case_test.go
+++ b/tests/lifecycle/test_case_test.go
@@ -133,7 +133,14 @@ func (s serviceLifecycleTestCase) execute(resourceGroup string) error {
 				stepName,
 			)
 		}
-		instance.ProvisioningContext, err = step.Execute(ctx, instance, plan)
+		instance.ProvisioningContext, err = step.Execute(
+			ctx,
+			instance,
+			plan,
+			// TODO: Still need to come up with a way of finding a related instance
+			// (if applicable).
+			service.Instance{},
+		)
 		if err != nil {
 			return err
 		}
@@ -190,7 +197,14 @@ func (s serviceLifecycleTestCase) execute(resourceGroup string) error {
 		// Assign results to temp variable in case they're nil. We don't want
 		// pc to ever be nil, or we risk a nil pointer dereference in the
 		// cleanup logic.
-		instance.ProvisioningContext, err = step.Execute(ctx, instance, plan)
+		instance.ProvisioningContext, err = step.Execute(
+			ctx,
+			instance,
+			plan,
+			// TODO: Still need to come up with a way of finding a related instance
+			// (if applicable).
+			service.Instance{},
+		)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This makes it so that all provisioning and deprovisioning steps receive another argument that is a "reference instance." This creates the possibility of accessing the details of one instance when provisioning a new one that is related to it in some way. As a concrete example-- when provisioning a new MS SQL database on an existing MS SQL Server, this allows the provisioning step to learn relevant details about what is logically the "parent" instance.

Note this PR does _not_ figure out how we obtain the reference instance. That will be its own discrete PR.