### PR TITLE
broker doesn't need to hang on to codec

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -43,7 +43,6 @@ type broker struct {
 	store       storage.Store
 	apiServer   api.Server
 	asyncEngine async.Engine
-	codec       crypto.Codec
 	catalog     service.Catalog
 }
 
@@ -92,7 +91,6 @@ func NewBroker(
 	b := &broker{
 		store:       storage.NewStore(redisClient, catalog, codec),
 		asyncEngine: async.NewEngine(redisClient),
-		codec:       codec,
 		catalog:     catalog,
 	}
 


### PR DESCRIPTION
Noticed there's no longer any reason for a `Broker` to hang on to a reference to a `crypto.Codec` any longer than it takes to initialize storage.