### PR TITLE
Adding build flags to inject the version and commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,19 +237,16 @@ CLI_BINARY_NAME := broker-cli
 build-mac-broker-cli: check-docker-compose
 	docker-compose run --rm -e GOOS=darwin -e GOARCH=amd64 dev \
 		go build -o ${CONTRIB_BINARY_DIR}/${CLI_BINARY_NAME} \
-		-ldflags '$(LDFLAGS)' \
 		./contrib/cmd/cli
 
 .PHONY: build-linux-broker-cli
 build-linux-broker-cli: check-docker-compose
 	docker-compose run --rm -e GOOS=linux -e GOARCH=amd64 dev \
 		go build -o ${CONTRIB_BINARY_DIR}/${CLI_BINARY_NAME} \
-		-ldflags '$(LDFLAGS)' \
 		./contrib/cmd/cli
 
 .PHONY: build-win-broker-cli
 build-win-broker-cli: check-docker-compose
 	docker-compose run --rm -e GOOS=windows -e GOARCH=amd64 dev \
 		go build -o ${CONTRIB_BINARY_DIR}/${CLI_BINARY_NAME} \
-		-ldflags '$(LDFLAGS)' \
 		./contrib/cmd/cli

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,12 @@ REL_IMAGE_NAME         = $(DOCKER_REPO)$(BASE_IMAGE_NAME):$(REL_VERSION)
 REL_MUTABLE_IMAGE_NAME = $(DOCKER_REPO)$(BASE_IMAGE_NAME):latest
 
 ifeq ($(REL_VERSION),)
-REL_VERSION="devel"
+BROKER_VERSION="devel"
+else
+BROKER_VERSION=$(REL_VERSION)
 endif
 
-LDFLAGS = -w -X main.commit=$(COMMIT) -X main.commit=$(GIT_VERSION) -X main.version=$(REL_VERSION)
+LDFLAGS = -w -X main.commit=$(COMMIT) -X main.commit=$(GIT_VERSION) -X main.version=$(BROKER_VERSION)
 
 # Checks for the existence of a docker client and prints a nice error message
 # if it isn't present

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ else
 BROKER_VERSION=$(REL_VERSION)
 endif
 
-LDFLAGS = -w -X main.commit=$(COMMIT) -X main.commit=$(GIT_VERSION) -X main.version=$(BROKER_VERSION)
+LDFLAGS = -w -X main.commit=$(GIT_VERSION) -X main.version=$(BROKER_VERSION)
 
 # Checks for the existence of a docker client and prints a nice error message
 # if it isn't present

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,12 @@ RC_MUTABLE_IMAGE_NAME  = $(DOCKER_REPO)$(BASE_IMAGE_NAME):canary
 REL_IMAGE_NAME         = $(DOCKER_REPO)$(BASE_IMAGE_NAME):$(REL_VERSION)
 REL_MUTABLE_IMAGE_NAME = $(DOCKER_REPO)$(BASE_IMAGE_NAME):latest
 
+ifeq ($(REL_VERSION),)
+REL_VERSION="devel"
+endif
+
+LDFLAGS = -w -X main.commit=$(COMMIT) -X main.commit=$(GIT_VERSION) -X main.version=$(REL_VERSION)
+
 # Checks for the existence of a docker client and prints a nice error message
 # if it isn't present
 .PHONY: check-docker
@@ -167,7 +173,7 @@ stop-test-redis: check-docker-compose
 .PHONY: build
 build: check-docker-compose
 	docker-compose run --rm dev \
-		go build -o ${BINARY_DIR}/${BINARY_NAME} ./cmd/broker
+		go build -o ${BINARY_DIR}/${BINARY_NAME} -ldflags '$(LDFLAGS)' ./cmd/broker
 
 # (Re)Build the Docker image for the osba and run it
 .PHONY: run
@@ -227,16 +233,19 @@ CLI_BINARY_NAME := broker-cli
 build-mac-broker-cli: check-docker-compose
 	docker-compose run --rm -e GOOS=darwin -e GOARCH=amd64 dev \
 		go build -o ${CONTRIB_BINARY_DIR}/${CLI_BINARY_NAME} \
+		-ldflags '$(LDFLAGS)' \
 		./contrib/cmd/cli
 
 .PHONY: build-linux-broker-cli
 build-linux-broker-cli: check-docker-compose
 	docker-compose run --rm -e GOOS=linux -e GOARCH=amd64 dev \
 		go build -o ${CONTRIB_BINARY_DIR}/${CLI_BINARY_NAME} \
+		-ldflags '$(LDFLAGS)' \
 		./contrib/cmd/cli
 
 .PHONY: build-win-broker-cli
 build-win-broker-cli: check-docker-compose
 	docker-compose run --rm -e GOOS=windows -e GOARCH=amd64 dev \
 		go build -o ${CONTRIB_BINARY_DIR}/${CLI_BINARY_NAME} \
+		-ldflags '$(LDFLAGS)' \
 		./contrib/cmd/cli

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -17,6 +17,11 @@ import (
 	"github.com/go-redis/redis"
 )
 
+var (
+	version string
+	commit  string
+)
+
 func init() {
 	// Initialize logging
 	// Split log output across stdout and stderr, depending on severity

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -54,7 +54,13 @@ func init() {
 }
 
 func main() {
-	log.Printf("Broker starting with version %s, commit %s", version, commit)
+	log.WithFields(
+		log.Fields{
+			"version": version,
+			"commit":  commit,
+		},
+	).Info("Open Service Broker for Azure starting")
+
 	// Redis client
 	redisConfig, err := getRedisConfig()
 	if err != nil {

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -54,6 +54,7 @@ func init() {
 }
 
 func main() {
+	log.Printf("Broker starting with version %s, commit %s", version, commit)
 	// Redis client
 	redisConfig, err := getRedisConfig()
 	if err != nil {


### PR DESCRIPTION
This patch injects the version and commit to the OSBA binary. If there is no version set, then sets the version to “devel”

This needs to go in before #172 