### PR TITLE
don't use codec where we don't need it anymore

### DIFF
--- a/cmd/compliance-test-broker/compliance-test-broker.go
+++ b/cmd/compliance-test-broker/compliance-test-broker.go
@@ -39,7 +39,6 @@ func main() {
 		8080,
 		memoryStorage.NewStore(fakeCatalog, noopCodec),
 		fakeAsync.NewEngine(),
-		noopCodec,
 		authenticator,
 		fakeCatalog,
 		" ",

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -56,12 +56,10 @@ func getTestServer(
 	if err != nil {
 		return nil, nil, err
 	}
-	noopCodec := noop.NewCodec()
 	s, err := NewServer(
 		8080,
-		memoryStorage.NewStore(fakeCatalog, noopCodec),
+		memoryStorage.NewStore(fakeCatalog, noop.NewCodec()),
 		fakeAsync.NewEngine(),
-		noopCodec,
 		always.NewAuthenticator(),
 		fakeCatalog,
 		defaultAzureLocation,

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Azure/open-service-broker-azure/pkg/api/authenticator"
 	"github.com/Azure/open-service-broker-azure/pkg/async"
-	"github.com/Azure/open-service-broker-azure/pkg/crypto"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/Azure/open-service-broker-azure/pkg/storage"
 	log "github.com/Sirupsen/logrus"
@@ -38,7 +37,6 @@ type server struct {
 	port            int
 	store           storage.Store
 	asyncEngine     async.Engine
-	codec           crypto.Codec
 	authenticator   authenticator.Authenticator
 	router          *mux.Router
 	catalog         service.Catalog
@@ -54,7 +52,6 @@ func NewServer(
 	port int,
 	store storage.Store,
 	asyncEngine async.Engine,
-	codec crypto.Codec,
 	authenticator authenticator.Authenticator,
 	catalog service.Catalog,
 	defaultAzureLocation string,
@@ -64,7 +61,6 @@ func NewServer(
 		port:                      port,
 		store:                     store,
 		asyncEngine:               asyncEngine,
-		codec:                     codec,
 		authenticator:             authenticator,
 		catalog:                   catalog,
 		defaultAzureLocation:      defaultAzureLocation,

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -119,7 +119,6 @@ func NewBroker(
 		8080,
 		b.store,
 		b.asyncEngine,
-		b.codec,
 		authenticator,
 		b.catalog,
 		defaultAzureLocation,


### PR DESCRIPTION
This is a follow-up to #153. The api server no longer needs access to the codec that the storage layer uses for encrypting / decrypting sensitive information, so this PR removes that.