### PR TITLE
Updating CircleCI to define DOCKER_REPO env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
     working_directory: ~/go/src/github.com/Azure/open-service-broker-azure
     environment:
       GOPATH: ~/go
-      REGISTRY: docker.io/microsoft/
+      DOCKER_REPO: microsoft/
     machine: true
     steps:
       - checkout
@@ -97,7 +97,7 @@ jobs:
           command: make docker-push-rc
   publish-release-images:
     environment:
-      REGISTRY: docker.io/microsoft/
+      DOCKER_REPO: microsoft/
     machine: true
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
     working_directory: ~/go/src/github.com/Azure/open-service-broker-azure
     environment:
       GOPATH: ~/go
-      REGISTRY: microsoft/
+      REGISTRY: docker.io/microsoft/
     machine: true
     steps:
       - checkout
@@ -97,7 +97,7 @@ jobs:
           command: make docker-push-rc
   publish-release-images:
     environment:
-      REGISTRY: microsoft/
+      REGISTRY: docker.io/microsoft/
     machine: true
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
     working_directory: ~/go/src/github.com/Azure/open-service-broker-azure
     environment:
       GOPATH: ~/go
+      REGISTRY: microsoft/
     machine: true
     steps:
       - checkout
@@ -95,6 +96,8 @@ jobs:
           name: Publish Release Candidate Images to Docker Hub
           command: make docker-push-rc
   publish-release-images:
+    environment:
+      REGISTRY: microsoft/
     machine: true
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ BINARY_NAME := osba
 # See https://github.com/Azure/open-service-broker-azure/issues/100
 BASE_IMAGE_NAME        = azure-service-broker
 
-RC_IMAGE_NAME          = $(REGISTRY)$(BASE_IMAGE_NAME):$(GIT_VERSION)
-RC_MUTABLE_IMAGE_NAME  = $(REGISTRY)$(BASE_IMAGE_NAME):canary
+RC_IMAGE_NAME          = $(DOCKER_REPO)$(BASE_IMAGE_NAME):$(GIT_VERSION)
+RC_MUTABLE_IMAGE_NAME  = $(DOCKER_REPO)$(BASE_IMAGE_NAME):canary
 
-REL_IMAGE_NAME         = $(REGISTRY)$(BASE_IMAGE_NAME):$(REL_VERSION)
-REL_MUTABLE_IMAGE_NAME = $(REGISTRY)$(BASE_IMAGE_NAME):latest
+REL_IMAGE_NAME         = $(DOCKER_REPO)$(BASE_IMAGE_NAME):$(REL_VERSION)
+REL_MUTABLE_IMAGE_NAME = $(DOCKER_REPO)$(BASE_IMAGE_NAME):latest
 
 # Checks for the existence of a docker client and prints a nice error message
 # if it isn't present


### PR DESCRIPTION
We previously set the REGISTRY environment variable in a deploy script.
When that was removed to streamline the release process, we need to
define it in Circle. Added two environment blocks to the publish-rc-images
and publish-release-images jobs.

Fixes: 145