### PR TITLE
Decomposition of single service into multiple services

### DIFF
--- a/pkg/service/catalog.go
+++ b/pkg/service/catalog.go
@@ -39,6 +39,7 @@ type Service interface {
 	ToJSON() ([]byte, error)
 	GetID() string
 	GetName() string
+	GetBindable() bool
 	GetServiceManager() ServiceManager
 	GetPlans() []Plan
 	GetPlan(planID string) (Plan, bool)
@@ -204,6 +205,11 @@ func (s *service) GetID() string {
 
 func (s *service) GetName() string {
 	return s.Name
+}
+
+// GetBindable returns true if a service is bindable
+func (s *service) GetBindable() bool {
+	return s.Bindable
 }
 
 func (s *service) GetServiceManager() ServiceManager {

--- a/pkg/services/sqldb/arm_template_db_only.go
+++ b/pkg/services/sqldb/arm_template_db_only.go
@@ -1,0 +1,52 @@
+package sqldb
+
+// nolint: lll
+var armTemplateDBOnlyBytes = []byte(`
+{
+	"$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+	"contentVersion": "1.0.0.0",
+	"parameters": {
+		"location": {
+			"type": "string"
+		},
+		"serverName": {
+			"type": "string"
+		},
+		"databaseName": {
+			"type": "string"
+		},
+		"edition": {
+			"type": "string"
+		},
+		"requestedServiceObjectiveName": {
+			"type": "string"
+		},
+		"maxSizeBytes": {
+			"type": "string"
+		},
+		"tags": {
+			"type": "object"
+		}
+	},
+	"variables": {
+		"SQLapiVersion": "2014-04-01"
+	},
+	"resources": [
+		{
+			"type": "Microsoft.Sql/servers/databases",
+			"name": "[concat(parameters('serverName'), '/', parameters('databaseName'))]",
+			"apiVersion": "[variables('SQLapiVersion')]",
+			"location": "[parameters('location')]",
+			"properties": {
+				"collation": "SQL_Latin1_General_CP1_CI_AS",
+				"edition": "[parameters('edition')]",
+				"requestedServiceObjectiveName": "[parameters('requestedServiceObjectiveName')]",
+				"maxSizeBytes": "[parameters('maxSizeBytes')]"
+			},
+			"tags": "[parameters('tags')]"
+		}
+	],
+	"outputs": {
+	}
+}
+`)

--- a/pkg/services/sqldb/arm_template_server_only.go
+++ b/pkg/services/sqldb/arm_template_server_only.go
@@ -1,0 +1,87 @@
+package sqldb
+
+// nolint: lll
+var armTemplateServerOnlyBytes = []byte(`
+{
+	"$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+	"contentVersion": "1.0.0.0",
+	"parameters": {
+		"location": {
+			"type": "string"
+		},
+		"serverName": {
+			"type": "string"
+		},
+		"version": {
+			"type": "string",
+			"allowedValues": [ "2.0", "12.0" ],
+			"defaultValue": "12.0"
+		},
+		"administratorLogin": {
+			"type": "string"
+		},
+		"administratorLoginPassword": {
+			"type": "securestring"
+		},
+		"firewallRuleName": {
+			"type": "string",
+			"minLength": 1,
+			"maxLength": 128,
+			"defaultValue": "AllowAll"
+		},
+		"firewallStartIpAddress": {
+			"type": "string",
+			"minLength": 1,
+			"maxLength": 15,
+			"defaultValue": "0.0.0.0"
+		},
+		"firewallEndIpAddress": {
+			"type": "string",
+			"minLength": 1,
+			"maxLength": 15,
+			"defaultValue": "0.0.0.0"
+		},
+		"tags": {
+			"type": "object"
+		}
+	},
+	"variables": {
+		"SQLapiVersion": "2014-04-01"
+	},
+	"resources": [
+		{
+			"type": "Microsoft.Sql/servers",
+			"name": "[parameters('serverName')]",
+			"apiVersion": "[variables('SQLapiVersion')]",
+			"location": "[parameters('location')]",
+			"properties": {
+				"administratorLogin": "[parameters('administratorLogin')]",
+				"administratorLoginPassword": "[parameters('administratorLoginPassword')]",
+				"version": "[parameters('version')]"
+			},
+			"tags": "[parameters('tags')]",
+			"resources": [
+				{
+					"type": "firewallrules",
+					"name": "[parameters('firewallRuleName')]",
+					"apiVersion": "[variables('SQLapiVersion')]",
+					"location": "[parameters('location')]",
+					"properties": {
+						"startIpAddress": "[parameters('firewallStartIpAddress')]",
+						"endIpAddress": "[parameters('firewallEndIpAddress')]"
+					},
+					"dependsOn": [
+						"[concat('Microsoft.Sql/servers/', parameters('serverName'))]"
+					]
+				}
+			]
+		}
+	],
+	"outputs": {
+		"fullyQualifiedDomainName": {
+			"type": "string",
+			"value": "[reference(parameters('serverName')).fullyQualifiedDomainName]"
+		}
+	}
+}
+`)

--- a/pkg/services/sqldb/bind.go
+++ b/pkg/services/sqldb/bind.go
@@ -187,5 +187,99 @@ func (d *dbOnlyManager) GetCredentials(
 	instance service.Instance,
 	binding service.Binding,
 ) (service.Credentials, error) {
-	return nil, nil
+	dt, ok := instance.Details.(*mssqlDBOnlyInstanceDetails)
+	if !ok {
+		return nil, fmt.Errorf(
+			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
+		)
+	}
+
+	loginName := generate.NewIdentifier()
+	password := generate.NewPassword()
+
+	// connect to master database to create login
+	masterDb, err := getDBConnection(
+		dt.AdministratorLogin,
+		dt.AdministratorLoginPassword,
+		dt.FullyQualifiedDomainName,
+		"master",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer masterDb.Close() // nolint: errcheck
+
+	if _, err = masterDb.Exec(
+		fmt.Sprintf("CREATE LOGIN \"%s\" WITH PASSWORD='%s'", loginName, password),
+	); err != nil {
+		return nil, fmt.Errorf(
+			`error creating login "%s": %s`,
+			loginName,
+			err,
+		)
+	}
+
+	// connect to new database to create user for the login
+	db, err := getDBConnection(
+		dt.AdministratorLogin,
+		dt.AdministratorLoginPassword,
+		dt.FullyQualifiedDomainName,
+		dt.DatabaseName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close() // nolint: errcheck
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error starting transaction on the new database: %s",
+			err,
+		)
+	}
+	defer func() {
+		if err != nil {
+			if err = tx.Rollback(); err != nil {
+				log.WithField("error", err).
+					Error("error rolling back transaction on the new database")
+			}
+			// Drop the login created in the last step
+			if _, err = masterDb.Exec(
+				fmt.Sprintf("DROP LOGIN \"%s\"", loginName),
+			); err != nil {
+				log.WithField("error", err).
+					Error("error dropping login on master database")
+			}
+		}
+	}()
+	if _, err = tx.Exec(
+		fmt.Sprintf("CREATE USER \"%s\" FOR LOGIN \"%s\"", loginName, loginName),
+	); err != nil {
+		return nil, fmt.Errorf(
+			`error creating user "%s": %s`,
+			loginName,
+			err,
+		)
+	}
+	if _, err = tx.Exec(
+		fmt.Sprintf("GRANT CONTROL to \"%s\"", loginName),
+	); err != nil {
+		return nil, fmt.Errorf(
+			`error granting CONTROL to user "%s": %s`,
+			loginName,
+			err,
+		)
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, fmt.Errorf(
+			"error committing transaction on the new database: %s",
+			err,
+		)
+	}
+
+	return &mssqlBindingDetails{
+		LoginName: loginName,
+		Password:  password,
+	}, nil
 }

--- a/pkg/services/sqldb/bind.go
+++ b/pkg/services/sqldb/bind.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-func (a *allInOneManger) ValidateBindingParameters(
+func (a *allInOneManager) ValidateBindingParameters(
 	bindingParameters service.BindingParameters,
 ) error {
 	// There are no parameters for binding to MSSQL, so there is nothing
@@ -32,7 +32,7 @@ func (d *dbOnlyManager) ValidateBindingParameters(
 	return nil
 }
 
-func (a *allInOneManger) Bind(
+func (a *allInOneManager) Bind(
 	instance service.Instance,
 	_ service.BindingParameters,
 ) (service.BindingDetails, error) {
@@ -133,7 +133,7 @@ func (a *allInOneManger) Bind(
 	}, nil
 }
 
-func (a *allInOneManger) GetCredentials(
+func (a *allInOneManager) GetCredentials(
 	instance service.Instance,
 	binding service.Binding,
 ) (service.Credentials, error) {

--- a/pkg/services/sqldb/catalog.go
+++ b/pkg/services/sqldb/catalog.go
@@ -13,7 +13,7 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				Bindable:    true,
 				Tags:        []string{"Azure", "SQL", "Database"},
 			},
-			m.serviceManager,
+			m.allInOneServiceManager,
 			service.NewPlan(&service.PlanProperties{
 				ID:          "3819fdfa-0aaa-11e6-86f4-000d3a002ed5",
 				Name:        "basic",
@@ -137,6 +137,166 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 			}),
 			service.NewPlan(&service.PlanProperties{
 				ID:          "470a869b-1b02-474b-b5e5-10ca0ea488df",
+				Name:        "data-warehouse-1200",
+				Description: "DataWarehouse1200 Tier, 1200 DWUs, 1024GB",
+				Free:        false,
+				Extended: map[string]interface{}{
+					"edition":                       "DataWarehouse",
+					"requestedServiceObjectiveName": "DW1200",
+					"maxSizeBytes":                  "1099511627776",
+				},
+			}),
+		),
+		//vm only service
+		service.NewService(
+			&service.ServiceProperties{
+				ID:          "a7454e0e-be2c-46ac-b55f-8c4278117525",
+				Name:        "azure-sqldb-vm-only",
+				Description: "Azure SQL Server VM (Experimental)",
+				Bindable:    false,
+				Tags:        []string{"Azure", "SQL", "Server", "VM"},
+			},
+			m.vmOnlyServiceManager,
+			service.NewPlan(&service.PlanProperties{
+				ID:          "24f0f42e-1ab3-474e-a5ca-b943b2c48eee",
+				Name:        "sqldb-vm-only",
+				Description: "Azure SQL Server VM Only",
+				Free:        false,
+			}),
+		),
+		//db only services
+		service.NewService(
+			&service.ServiceProperties{
+				ID:          "2bbc160c-e279-4757-a6b6-4c0a4822d0aa",
+				Name:        "azure-sqldb-db-only",
+				Description: "Azure SQL Database Only(Experimental)",
+				Bindable:    true,
+				Tags:        []string{"Azure", "SQL", "Database"},
+			},
+			m.dbOnlyServiceManager,
+			service.NewPlan(&service.PlanProperties{
+				ID:          "8fa8d759-c142-45dd-ae38-b93482ddc04a",
+				Name:        "basic",
+				Description: "Basic Tier, 5 DTUs, 2GB, 7 days point-in-time restore",
+				Free:        false,
+				Extended: map[string]interface{}{
+					"edition":                       "Basic",
+					"requestedServiceObjectiveName": "Basic",
+					"maxSizeBytes":                  "2147483648",
+				},
+			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "9d36b6b3-b5f3-4907-a713-5cc13b785409",
+				Name:        "standard-s0",
+				Description: "Standard Tier, 10 DTUs, 250GB, 35 days point-in-time restore",
+				Free:        false,
+				Extended: map[string]interface{}{
+					"edition":                       "Standard",
+					"requestedServiceObjectiveName": "S0",
+					"maxSizeBytes":                  "268435456000",
+				},
+			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "01c397f8-c999-4e86-bcc2-654cd8cae5fd",
+				Name:        "standard-s1",
+				Description: "StandardS1 Tier, 20 DTUs, 250GB, 35 days point-in-time restore",
+				Free:        false,
+				Extended: map[string]interface{}{
+					"edition":                       "Standard",
+					"requestedServiceObjectiveName": "S1",
+					"maxSizeBytes":                  "268435456000",
+				},
+			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "9cd114a0-8356-4247-9b71-2e685e5a29f3",
+				Name:        "standard-s2",
+				Description: "StandardS2 Tier, 50 DTUs, 250GB, 35 days point-in-time restore",
+				Free:        false,
+				Extended: map[string]interface{}{
+					"edition":                       "Standard",
+					"requestedServiceObjectiveName": "S2",
+					"maxSizeBytes":                  "268435456000",
+				},
+			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "624828a9-c73c-4d35-bc9d-ea41cfc75853",
+				Name:        "standard-s3",
+				Description: "StandardS3 Tier, 100 DTUs, 250GB, 35 days point-in-time restore",
+				Free:        false,
+				Extended: map[string]interface{}{
+					"edition":                       "Standard",
+					"requestedServiceObjectiveName": "S3",
+					"maxSizeBytes":                  "268435456000",
+				},
+			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "220e922a-a5b2-43e4-9388-fe45a32bbf31",
+				Name:        "premium-p1",
+				Description: "PremiumP1 Tier, 125 DTUs, 500GB, 35 days point-in-time restore",
+				Free:        false,
+				Extended: map[string]interface{}{
+					"edition":                       "Premium",
+					"requestedServiceObjectiveName": "P1",
+					"maxSizeBytes":                  "536870912000",
+				},
+			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "e7eb13df-1fda-4492-b218-00dd0db1c85d",
+				Name:        "premium-p2",
+				Description: "PremiumP2 Tier, 250 DTUs, 500GB, 35 days point-in-time restore",
+				Free:        false,
+				Extended: map[string]interface{}{
+					"edition":                       "Premium",
+					"requestedServiceObjectiveName": "P2",
+					"maxSizeBytes":                  "536870912000",
+				},
+			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "feb25d68-2b52-41b5-a249-28a747bc2c2e",
+				Name:        "premium-p4",
+				Description: "PremiumP4 Tier, 500 DTUs, 500GB, 35 days point-in-time restore",
+				Free:        false,
+				Extended: map[string]interface{}{
+					"edition":                       "Premium",
+					"requestedServiceObjectiveName": "P4",
+					"maxSizeBytes":                  "536870912000",
+				},
+			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "19487202-dc8a-4930-bbad-7bbf1486dbca",
+				Name:        "premium-p6",
+				Description: "PremiumP6 Tier, 1000 DTUs, 500GB, 35 days point-in-time restore",
+				Free:        false,
+				Extended: map[string]interface{}{
+					"edition":                       "Premium",
+					"requestedServiceObjectiveName": "P6",
+					"maxSizeBytes":                  "536870912000",
+				},
+			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "a561c45a-33c8-412e-9315-411c1d7035da",
+				Name:        "premium-p11",
+				Description: "PremiumP11 Tier, 1750 DTUs, 1024GB, 35 days point-in-time restore",
+				Free:        false,
+				Extended: map[string]interface{}{
+					"edition":                       "Premium",
+					"requestedServiceObjectiveName": "P11",
+					"maxSizeBytes":                  "1099511627776",
+				},
+			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "7a466f47-f137-4b9c-a63d-c5cbe724b874",
+				Name:        "data-warehouse-100",
+				Description: "DataWarehouse100 Tier, 100 DWUs, 1024GB",
+				Free:        false,
+				Extended: map[string]interface{}{
+					"edition":                       "DataWarehouse",
+					"requestedServiceObjectiveName": "DW100",
+					"maxSizeBytes":                  "1099511627776",
+				},
+			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "2717d839-be32-4225-8685-47adf0e6ff15",
 				Name:        "data-warehouse-1200",
 				Description: "DataWarehouse1200 Tier, 1200 DWUs, 1024GB",
 				Free:        false,

--- a/pkg/services/sqldb/db_connection.go
+++ b/pkg/services/sqldb/db_connection.go
@@ -9,7 +9,9 @@ import (
 )
 
 func getDBConnection(
-	dt *mssqlInstanceDetails,
+	administratorLogin string,
+	administratorLoginPassword string,
+	fullyQualifiedDomainName string,
 	databaseName string,
 ) (*sql.DB, error) {
 
@@ -21,10 +23,10 @@ func getDBConnection(
 	u := &url.URL{
 		Scheme: "sqlserver",
 		User: url.UserPassword(
-			dt.AdministratorLogin,
-			dt.AdministratorLoginPassword,
+			administratorLogin,
+			administratorLoginPassword,
 		),
-		Host:     fmt.Sprintf("%s:1433", dt.FullyQualifiedDomainName),
+		Host:     fmt.Sprintf("%s:1433", fullyQualifiedDomainName),
 		RawQuery: query.Encode(),
 	}
 

--- a/pkg/services/sqldb/deprovision.go
+++ b/pkg/services/sqldb/deprovision.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (a *allInOneManger) GetDeprovisioner(
+func (a *allInOneManager) GetDeprovisioner(
 	service.Plan,
 ) (service.Deprovisioner, error) {
 	return service.NewDeprovisioner(
@@ -39,7 +39,7 @@ func (d *dbOnlyManager) GetDeprovisioner(
 	)
 }
 
-func (a *allInOneManger) deleteARMDeployment(
+func (a *allInOneManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
@@ -93,7 +93,7 @@ func (d *dbOnlyManager) deleteARMDeployment(
 	return instance.Details, nil
 }
 
-func (a *allInOneManger) deleteMsSQLServerOrDatabase(
+func (a *allInOneManager) deleteMsSQLServerOrDatabase(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,

--- a/pkg/services/sqldb/deprovision.go
+++ b/pkg/services/sqldb/deprovision.go
@@ -45,10 +45,10 @@ func (a *allInOneManager) deleteARMDeployment(
 	_ service.Plan,
 	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
+	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
+			"error casting instance.Details as *mssqlInstanceDetails",
 		)
 	}
 	err := a.armDeployer.Delete(
@@ -89,10 +89,10 @@ func (d *dbOnlyManager) deleteARMDeployment(
 	_ service.Plan,
 	referenceInstance service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlDBOnlyInstanceDetails)
+	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
+			"error casting instance.Details as *mssqlInstanceDetails",
 		)
 	}
 	err := d.armDeployer.Delete(
@@ -111,10 +111,10 @@ func (a *allInOneManager) deleteMsSQLServer(
 	_ service.Plan,
 	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
+	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
+			"error casting instance.Details as *mssqlInstanceDetails",
 		)
 	}
 	if err := a.mssqlManager.DeleteServer(
@@ -132,10 +132,10 @@ func (d *dbOnlyManager) deleteMsSQLDatabase(
 	_ service.Plan,
 	referenceInstance service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlDBOnlyInstanceDetails)
+	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
+			"error casting instance.Details as *mssqlInstanceDetails",
 		)
 	}
 	if err := d.mssqlManager.DeleteDatabase(

--- a/pkg/services/sqldb/mssql.go
+++ b/pkg/services/sqldb/mssql.go
@@ -7,12 +7,12 @@ import (
 )
 
 type module struct {
-	allInOneServiceManager *allInOneManger
+	allInOneServiceManager *allInOneManager
 	vmOnlyServiceManager   *vmOnlyManager
 	dbOnlyServiceManager   *dbOnlyManager
 }
 
-type allInOneManger struct {
+type allInOneManager struct {
 	armDeployer  arm.Deployer
 	mssqlManager mssql.Manager
 }
@@ -35,7 +35,7 @@ func New(
 	mssqlManager mssql.Manager,
 ) service.Module {
 	return &module{
-		allInOneServiceManager: &allInOneManger{
+		allInOneServiceManager: &allInOneManager{
 			armDeployer:  armDeployer,
 			mssqlManager: mssqlManager,
 		},

--- a/pkg/services/sqldb/mssql.go
+++ b/pkg/services/sqldb/mssql.go
@@ -7,10 +7,22 @@ import (
 )
 
 type module struct {
-	serviceManager *serviceManager
+	allInOneServiceManager *allInOneManger
+	vmOnlyServiceManager   *vmOnlyManager
+	dbOnlyServiceManager   *dbOnlyManager
 }
 
-type serviceManager struct {
+type allInOneManger struct {
+	armDeployer  arm.Deployer
+	mssqlManager mssql.Manager
+}
+
+type vmOnlyManager struct {
+	armDeployer  arm.Deployer
+	mssqlManager mssql.Manager
+}
+
+type dbOnlyManager struct {
 	armDeployer  arm.Deployer
 	mssqlManager mssql.Manager
 }
@@ -23,7 +35,15 @@ func New(
 	mssqlManager mssql.Manager,
 ) service.Module {
 	return &module{
-		serviceManager: &serviceManager{
+		allInOneServiceManager: &allInOneManger{
+			armDeployer:  armDeployer,
+			mssqlManager: mssqlManager,
+		},
+		vmOnlyServiceManager: &vmOnlyManager{
+			armDeployer:  armDeployer,
+			mssqlManager: mssqlManager,
+		},
+		dbOnlyServiceManager: &dbOnlyManager{
 			armDeployer:  armDeployer,
 			mssqlManager: mssqlManager,
 		},

--- a/pkg/services/sqldb/provision.go
+++ b/pkg/services/sqldb/provision.go
@@ -12,14 +12,14 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-func (s *serviceManager) ValidateProvisioningParameters(
+func (a *allInOneManger) ValidateProvisioningParameters(
 	provisioningParameters service.ProvisioningParameters,
 ) error {
-	pp, ok := provisioningParameters.(*ProvisioningParameters)
+	pp, ok := provisioningParameters.(*ServerProvisioningParams)
 	if !ok {
 		return errors.New(
 			"error casting provisioningParameters as " +
-				"*mssql.ProvisioningParameters",
+				"*mssql.ServerProvisioningParams",
 		)
 	}
 	if pp.FirewallIPStart != "" || pp.FirewallIPEnd != "" {
@@ -66,25 +66,104 @@ func (s *serviceManager) ValidateProvisioningParameters(
 	return nil
 }
 
-func (s *serviceManager) GetProvisioner(
+func (v *vmOnlyManager) ValidateProvisioningParameters(
+	provisioningParameters service.ProvisioningParameters,
+) error {
+	pp, ok := provisioningParameters.(*ServerProvisioningParams)
+	if !ok {
+		return errors.New(
+			"error casting provisioningParameters as " +
+				"*mssql.ServerProvisioningParams",
+		)
+	}
+	if pp.FirewallIPStart != "" || pp.FirewallIPEnd != "" {
+		if pp.FirewallIPStart == "" {
+			return service.NewValidationError(
+				"firewallStartIPAddress",
+				"must be set when firewallEndIPAddress is set",
+			)
+		}
+		if pp.FirewallIPEnd == "" {
+			return service.NewValidationError(
+				"firewallEndIPAddress",
+				"must be set when firewallStartIPAddress is set",
+			)
+		}
+	}
+	startIP := net.ParseIP(pp.FirewallIPStart)
+	if pp.FirewallIPStart != "" && startIP == nil {
+		return service.NewValidationError(
+			"firewallStartIPAddress",
+			fmt.Sprintf(`invalid value: "%s"`, pp.FirewallIPStart),
+		)
+	}
+	endIP := net.ParseIP(pp.FirewallIPEnd)
+	if pp.FirewallIPEnd != "" && endIP == nil {
+		return service.NewValidationError(
+			"firewallEndIPAddress",
+			fmt.Sprintf(`invalid value: "%s"`, pp.FirewallIPEnd),
+		)
+	}
+	//The net.IP.To4 method returns a 4 byte representation of an IPv4 address.
+	//Once converted,comparing two IP addresses can be done by using the
+	//bytes. Compare function. Per the ARM template documentation,
+	//startIP must be <= endIP.
+	startBytes := startIP.To4()
+	endBytes := endIP.To4()
+	if bytes.Compare(startBytes, endBytes) > 0 {
+		return service.NewValidationError(
+			"firewallEndIPAddress",
+			fmt.Sprintf(`invalid value: "%s". must be 
+				greater than or equal to firewallStartIPAddress`, pp.FirewallIPEnd),
+		)
+	}
+	return nil
+}
+
+//TODO: implement db only validation
+func (d *dbOnlyManager) ValidateProvisioningParameters(
+	_ service.ProvisioningParameters,
+) error {
+	return nil
+}
+
+func (a *allInOneManger) GetProvisioner(
 	service.Plan,
 ) (service.Provisioner, error) {
 	return service.NewProvisioner(
-		service.NewProvisioningStep("preProvision", s.preProvision),
-		service.NewProvisioningStep("deployARMTemplate", s.deployARMTemplate),
+		service.NewProvisioningStep("preProvision", a.preProvision),
+		service.NewProvisioningStep("deployARMTemplate", a.deployARMTemplate),
 	)
 }
 
-func (s *serviceManager) preProvision(
+func (v *vmOnlyManager) GetProvisioner(
+	service.Plan,
+) (service.Provisioner, error) {
+	return service.NewProvisioner(
+		service.NewProvisioningStep("preProvision", v.preProvision),
+		service.NewProvisioningStep("deployARMTemplate", v.deployARMTemplate),
+	)
+}
+
+func (d *dbOnlyManager) GetProvisioner(
+	service.Plan,
+) (service.Provisioner, error) {
+	return service.NewProvisioner(
+		service.NewProvisioningStep("preProvision", d.preProvision),
+		service.NewProvisioningStep("deployARMTemplate", d.deployARMTemplate),
+	)
+}
+
+func (a *allInOneManger) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
 	_ service.Instance, //reference instance
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
+	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
 	if !ok {
 		return nil, errors.New(
-			"error casting instance.Details as *mssqlInstanceDetails",
+			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
 		)
 	}
 	dt.ARMDeploymentName = uuid.NewV4().String()
@@ -95,16 +174,75 @@ func (s *serviceManager) preProvision(
 	return dt, nil
 }
 
-func buildARMTemplateParameters(
+func (v *vmOnlyManager) preProvision(
+	_ context.Context,
+	instance service.Instance,
+	_ service.Plan,
+	_ service.Instance, //reference instance
+) (service.InstanceDetails, error) {
+	dt, ok := instance.Details.(*mssqlVMOnlyInstanceDetails)
+	if !ok {
+		return nil, errors.New(
+			"error casting instance.Details as *mssqlVMOnlyInstanceDetails",
+		)
+	}
+	dt.ARMDeploymentName = uuid.NewV4().String()
+	dt.ServerName = uuid.NewV4().String()
+	dt.AdministratorLogin = generate.NewIdentifier()
+	dt.AdministratorLoginPassword = generate.NewPassword()
+	return dt, nil
+}
+
+//TODO : Implement db only
+func (d *dbOnlyManager) preProvision(
+	_ context.Context,
+	instance service.Instance,
+	_ service.Plan,
+	referenceInstance service.Instance, //reference instance
+) (service.InstanceDetails, error) {
+	dt, ok := instance.Details.(*mssqlDBOnlyInstanceDetails)
+	if !ok {
+		return nil, errors.New(
+			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
+		)
+	}
+	//Assume refererence instance is a vm only instance?
+	rdt, ok := referenceInstance.Details.(*mssqlVMOnlyInstanceDetails)
+	if !ok {
+		return nil, errors.New(
+			"error casting referenceInstance.Details as " +
+				"*mssqlVMOnlyInstanceDetails",
+		)
+	}
+	dt.ServerName = rdt.ServerName
+	dt.DatabaseName = generate.NewIdentifier()
+	return dt, nil
+}
+
+func (a *allInOneManger) deployARMTemplate(
+	_ context.Context,
+	instance service.Instance,
 	plan service.Plan,
-	details *mssqlInstanceDetails,
-	provisioningParameters *ProvisioningParameters,
-) map[string]interface{} {
+	_ service.Instance, //reference instance
+) (service.InstanceDetails, error) {
+	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
+	if !ok {
+		return nil, errors.New(
+			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
+		)
+	}
+	pp, ok := instance.ProvisioningParameters.(*ServerProvisioningParams)
+	if !ok {
+		return nil, errors.New(
+			"error casting provisioningParameters as " +
+				"*mssql.ServerProvisioningParams",
+		)
+	}
 	p := map[string]interface{}{ // ARM template params
-		"serverName":                 details.ServerName,
-		"administratorLogin":         details.AdministratorLogin,
-		"administratorLoginPassword": details.AdministratorLoginPassword,
-		"databaseName":               details.DatabaseName,
+		"serverName":                 dt.ServerName,
+		"administratorLogin":         dt.AdministratorLogin,
+		"administratorLoginPassword": dt.AdministratorLoginPassword,
+		"databaseName":               dt.DatabaseName,
 		"edition":                    plan.GetProperties().Extended["edition"],
 		"requestedServiceObjectiveName": plan.GetProperties().
 			Extended["requestedServiceObjectiveName"],
@@ -114,43 +252,20 @@ func buildARMTemplateParameters(
 	//Only include these if they are not empty.
 	//ARM Deployer will fail if the values included are not
 	//valid IPV4 addresses (i.e. empty string wil fail)
-	if provisioningParameters.FirewallIPStart != "" {
-		p["firewallStartIpAddress"] = provisioningParameters.FirewallIPStart
+	if pp.FirewallIPStart != "" {
+		p["firewallStartIpAddress"] = pp.FirewallIPStart
 	}
-	if provisioningParameters.FirewallIPEnd != "" {
-		p["firewallEndIpAddress"] = provisioningParameters.FirewallIPEnd
+	if pp.FirewallIPEnd != "" {
+		p["firewallEndIpAddress"] = pp.FirewallIPEnd
 	}
-	return p
-}
-
-func (s *serviceManager) deployARMTemplate(
-	_ context.Context,
-	instance service.Instance,
-	plan service.Plan,
-	_ service.Instance, //reference instance
-) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
-	if !ok {
-		return nil, errors.New(
-			"error casting instance.Details as *mssqlInstanceDetails",
-		)
-	}
-	pp, ok := instance.ProvisioningParameters.(*ProvisioningParameters)
-	if !ok {
-		return nil, errors.New(
-			"error casting provisioningParameters as " +
-				"*mssql.ProvisioningParameters",
-		)
-	}
-	armTemplateParameters := buildARMTemplateParameters(plan, dt, pp)
 	// new server scenario
-	outputs, err := s.armDeployer.Deploy(
+	outputs, err := a.armDeployer.Deploy(
 		dt.ARMDeploymentName,
 		instance.ResourceGroup,
 		instance.Location,
 		armTemplateNewServerBytes,
 		nil, // Go template params
-		armTemplateParameters,
+		p,
 		instance.Tags,
 	)
 	if err != nil {
@@ -164,5 +279,100 @@ func (s *serviceManager) deployARMTemplate(
 		)
 	}
 	dt.FullyQualifiedDomainName = fullyQualifiedDomainName
+	return dt, nil
+}
+
+func (v *vmOnlyManager) deployARMTemplate(
+	_ context.Context,
+	instance service.Instance,
+	_ service.Plan,
+	_ service.Instance, //reference instance
+) (service.InstanceDetails, error) {
+	dt, ok := instance.Details.(*mssqlVMOnlyInstanceDetails)
+	if !ok {
+		return nil, errors.New(
+			"error casting instance.Details as *mssqlVMOnlyInstanceDetails",
+		)
+	}
+	pp, ok := instance.ProvisioningParameters.(*ServerProvisioningParams)
+	if !ok {
+		return nil, errors.New(
+			"error casting provisioningParameters as " +
+				"*mssql.ServerProvisioningParams",
+		)
+	}
+	p := map[string]interface{}{ // ARM template params
+		"serverName":                 dt.ServerName,
+		"administratorLogin":         dt.AdministratorLogin,
+		"administratorLoginPassword": dt.AdministratorLoginPassword,
+	}
+	//Only include these if they are not empty.
+	//ARM Deployer will fail if the values included are not
+	//valid IPV4 addresses (i.e. empty string wil fail)
+	if pp.FirewallIPStart != "" {
+		p["firewallStartIpAddress"] = pp.FirewallIPStart
+	}
+	if pp.FirewallIPEnd != "" {
+		p["firewallEndIpAddress"] = pp.FirewallIPEnd
+	}
+	// new server scenario
+	outputs, err := v.armDeployer.Deploy(
+		dt.ARMDeploymentName,
+		instance.ResourceGroup,
+		instance.Location,
+		armTemplateServerOnlyBytes,
+		nil, // Go template params
+		p,
+		instance.Tags,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error deploying ARM template: %s", err)
+	}
+	fullyQualifiedDomainName, ok := outputs["fullyQualifiedDomainName"].(string)
+	if !ok {
+		return nil, fmt.Errorf(
+			"error retrieving fully qualified domain name from deployment: %s",
+			err,
+		)
+	}
+	dt.FullyQualifiedDomainName = fullyQualifiedDomainName
+	return dt, nil
+}
+
+func (d *dbOnlyManager) deployARMTemplate(
+	_ context.Context,
+	instance service.Instance,
+	plan service.Plan,
+	_ service.Instance, //reference instance
+) (service.InstanceDetails, error) {
+	dt, ok := instance.Details.(*mssqlDBOnlyInstanceDetails)
+	if !ok {
+		return nil, errors.New(
+			"error casting instance.Details as " +
+				"*mssqlDBOnlyInstanceDetails",
+		)
+	}
+	p := map[string]interface{}{ // ARM template params
+		"serverName":   dt.ServerName,
+		"databaseName": dt.DatabaseName,
+		"edition":      plan.GetProperties().Extended["edition"],
+		"requestedServiceObjectiveName": plan.GetProperties().
+			Extended["requestedServiceObjectiveName"],
+		"maxSizeBytes": plan.GetProperties().
+			Extended["maxSizeBytes"],
+	}
+	//No output, so ignore the output
+	_, err := d.armDeployer.Deploy(
+		dt.ARMDeploymentName,
+		instance.ResourceGroup,
+		instance.Location,
+		armTemplateDBOnlyBytes,
+		nil, // Go template params
+		p,
+		instance.Tags,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error deploying ARM template: %s", err)
+	}
 	return dt, nil
 }

--- a/pkg/services/sqldb/provision.go
+++ b/pkg/services/sqldb/provision.go
@@ -199,7 +199,7 @@ func (d *dbOnlyManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	referenceInstance service.Instance, //reference instance
+	referenceInstance service.Instance,
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
@@ -207,7 +207,7 @@ func (d *dbOnlyManager) preProvision(
 			"error casting instance.Details as *mssqlInstanceDetails",
 		)
 	}
-	//Assume refererence instance is a vm only instance?
+	//Assume refererence instance is a vm only instance. Fail if not
 	rdt, ok := referenceInstance.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {
 		return nil, errors.New(
@@ -227,7 +227,9 @@ func (d *dbOnlyManager) preProvision(
 
 	dt.DatabaseName = generate.NewIdentifier()
 
-	//Build the instance details with the reference instance details
+	//Build the instance details with the reference instance details.
+	//These are needed right now because Bind doesn't deal with ref instance.
+	//Refactor this when it does
 	dt.ServerName = rdt.ServerName
 	dt.AdministratorLogin = rdt.AdministratorLogin
 	dt.AdministratorLoginPassword = rdt.AdministratorLoginPassword
@@ -366,7 +368,7 @@ func (d *dbOnlyManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	referenceInstance service.Instance, //reference instance
+	referenceInstance service.Instance,
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {

--- a/pkg/services/sqldb/provision.go
+++ b/pkg/services/sqldb/provision.go
@@ -12,7 +12,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-func (a *allInOneManger) ValidateProvisioningParameters(
+func (a *allInOneManager) ValidateProvisioningParameters(
 	provisioningParameters service.ProvisioningParameters,
 ) error {
 	pp, ok := provisioningParameters.(*ServerProvisioningParams)
@@ -127,7 +127,7 @@ func (d *dbOnlyManager) ValidateProvisioningParameters(
 	return nil
 }
 
-func (a *allInOneManger) GetProvisioner(
+func (a *allInOneManager) GetProvisioner(
 	service.Plan,
 ) (service.Provisioner, error) {
 	return service.NewProvisioner(
@@ -154,7 +154,7 @@ func (d *dbOnlyManager) GetProvisioner(
 	)
 }
 
-func (a *allInOneManger) preProvision(
+func (a *allInOneManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
@@ -219,7 +219,7 @@ func (d *dbOnlyManager) preProvision(
 	return dt, nil
 }
 
-func (a *allInOneManger) deployARMTemplate(
+func (a *allInOneManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,

--- a/pkg/services/sqldb/provision.go
+++ b/pkg/services/sqldb/provision.go
@@ -162,10 +162,10 @@ func (a *allInOneManager) preProvision(
 	_ service.Plan,
 	_ service.Instance, //reference instance
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
+	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
 		return nil, errors.New(
-			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
+			"error casting instance.Details as *mssqlInstanceDetails",
 		)
 	}
 	dt.ARMDeploymentName = uuid.NewV4().String()
@@ -201,10 +201,10 @@ func (d *dbOnlyManager) preProvision(
 	_ service.Plan,
 	referenceInstance service.Instance, //reference instance
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlDBOnlyInstanceDetails)
+	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
 		return nil, errors.New(
-			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
+			"error casting instance.Details as *mssqlInstanceDetails",
 		)
 	}
 	//Assume refererence instance is a vm only instance?
@@ -248,10 +248,10 @@ func (a *allInOneManager) deployARMTemplate(
 	plan service.Plan,
 	_ service.Instance, //reference instance
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
+	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
 		return nil, errors.New(
-			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
+			"error casting instance.Details as *mssqlInstanceDetails",
 		)
 	}
 	pp, ok := instance.ProvisioningParameters.(*ServerProvisioningParams)
@@ -368,11 +368,10 @@ func (d *dbOnlyManager) deployARMTemplate(
 	plan service.Plan,
 	referenceInstance service.Instance, //reference instance
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlDBOnlyInstanceDetails)
+	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
 		return nil, errors.New(
-			"error casting instance.Details as " +
-				"*mssqlDBOnlyInstanceDetails",
+			"error casting instance.Details as *mssqlInstanceDetails",
 		)
 	}
 	p := map[string]interface{}{ // ARM template params

--- a/pkg/services/sqldb/provision_test.go
+++ b/pkg/services/sqldb/provision_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestValidateNoFirewallConfig(t *testing.T) {
 
-	sm := &serviceManager{}
+	sm := &allInOneManger{}
 
-	pp := &ProvisioningParameters{}
+	pp := &ServerProvisioningParams{}
 
 	error := sm.ValidateProvisioningParameters(pp)
 	assert.Nil(t, error)
@@ -19,9 +19,9 @@ func TestValidateNoFirewallConfig(t *testing.T) {
 
 func TestValidateGoodFirewallConfig(t *testing.T) {
 
-	sm := &serviceManager{}
+	sm := &allInOneManger{}
 
-	pp := &ProvisioningParameters{
+	pp := &ServerProvisioningParams{
 		FirewallIPStart: "192.168.86.1",
 		FirewallIPEnd:   "192.168.86.100",
 	}
@@ -31,8 +31,8 @@ func TestValidateGoodFirewallConfig(t *testing.T) {
 }
 
 func TestValidateMissingEndFirewallConfig(t *testing.T) {
-	sm := &serviceManager{}
-	pp := &ProvisioningParameters{
+	sm := &allInOneManger{}
+	pp := &ServerProvisioningParams{
 		FirewallIPStart: "192.168.86.1",
 	}
 	error := sm.ValidateProvisioningParameters(pp)
@@ -43,8 +43,8 @@ func TestValidateMissingEndFirewallConfig(t *testing.T) {
 }
 
 func TestValidateMissingStartFirewallConfig(t *testing.T) {
-	sm := &serviceManager{}
-	pp := &ProvisioningParameters{
+	sm := &allInOneManger{}
+	pp := &ServerProvisioningParams{
 		FirewallIPEnd: "192.168.86.200",
 	}
 	error := sm.ValidateProvisioningParameters(pp)
@@ -55,8 +55,8 @@ func TestValidateMissingStartFirewallConfig(t *testing.T) {
 }
 
 func TestValidateInvalidIP(t *testing.T) {
-	sm := &serviceManager{}
-	pp := &ProvisioningParameters{
+	sm := &allInOneManger{}
+	pp := &ServerProvisioningParams{
 		FirewallIPStart: "decafbad",
 		FirewallIPEnd:   "192.168.86.200",
 	}
@@ -68,8 +68,8 @@ func TestValidateInvalidIP(t *testing.T) {
 }
 
 func TestValidateIncompleteIP(t *testing.T) {
-	sm := &serviceManager{}
-	pp := &ProvisioningParameters{
+	sm := &allInOneManger{}
+	pp := &ServerProvisioningParams{
 		FirewallIPStart: "192.168.",
 		FirewallIPEnd:   "192.168.86.200",
 	}

--- a/pkg/services/sqldb/provision_test.go
+++ b/pkg/services/sqldb/provision_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestValidateNoFirewallConfig(t *testing.T) {
 
-	sm := &allInOneManger{}
+	sm := &allInOneManager{}
 
 	pp := &ServerProvisioningParams{}
 
@@ -19,7 +19,7 @@ func TestValidateNoFirewallConfig(t *testing.T) {
 
 func TestValidateGoodFirewallConfig(t *testing.T) {
 
-	sm := &allInOneManger{}
+	sm := &allInOneManager{}
 
 	pp := &ServerProvisioningParams{
 		FirewallIPStart: "192.168.86.1",
@@ -31,7 +31,7 @@ func TestValidateGoodFirewallConfig(t *testing.T) {
 }
 
 func TestValidateMissingEndFirewallConfig(t *testing.T) {
-	sm := &allInOneManger{}
+	sm := &allInOneManager{}
 	pp := &ServerProvisioningParams{
 		FirewallIPStart: "192.168.86.1",
 	}
@@ -43,7 +43,7 @@ func TestValidateMissingEndFirewallConfig(t *testing.T) {
 }
 
 func TestValidateMissingStartFirewallConfig(t *testing.T) {
-	sm := &allInOneManger{}
+	sm := &allInOneManager{}
 	pp := &ServerProvisioningParams{
 		FirewallIPEnd: "192.168.86.200",
 	}
@@ -55,7 +55,7 @@ func TestValidateMissingStartFirewallConfig(t *testing.T) {
 }
 
 func TestValidateInvalidIP(t *testing.T) {
-	sm := &allInOneManger{}
+	sm := &allInOneManager{}
 	pp := &ServerProvisioningParams{
 		FirewallIPStart: "decafbad",
 		FirewallIPEnd:   "192.168.86.200",
@@ -68,7 +68,7 @@ func TestValidateInvalidIP(t *testing.T) {
 }
 
 func TestValidateIncompleteIP(t *testing.T) {
-	sm := &allInOneManger{}
+	sm := &allInOneManager{}
 	pp := &ServerProvisioningParams{
 		FirewallIPStart: "192.168.",
 		FirewallIPEnd:   "192.168.86.200",

--- a/pkg/services/sqldb/types.go
+++ b/pkg/services/sqldb/types.go
@@ -31,9 +31,12 @@ type mssqlVMOnlyInstanceDetails struct {
 }
 
 type mssqlDBOnlyInstanceDetails struct {
-	ARMDeploymentName string `json:"armDeployment"`
-	ServerName        string `json:"server"`
-	DatabaseName      string `json:"database"`
+	ARMDeploymentName          string `json:"armDeployment"`
+	ServerName                 string `json:"server"`
+	AdministratorLogin         string `json:"administratorLogin"`
+	AdministratorLoginPassword string `json:"administratorLoginPassword"`
+	DatabaseName               string `json:"database"`
+	FullyQualifiedDomainName   string `json:"fullyQualifiedDomainName"`
 }
 
 // UpdatingParameters encapsulates MSSQL-specific updating options

--- a/pkg/services/sqldb/types.go
+++ b/pkg/services/sqldb/types.go
@@ -74,7 +74,7 @@ type Config struct {
 }
 
 func (
-	a *allInOneManger,
+	a *allInOneManager,
 ) GetEmptyProvisioningParameters() service.ProvisioningParameters {
 	return &ServerProvisioningParams{}
 }
@@ -92,7 +92,7 @@ func (
 }
 
 func (
-	a *allInOneManger,
+	a *allInOneManager,
 ) GetEmptyUpdatingParameters() service.UpdatingParameters {
 	return &UpdatingParameters{}
 }
@@ -110,7 +110,7 @@ func (
 }
 
 func (
-	a *allInOneManger,
+	a *allInOneManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
 	return &mssqlAllInOneInstanceDetails{}
 }
@@ -128,7 +128,7 @@ func (
 }
 
 func (
-	a *allInOneManger,
+	a *allInOneManager,
 ) GetEmptyBindingParameters() service.BindingParameters {
 	return &BindingParameters{}
 }
@@ -146,7 +146,7 @@ func (
 }
 
 func (
-	a *allInOneManger,
+	a *allInOneManager,
 ) GetEmptyBindingDetails() service.BindingDetails {
 	return &mssqlBindingDetails{}
 }

--- a/pkg/services/sqldb/types.go
+++ b/pkg/services/sqldb/types.go
@@ -13,7 +13,10 @@ type ServerProvisioningParams struct {
 type DBProvisioningParams struct {
 }
 
-type mssqlAllInOneInstanceDetails struct {
+// instance details are common to the DB only and All In One Service.
+// Bind doesn't get passed reference instance info, so we need the
+// Server Name, and Administrator Info in order to complete Binding
+type mssqlInstanceDetails struct {
 	ARMDeploymentName          string `json:"armDeployment"`
 	ServerName                 string `json:"server"`
 	AdministratorLogin         string `json:"administratorLogin"`
@@ -27,15 +30,6 @@ type mssqlVMOnlyInstanceDetails struct {
 	ServerName                 string `json:"server"`
 	AdministratorLogin         string `json:"administratorLogin"`
 	AdministratorLoginPassword string `json:"administratorLoginPassword"`
-	FullyQualifiedDomainName   string `json:"fullyQualifiedDomainName"`
-}
-
-type mssqlDBOnlyInstanceDetails struct {
-	ARMDeploymentName          string `json:"armDeployment"`
-	ServerName                 string `json:"server"`
-	AdministratorLogin         string `json:"administratorLogin"`
-	AdministratorLoginPassword string `json:"administratorLoginPassword"`
-	DatabaseName               string `json:"database"`
 	FullyQualifiedDomainName   string `json:"fullyQualifiedDomainName"`
 }
 
@@ -115,7 +109,7 @@ func (
 func (
 	a *allInOneManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
-	return &mssqlAllInOneInstanceDetails{}
+	return &mssqlInstanceDetails{}
 }
 
 func (
@@ -127,7 +121,7 @@ func (
 func (
 	d *dbOnlyManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
-	return &mssqlDBOnlyInstanceDetails{}
+	return &mssqlInstanceDetails{}
 }
 
 func (

--- a/pkg/services/sqldb/types.go
+++ b/pkg/services/sqldb/types.go
@@ -2,20 +2,38 @@ package sqldb
 
 import "github.com/Azure/open-service-broker-azure/pkg/service"
 
-// ProvisioningParameters encapsulates MSSQL-specific provisioning options
-type ProvisioningParameters struct {
-	ServerName      string `json:"server"`
+// ServerProvisioningParams encapsulates MSSQL-server specific provisioning
+//options
+type ServerProvisioningParams struct {
 	FirewallIPStart string `json:"firewallStartIPAddress"`
 	FirewallIPEnd   string `json:"firewallEndIPAddress"`
 }
 
-type mssqlInstanceDetails struct {
+// DBProvisioningParams encapsulates MSSQL-specific provisioning options
+type DBProvisioningParams struct {
+}
+
+type mssqlAllInOneInstanceDetails struct {
 	ARMDeploymentName          string `json:"armDeployment"`
 	ServerName                 string `json:"server"`
 	AdministratorLogin         string `json:"administratorLogin"`
 	AdministratorLoginPassword string `json:"administratorLoginPassword"`
 	DatabaseName               string `json:"database"`
 	FullyQualifiedDomainName   string `json:"fullyQualifiedDomainName"`
+}
+
+type mssqlVMOnlyInstanceDetails struct {
+	ARMDeploymentName          string `json:"armDeployment"`
+	ServerName                 string `json:"server"`
+	AdministratorLogin         string `json:"administratorLogin"`
+	AdministratorLoginPassword string `json:"administratorLoginPassword"`
+	FullyQualifiedDomainName   string `json:"fullyQualifiedDomainName"`
+}
+
+type mssqlDBOnlyInstanceDetails struct {
+	ARMDeploymentName string `json:"armDeployment"`
+	ServerName        string `json:"server"`
+	DatabaseName      string `json:"database"`
 }
 
 // UpdatingParameters encapsulates MSSQL-specific updating options
@@ -56,27 +74,91 @@ type Config struct {
 }
 
 func (
-	s *serviceManager,
+	a *allInOneManger,
 ) GetEmptyProvisioningParameters() service.ProvisioningParameters {
-	return &ProvisioningParameters{}
+	return &ServerProvisioningParams{}
 }
 
 func (
-	s *serviceManager,
+	v *vmOnlyManager,
+) GetEmptyProvisioningParameters() service.ProvisioningParameters {
+	return &ServerProvisioningParams{}
+}
+
+func (
+	d *dbOnlyManager,
+) GetEmptyProvisioningParameters() service.ProvisioningParameters {
+	return &DBProvisioningParams{}
+}
+
+func (
+	a *allInOneManger,
 ) GetEmptyUpdatingParameters() service.UpdatingParameters {
 	return &UpdatingParameters{}
 }
 
 func (
-	s *serviceManager,
-) GetEmptyInstanceDetails() service.InstanceDetails {
-	return &mssqlInstanceDetails{}
+	v *vmOnlyManager,
+) GetEmptyUpdatingParameters() service.UpdatingParameters {
+	return &UpdatingParameters{}
 }
 
-func (s *serviceManager) GetEmptyBindingParameters() service.BindingParameters {
+func (
+	d *dbOnlyManager,
+) GetEmptyUpdatingParameters() service.UpdatingParameters {
+	return &UpdatingParameters{}
+}
+
+func (
+	a *allInOneManger,
+) GetEmptyInstanceDetails() service.InstanceDetails {
+	return &mssqlAllInOneInstanceDetails{}
+}
+
+func (
+	v *vmOnlyManager,
+) GetEmptyInstanceDetails() service.InstanceDetails {
+	return &mssqlVMOnlyInstanceDetails{}
+}
+
+func (
+	d *dbOnlyManager,
+) GetEmptyInstanceDetails() service.InstanceDetails {
+	return &mssqlDBOnlyInstanceDetails{}
+}
+
+func (
+	a *allInOneManger,
+) GetEmptyBindingParameters() service.BindingParameters {
 	return &BindingParameters{}
 }
 
-func (s *serviceManager) GetEmptyBindingDetails() service.BindingDetails {
+func (
+	v *vmOnlyManager,
+) GetEmptyBindingParameters() service.BindingParameters {
+	return &BindingParameters{}
+}
+
+func (
+	d *dbOnlyManager,
+) GetEmptyBindingParameters() service.BindingParameters {
+	return &BindingParameters{}
+}
+
+func (
+	a *allInOneManger,
+) GetEmptyBindingDetails() service.BindingDetails {
+	return &mssqlBindingDetails{}
+}
+
+func (
+	v *vmOnlyManager,
+) GetEmptyBindingDetails() service.BindingDetails {
+	return &mssqlBindingDetails{}
+}
+
+func (
+	d *dbOnlyManager,
+) GetEmptyBindingDetails() service.BindingDetails {
 	return &mssqlBindingDetails{}
 }

--- a/pkg/services/sqldb/unbind.go
+++ b/pkg/services/sqldb/unbind.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (a *allInOneManger) Unbind(
+func (a *allInOneManager) Unbind(
 	instance service.Instance,
 	bindingDetails service.BindingDetails,
 ) error {

--- a/pkg/services/sqldb/unbind.go
+++ b/pkg/services/sqldb/unbind.go
@@ -6,14 +6,14 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (s *serviceManager) Unbind(
+func (a *allInOneManger) Unbind(
 	instance service.Instance,
 	bindingDetails service.BindingDetails,
 ) error {
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
+	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
 	if !ok {
 		return fmt.Errorf(
-			"error casting instance.Details as *mssqlInstanceDetails",
+			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
 		)
 	}
 	bc, ok := bindingDetails.(*mssqlBindingDetails)
@@ -24,7 +24,11 @@ func (s *serviceManager) Unbind(
 	}
 
 	// connect to new database to drop user for the login
-	db, err := getDBConnection(dt, dt.DatabaseName)
+	db, err := getDBConnection(
+		dt.AdministratorLogin,
+		dt.AdministratorLoginPassword,
+		dt.FullyQualifiedDomainName,
+		dt.DatabaseName)
 	if err != nil {
 		return err
 	}
@@ -41,7 +45,11 @@ func (s *serviceManager) Unbind(
 	}
 
 	// connect to master database to drop login
-	masterDb, err := getDBConnection(dt, "master")
+	masterDb, err := getDBConnection(
+		dt.AdministratorLogin,
+		dt.AdministratorLoginPassword,
+		dt.FullyQualifiedDomainName,
+		"master")
 	if err != nil {
 		return err
 	}
@@ -57,5 +65,22 @@ func (s *serviceManager) Unbind(
 		)
 	}
 
+	return nil
+}
+
+//TODO : Unbind is not valid for VM only.
+//Determine what to do.
+func (v *vmOnlyManager) Unbind(
+	_ service.Instance,
+	_ service.BindingDetails,
+) error {
+	return nil
+}
+
+//TODO: Implement DB Only Manager
+func (d *dbOnlyManager) Unbind(
+	_ service.Instance,
+	_ service.BindingDetails,
+) error {
 	return nil
 }

--- a/pkg/services/sqldb/unbind.go
+++ b/pkg/services/sqldb/unbind.go
@@ -77,10 +77,64 @@ func (v *vmOnlyManager) Unbind(
 	return nil
 }
 
-//TODO: Implement DB Only Manager
 func (d *dbOnlyManager) Unbind(
-	_ service.Instance,
-	_ service.BindingDetails,
+	instance service.Instance,
+	bindingDetails service.BindingDetails,
 ) error {
+	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
+	if !ok {
+		return fmt.Errorf(
+			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
+		)
+	}
+	bc, ok := bindingDetails.(*mssqlBindingDetails)
+	if !ok {
+		return fmt.Errorf(
+			"error casting bindingDetails as *mssqlBindingDetails",
+		)
+	}
+
+	// connect to new database to drop user for the login
+	db, err := getDBConnection(
+		dt.AdministratorLogin,
+		dt.AdministratorLoginPassword,
+		dt.FullyQualifiedDomainName,
+		dt.DatabaseName)
+	if err != nil {
+		return err
+	}
+	defer db.Close() // nolint: errcheck
+
+	if _, err = db.Exec(
+		fmt.Sprintf("DROP USER \"%s\"", bc.LoginName),
+	); err != nil {
+		return fmt.Errorf(
+			`error dropping user "%s": %s`,
+			bc.LoginName,
+			err,
+		)
+	}
+
+	// connect to master database to drop login
+	masterDb, err := getDBConnection(
+		dt.AdministratorLogin,
+		dt.AdministratorLoginPassword,
+		dt.FullyQualifiedDomainName,
+		"master")
+	if err != nil {
+		return err
+	}
+	defer masterDb.Close() // nolint: errcheck
+
+	if _, err = masterDb.Exec(
+		fmt.Sprintf("DROP LOGIN \"%s\"", bc.LoginName),
+	); err != nil {
+		return fmt.Errorf(
+			`error dropping login "%s": %s`,
+			bc.LoginName,
+			err,
+		)
+	}
+
 	return nil
 }

--- a/pkg/services/sqldb/update.go
+++ b/pkg/services/sqldb/update.go
@@ -4,13 +4,13 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (a *allInOneManger) ValidateUpdatingParameters(
+func (a *allInOneManager) ValidateUpdatingParameters(
 	updatingParameters service.UpdatingParameters,
 ) error {
 	return nil
 }
 
-func (a *allInOneManger) GetUpdater(service.Plan) (service.Updater, error) {
+func (a *allInOneManager) GetUpdater(service.Plan) (service.Updater, error) {
 	return service.NewUpdater()
 }
 

--- a/pkg/services/sqldb/update.go
+++ b/pkg/services/sqldb/update.go
@@ -4,12 +4,32 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (s *serviceManager) ValidateUpdatingParameters(
+func (a *allInOneManger) ValidateUpdatingParameters(
 	updatingParameters service.UpdatingParameters,
 ) error {
 	return nil
 }
 
-func (s *serviceManager) GetUpdater(service.Plan) (service.Updater, error) {
+func (a *allInOneManger) GetUpdater(service.Plan) (service.Updater, error) {
+	return service.NewUpdater()
+}
+
+func (v *vmOnlyManager) ValidateUpdatingParameters(
+	updatingParameters service.UpdatingParameters,
+) error {
+	return nil
+}
+
+func (v *vmOnlyManager) GetUpdater(service.Plan) (service.Updater, error) {
+	return service.NewUpdater()
+}
+
+func (d *dbOnlyManager) ValidateUpdatingParameters(
+	updatingParameters service.UpdatingParameters,
+) error {
+	return nil
+}
+
+func (d *dbOnlyManager) GetUpdater(service.Plan) (service.Updater, error) {
 	return service.NewUpdater()
 }

--- a/tests/lifecycle/mssql_cases_test.go
+++ b/tests/lifecycle/mssql_cases_test.go
@@ -30,12 +30,24 @@ func getMssqlCases(
 			serviceID:   "fb9bc99e-0aa9-11e6-8a8a-000d3a002ed5",
 			planID:      "3819fdfa-0aaa-11e6-86f4-000d3a002ed5",
 			location:    "southcentralus",
-			provisioningParameters: &sqldb.ProvisioningParameters{
+			provisioningParameters: &sqldb.ServerProvisioningParams{
 				FirewallIPStart: "0.0.0.0",
 				FirewallIPEnd:   "255.255.255.255",
 			},
 			bindingParameters: &sqldb.BindingParameters{},
 			testCredentials:   testMsSQLCreds(),
+		},
+		//server only scenario
+		{ // new server scenario
+			module:      sqldb.New(armDeployer, msSQLManager),
+			description: "new server only",
+			serviceID:   "a7454e0e-be2c-46ac-b55f-8c4278117525",
+			planID:      "24f0f42e-1ab3-474e-a5ca-b943b2c48eee",
+			location:    "southcentralus",
+			provisioningParameters: &sqldb.ServerProvisioningParams{
+				FirewallIPStart: "0.0.0.0",
+				FirewallIPEnd:   "255.255.255.255",
+			},
 		},
 	}, nil
 }

--- a/tests/lifecycle/mssql_cases_test.go
+++ b/tests/lifecycle/mssql_cases_test.go
@@ -24,9 +24,9 @@ func getMssqlCases(
 	}
 
 	return []serviceLifecycleTestCase{
-		{ // new server scenario
+		{ // all-in-one scenario
 			module:      sqldb.New(armDeployer, msSQLManager),
-			description: "new server and database",
+			description: "new server and database (all in one)",
 			serviceID:   "fb9bc99e-0aa9-11e6-8a8a-000d3a002ed5",
 			planID:      "3819fdfa-0aaa-11e6-86f4-000d3a002ed5",
 			location:    "southcentralus",
@@ -47,7 +47,7 @@ func getMssqlCases(
 				FirewallIPStart: "0.0.0.0",
 				FirewallIPEnd:   "255.255.255.255",
 			},
-		}, //TODO: Add a lifecycle test for database only. Need to provision server first
+		}, //TODO: Add a lifecycle test for database only.
 	}, nil
 }
 

--- a/tests/lifecycle/mssql_cases_test.go
+++ b/tests/lifecycle/mssql_cases_test.go
@@ -37,8 +37,7 @@ func getMssqlCases(
 			bindingParameters: &sqldb.BindingParameters{},
 			testCredentials:   testMsSQLCreds(),
 		},
-		//server only scenario
-		{ // new server scenario
+		{ //server only scenario
 			module:      sqldb.New(armDeployer, msSQLManager),
 			description: "new server only",
 			serviceID:   "a7454e0e-be2c-46ac-b55f-8c4278117525",
@@ -48,7 +47,7 @@ func getMssqlCases(
 				FirewallIPStart: "0.0.0.0",
 				FirewallIPEnd:   "255.255.255.255",
 			},
-		},
+		}, //TODO: Add a lifecycle test for database only. Need to provision server first
 	}, nil
 }
 

--- a/tests/lifecycle/test_case_test.go
+++ b/tests/lifecycle/test_case_test.go
@@ -150,33 +150,35 @@ func (s serviceLifecycleTestCase) execute(resourceGroup string) error {
 		}
 	}
 
-	// Bind
-	bd, err := serviceManager.Bind(instance, s.bindingParameters)
-	if err != nil {
-		return err
-	}
+	//Only test the binding operations if the service is bindable
+	if svc.GetBindable() {
+		// Bind
+		bd, err := serviceManager.Bind(instance, s.bindingParameters)
+		if err != nil {
+			return err
+		}
 
-	binding := service.Binding{Details: bd}
+		binding := service.Binding{Details: bd}
 
-	credentials, err := serviceManager.GetCredentials(instance, binding)
-	if err != nil {
-		return err
-	}
+		credentials, err := serviceManager.GetCredentials(instance, binding)
+		if err != nil {
+			return err
+		}
 
-	// Test the credentials
-	if s.testCredentials != nil {
-		err = s.testCredentials(credentials)
+		// Test the credentials
+		if s.testCredentials != nil {
+			err = s.testCredentials(credentials)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Unbind
+		err = serviceManager.Unbind(instance, bd)
 		if err != nil {
 			return err
 		}
 	}
-
-	// Unbind
-	err = serviceManager.Unbind(instance, bd)
-	if err != nil {
-		return err
-	}
-
 	// Deprovision...
 	deprovisioner, err := serviceManager.GetDeprovisioner(plan)
 	if err != nil {

--- a/tests/lifecycle/test_case_test.go
+++ b/tests/lifecycle/test_case_test.go
@@ -153,30 +153,30 @@ func (s serviceLifecycleTestCase) execute(resourceGroup string) error {
 	//Only test the binding operations if the service is bindable
 	if svc.GetBindable() {
 		// Bind
-		bd, err := serviceManager.Bind(instance, s.bindingParameters)
-		if err != nil {
-			return err
+		bd, bErr := serviceManager.Bind(instance, s.bindingParameters)
+		if bErr != nil {
+			return bErr
 		}
 
 		binding := service.Binding{Details: bd}
 
-		credentials, err := serviceManager.GetCredentials(instance, binding)
-		if err != nil {
-			return err
+		credentials, bErr := serviceManager.GetCredentials(instance, binding)
+		if bErr != nil {
+			return bErr
 		}
 
 		// Test the credentials
 		if s.testCredentials != nil {
-			err = s.testCredentials(credentials)
-			if err != nil {
-				return err
+			bErr = s.testCredentials(credentials)
+			if bErr != nil {
+				return bErr
 			}
 		}
 
 		// Unbind
-		err = serviceManager.Unbind(instance, bd)
-		if err != nil {
-			return err
+		bErr = serviceManager.Unbind(instance, bd)
+		if bErr != nil {
+			return bErr
 		}
 	}
 	// Deprovision...

--- a/tests/lifecycle/test_cases_test.go
+++ b/tests/lifecycle/test_cases_test.go
@@ -18,17 +18,17 @@ func getTestCases(resourceGroup string) ([]serviceLifecycleTestCase, error) {
 		armDeployer arm.Deployer,
 		resourceGroup string,
 	) ([]serviceLifecycleTestCase, error){
-		getRediscacheCases,
-		getACICases,
-		getCosmosdbCases,
-		getEventhubCases,
-		getKeyvaultCases,
+		//getRediscacheCases,
+		//getACICases,
+		//getCosmosdbCases,
+		//getEventhubCases,
+		//getKeyvaultCases,
 		getMssqlCases,
-		getMysqlCases,
-		getPostgresqlCases,
-		getSearchCases,
-		getServicebusCases,
-		getStorageCases,
+		//getMysqlCases,
+		//getPostgresqlCases,
+		//getSearchCases,
+		//getServicebusCases,
+		//getStorageCases,
 	}
 
 	for _, getTestCaseFunc := range getTestCaseFuncs {

--- a/tests/lifecycle/test_cases_test.go
+++ b/tests/lifecycle/test_cases_test.go
@@ -18,17 +18,17 @@ func getTestCases(resourceGroup string) ([]serviceLifecycleTestCase, error) {
 		armDeployer arm.Deployer,
 		resourceGroup string,
 	) ([]serviceLifecycleTestCase, error){
-		//getRediscacheCases,
-		//getACICases,
-		//getCosmosdbCases,
-		//getEventhubCases,
-		//getKeyvaultCases,
+		getRediscacheCases,
+		getACICases,
+		getCosmosdbCases,
+		getEventhubCases,
+		getKeyvaultCases,
 		getMssqlCases,
-		//getMysqlCases,
-		//getPostgresqlCases,
-		//getSearchCases,
-		//getServicebusCases,
-		//getStorageCases,
+		getMysqlCases,
+		getPostgresqlCases,
+		getSearchCases,
+		getServicebusCases,
+		getStorageCases,
 	}
 
 	for _, getTestCaseFunc := range getTestCaseFuncs {


### PR DESCRIPTION
1.) This renames the existing service manager into a service to
    implement the all in one scenario (existing)
2.) Next, two new services are added (vm only and db only)
3.) Each lifecycle operation go file (bind, deprovision, provision, unbind)
    now declares a method for each service manager struct
4.) Added new services to the catalog
5.) DB only option is plumbed in, but won't work as of yet (ref instance)
6.) Refactored catalog/service interface to add GetBindable() method
7.) Modified tests to only execute binding related tests if plan
    is bindable

I'm wondering if it would make sense to decompose the lifecycle go files. Right now, we are violating DRY for these, so might also be good to identify commonality and refactor the Provision Params / Instance Details to use embedding to get some reuse.  