### PR TITLE
add ref instance as instance attribute

### DIFF
--- a/pkg/broker/deprovision.go
+++ b/pkg/broker/deprovision.go
@@ -115,9 +115,6 @@ func (b *broker) doDeprovisionStep(
 		ctx,
 		instance,
 		plan,
-		// TODO: Still need to come up with a way of finding a related instance
-		// (if applicable).
-		service.Instance{},
 	)
 	if err != nil {
 		return b.handleDeprovisioningError(

--- a/pkg/broker/provision.go
+++ b/pkg/broker/provision.go
@@ -115,9 +115,6 @@ func (b *broker) doProvisionStep(
 		ctx,
 		instance,
 		plan,
-		// TODO: Still need to come up with a way of finding a related instance
-		// (if applicable).
-		service.Instance{},
 	)
 	if err != nil {
 		return b.handleProvisioningError(

--- a/pkg/service/deprovisioner.go
+++ b/pkg/service/deprovisioner.go
@@ -11,7 +11,6 @@ type DeprovisioningStepFunction func(
 	ctx context.Context,
 	instance Instance,
 	plan Plan,
-	refInstance Instance,
 ) (InstanceDetails, error)
 
 // DeprovisioningStep is an interface to be implemented by types that represent
@@ -22,7 +21,6 @@ type DeprovisioningStep interface {
 		ctx context.Context,
 		instance Instance,
 		plan Plan,
-		refInstance Instance,
 	) (InstanceDetails, error)
 }
 
@@ -66,7 +64,6 @@ func (d *deprovisioningStep) Execute(
 	ctx context.Context,
 	instance Instance,
 	plan Plan,
-	refInstance Instance,
 ) (InstanceDetails, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -74,7 +71,6 @@ func (d *deprovisioningStep) Execute(
 		ctx,
 		instance,
 		plan,
-		refInstance,
 	)
 }
 

--- a/pkg/service/instance.go
+++ b/pkg/service/instance.go
@@ -9,9 +9,10 @@ import (
 
 // Instance represents an instance of a service
 type Instance struct {
-	InstanceID                      string                 `json:"instanceId"`             // nolint: lll
-	ServiceID                       string                 `json:"serviceId"`              // nolint: lll
-	PlanID                          string                 `json:"planId"`                 // nolint: lll
+	InstanceID                      string                 `json:"instanceId"` // nolint: lll
+	ServiceID                       string                 `json:"serviceId"`  // nolint: lll
+	PlanID                          string                 `json:"planId"`     // nolint: lll
+	Parent                          *Instance              `json:"-"`
 	EncryptedProvisioningParameters []byte                 `json:"provisioningParameters"` // nolint: lll
 	ProvisioningParameters          ProvisioningParameters `json:"-"`
 	EncryptedUpdatingParameters     []byte                 `json:"updatingParameters"` // nolint: lll

--- a/pkg/service/provisioner.go
+++ b/pkg/service/provisioner.go
@@ -11,7 +11,6 @@ type ProvisioningStepFunction func(
 	ctx context.Context,
 	instance Instance,
 	plan Plan,
-	refInstance Instance,
 ) (InstanceDetails, error)
 
 // ProvisioningStep is an interface to be implemented by types that represent
@@ -22,7 +21,6 @@ type ProvisioningStep interface {
 		ctx context.Context,
 		instance Instance,
 		plan Plan,
-		refInstance Instance,
 	) (InstanceDetails, error)
 }
 
@@ -66,7 +64,6 @@ func (p *provisioningStep) Execute(
 	ctx context.Context,
 	instance Instance,
 	plan Plan,
-	refInstance Instance,
 ) (InstanceDetails, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -74,7 +71,6 @@ func (p *provisioningStep) Execute(
 		ctx,
 		instance,
 		plan,
-		refInstance,
 	)
 }
 

--- a/pkg/services/aci/deprovision.go
+++ b/pkg/services/aci/deprovision.go
@@ -20,7 +20,6 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*aciInstanceDetails)
 	if !ok {
@@ -41,7 +40,6 @@ func (s *serviceManager) deleteACIServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*aciInstanceDetails)
 	if !ok {

--- a/pkg/services/aci/provision.go
+++ b/pkg/services/aci/provision.go
@@ -40,7 +40,6 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*aciInstanceDetails)
 	if !ok {
@@ -57,7 +56,6 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*aciInstanceDetails)
 	if !ok {

--- a/pkg/services/cosmosdb/deprovision.go
+++ b/pkg/services/cosmosdb/deprovision.go
@@ -23,7 +23,6 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*cosmosdbInstanceDetails)
 	if !ok {
@@ -44,7 +43,6 @@ func (s *serviceManager) deleteCosmosDBServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*cosmosdbInstanceDetails)
 	if !ok {

--- a/pkg/services/cosmosdb/provision.go
+++ b/pkg/services/cosmosdb/provision.go
@@ -30,7 +30,6 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*cosmosdbInstanceDetails)
 	if !ok {
@@ -47,7 +46,6 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*cosmosdbInstanceDetails)
 	if !ok {

--- a/pkg/services/eventhubs/deprovision.go
+++ b/pkg/services/eventhubs/deprovision.go
@@ -20,7 +20,6 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*eventHubInstanceDetails)
 	if !ok {
@@ -41,7 +40,6 @@ func (s *serviceManager) deleteNamespace(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*eventHubInstanceDetails)
 	if !ok {

--- a/pkg/services/eventhubs/provision.go
+++ b/pkg/services/eventhubs/provision.go
@@ -29,7 +29,6 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*eventHubInstanceDetails)
 	if !ok {
@@ -47,7 +46,6 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*eventHubInstanceDetails)
 	if !ok {

--- a/pkg/services/fake/fake.go
+++ b/pkg/services/fake/fake.go
@@ -97,7 +97,6 @@ func (s *ServiceManager) provision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	return instance.Details, nil
 }
@@ -173,7 +172,6 @@ func (s *ServiceManager) deprovision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	return instance.Details, nil
 }

--- a/pkg/services/keyvault/deprovision.go
+++ b/pkg/services/keyvault/deprovision.go
@@ -23,7 +23,6 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*keyvaultInstanceDetails)
 	if !ok {
@@ -44,7 +43,6 @@ func (s *serviceManager) deleteKeyVaultServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*keyvaultInstanceDetails)
 	if !ok {

--- a/pkg/services/keyvault/provision.go
+++ b/pkg/services/keyvault/provision.go
@@ -53,7 +53,6 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*keyvaultInstanceDetails)
 	if !ok {
@@ -70,7 +69,6 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*keyvaultInstanceDetails)
 	if !ok {

--- a/pkg/services/mysqldb/deprovision.go
+++ b/pkg/services/mysqldb/deprovision.go
@@ -20,7 +20,6 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mysqlInstanceDetails)
 	if !ok {
@@ -41,7 +40,6 @@ func (s *serviceManager) deleteMySQLServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mysqlInstanceDetails)
 	if !ok {

--- a/pkg/services/mysqldb/provision.go
+++ b/pkg/services/mysqldb/provision.go
@@ -88,7 +88,6 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mysqlInstanceDetails)
 	if !ok {
@@ -157,7 +156,6 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mysqlInstanceDetails)
 	if !ok {

--- a/pkg/services/postgresqldb/deprovision.go
+++ b/pkg/services/postgresqldb/deprovision.go
@@ -23,7 +23,6 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*postgresqlInstanceDetails)
 	if !ok {
@@ -44,7 +43,6 @@ func (s *serviceManager) deletePostgreSQLServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*postgresqlInstanceDetails)
 	if !ok {

--- a/pkg/services/postgresqldb/provision.go
+++ b/pkg/services/postgresqldb/provision.go
@@ -92,7 +92,6 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*postgresqlInstanceDetails)
 	if !ok {
@@ -161,7 +160,6 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*postgresqlInstanceDetails)
 	if !ok {
@@ -206,7 +204,6 @@ func (s *serviceManager) setupDatabase(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*postgresqlInstanceDetails)
 	if !ok {
@@ -270,7 +267,6 @@ func (s *serviceManager) createExtensions(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*postgresqlInstanceDetails)
 	if !ok {

--- a/pkg/services/rediscache/deprovision.go
+++ b/pkg/services/rediscache/deprovision.go
@@ -20,7 +20,6 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*redisInstanceDetails)
 	if !ok {
@@ -41,7 +40,6 @@ func (s *serviceManager) deleteRedisServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*redisInstanceDetails)
 	if !ok {

--- a/pkg/services/rediscache/provision.go
+++ b/pkg/services/rediscache/provision.go
@@ -29,7 +29,6 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*redisInstanceDetails)
 	if !ok {
@@ -46,7 +45,6 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*redisInstanceDetails)
 	if !ok {

--- a/pkg/services/search/deprovision.go
+++ b/pkg/services/search/deprovision.go
@@ -20,7 +20,6 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*searchInstanceDetails)
 	if !ok {
@@ -41,7 +40,6 @@ func (s *serviceManager) deleteAzureSearch(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*searchInstanceDetails)
 	if !ok {

--- a/pkg/services/search/provision.go
+++ b/pkg/services/search/provision.go
@@ -29,7 +29,6 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*searchInstanceDetails)
 	if !ok {
@@ -46,7 +45,6 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*searchInstanceDetails)
 	if !ok {

--- a/pkg/services/servicebus/deprovision.go
+++ b/pkg/services/servicebus/deprovision.go
@@ -20,7 +20,6 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*serviceBusInstanceDetails)
 	if !ok {
@@ -41,7 +40,6 @@ func (s *serviceManager) deleteNamespace(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*serviceBusInstanceDetails)
 	if !ok {

--- a/pkg/services/servicebus/provision.go
+++ b/pkg/services/servicebus/provision.go
@@ -29,7 +29,6 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*serviceBusInstanceDetails)
 	if !ok {
@@ -46,7 +45,6 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*serviceBusInstanceDetails)
 	if !ok {

--- a/pkg/services/sqldb/deprovision.go
+++ b/pkg/services/sqldb/deprovision.go
@@ -47,7 +47,6 @@ func (a *allInOneManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
@@ -69,7 +68,6 @@ func (v *vmOnlyManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {
@@ -91,7 +89,6 @@ func (d *dbOnlyManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	referenceInstance service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
@@ -101,7 +98,7 @@ func (d *dbOnlyManager) deleteARMDeployment(
 	}
 	err := d.armDeployer.Delete(
 		dt.ARMDeploymentName,
-		referenceInstance.ResourceGroup,
+		instance.Parent.ResourceGroup,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error deleting ARM deployment: %s", err)
@@ -113,7 +110,6 @@ func (a *allInOneManager) deleteMsSQLServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
@@ -134,7 +130,6 @@ func (v *vmOnlyManager) deleteMsSQLServer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance,
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {
@@ -155,7 +150,6 @@ func (d *dbOnlyManager) deleteMsSQLDatabase(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	referenceInstance service.Instance,
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
@@ -166,7 +160,7 @@ func (d *dbOnlyManager) deleteMsSQLDatabase(
 	if err := d.mssqlManager.DeleteDatabase(
 		dt.ServerName,
 		dt.DatabaseName,
-		referenceInstance.ResourceGroup,
+		instance.Parent.ResourceGroup,
 	); err != nil {
 		return dt, fmt.Errorf("error deleting mssql database: %s", err)
 	}

--- a/pkg/services/sqldb/provision.go
+++ b/pkg/services/sqldb/provision.go
@@ -160,7 +160,6 @@ func (a *allInOneManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, //reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
@@ -180,7 +179,6 @@ func (v *vmOnlyManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, //reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {
@@ -199,7 +197,6 @@ func (d *dbOnlyManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	referenceInstance service.Instance,
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
@@ -208,7 +205,7 @@ func (d *dbOnlyManager) preProvision(
 		)
 	}
 	//Assume refererence instance is a vm only instance. Fail if not
-	rdt, ok := referenceInstance.Details.(*mssqlVMOnlyInstanceDetails)
+	rdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {
 		return nil, errors.New(
 			"error casting referenceInstance.Details as " +
@@ -248,7 +245,6 @@ func (a *allInOneManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	_ service.Instance, //reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
@@ -311,7 +307,6 @@ func (v *vmOnlyManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, //reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {
@@ -368,7 +363,6 @@ func (d *dbOnlyManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	referenceInstance service.Instance,
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*mssqlInstanceDetails)
 	if !ok {
@@ -388,8 +382,8 @@ func (d *dbOnlyManager) deployARMTemplate(
 	//No output, so ignore the output
 	_, err := d.armDeployer.Deploy(
 		dt.ARMDeploymentName,
-		referenceInstance.ResourceGroup,
-		referenceInstance.Location,
+		instance.Parent.ResourceGroup,
+		instance.Parent.Location,
 		armTemplateDBOnlyBytes,
 		nil, // Go template params
 		p,

--- a/pkg/services/sqldb/types.go
+++ b/pkg/services/sqldb/types.go
@@ -13,7 +13,8 @@ type ServerProvisioningParams struct {
 type DBProvisioningParams struct {
 }
 
-// instance details are common to the DB only and All In One Service.
+// TODO: Fix this...
+// Instance details are common to the DB only and All In One Service.
 // Bind doesn't get passed reference instance info, so we need the
 // Server Name, and Administrator Info in order to complete Binding
 type mssqlInstanceDetails struct {

--- a/pkg/services/storage/deprovision.go
+++ b/pkg/services/storage/deprovision.go
@@ -23,7 +23,6 @@ func (s *serviceManager) deleteARMDeployment(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*storageInstanceDetails)
 	if !ok {
@@ -44,7 +43,6 @@ func (s *serviceManager) deleteStorageAccount(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*storageInstanceDetails)
 	if !ok {

--- a/pkg/services/storage/provision.go
+++ b/pkg/services/storage/provision.go
@@ -49,7 +49,6 @@ func (s *serviceManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*storageInstanceDetails)
 	if !ok {
@@ -80,7 +79,6 @@ func (s *serviceManager) deployARMTemplate(
 	_ context.Context,
 	instance service.Instance,
 	plan service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*storageInstanceDetails)
 	if !ok {
@@ -133,7 +131,6 @@ func (s *serviceManager) createBlobContainer(
 	_ context.Context,
 	instance service.Instance,
 	_ service.Plan,
-	_ service.Instance, // Reference instance
 ) (service.InstanceDetails, error) {
 	dt, ok := instance.Details.(*storageInstanceDetails)
 	if !ok {

--- a/tests/lifecycle/test_case_test.go
+++ b/tests/lifecycle/test_case_test.go
@@ -136,9 +136,6 @@ func (s serviceLifecycleTestCase) execute(resourceGroup string) error {
 			ctx,
 			instance,
 			plan,
-			// TODO: Still need to come up with a way of finding a related instance
-			// (if applicable).
-			service.Instance{},
 		)
 		if err != nil {
 			return err
@@ -206,9 +203,6 @@ func (s serviceLifecycleTestCase) execute(resourceGroup string) error {
 			ctx,
 			instance,
 			plan,
-			// TODO: Still need to come up with a way of finding a related instance
-			// (if applicable).
-			service.Instance{},
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
@jeremyrickard this allows access to "ref instances" without us polluting various function signatures by requiring that these get passed around as a separate argument.

The problem of how we find that instance in the first place is _still_ an issue, but this should unblock you in terms of the ability to refactor some of the types used by the three service managers in the sqldb module.