### PR TITLE
Add REGISTRY variable to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ BINARY_NAME := osba
 #
 # See https://github.com/Azure/open-service-broker-azure/issues/100
 BASE_IMAGE_NAME        = azure-service-broker
+REGISTRY               = microsoft/
 
 RC_IMAGE_NAME          = $(REGISTRY)$(BASE_IMAGE_NAME):$(GIT_VERSION)
 RC_MUTABLE_IMAGE_NAME  = $(REGISTRY)$(BASE_IMAGE_NAME):canary


### PR DESCRIPTION
Added a Registry variable to the Makefile. It was used in
image names, but never defined. This caused the master build to fail.

Fixes #145