### PR TITLE
Adding ability to filter lifecycle tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ test-service-lifecycles: check-docker-compose check-azure-env-vars
 		-e AZURE_TENANT_ID=$${AZURE_TENANT_ID} \
 		-e AZURE_CLIENT_ID=$${AZURE_CLIENT_ID} \
 		-e AZURE_CLIENT_SECRET=$${AZURE_CLIENT_SECRET} \
+		-e TEST_MODULES=$${TEST_MODULES} \
 		test \
 		bash -c 'go test \
 			-parallel 10 \

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -152,6 +152,15 @@ after themselves.__
 $ make test-service-lifecycles
 ```
 
+If you'd like to run a subset of the service lifecycle tests, you can select
+a subset of the services by a comma delimited list of module names to the 
+TEST_MODULES environment variable. For example, to run only the `aci` and 
+`mssql` tests:
+
+```console
+$ TEST_MODULES=aci,mssql make test-service-lifecycles
+```
+
 Regardless of success or failure, after tests have completed, you can verify
 that they have cleaned up after themselves by searching for resource groups
 named using the scheme "test=*":

--- a/tests/lifecycle/test_case_test.go
+++ b/tests/lifecycle/test_case_test.go
@@ -28,6 +28,10 @@ type serviceLifecycleTestCase struct {
 	testCredentials        func(credentials service.Credentials) error
 }
 
+func (s serviceLifecycleTestCase) getModule() service.Module {
+	return s.module
+}
+
 func (s serviceLifecycleTestCase) getName() string {
 	base := fmt.Sprintf(
 		"TestServices/lifecycle/%s",

--- a/tests/lifecycle/test_case_test.go
+++ b/tests/lifecycle/test_case_test.go
@@ -28,10 +28,6 @@ type serviceLifecycleTestCase struct {
 	testCredentials        func(credentials service.Credentials) error
 }
 
-func (s serviceLifecycleTestCase) getModule() service.Module {
-	return s.module
-}
-
 func (s serviceLifecycleTestCase) getName() string {
 	base := fmt.Sprintf(
 		"TestServices/lifecycle/%s",

--- a/tests/lifecycle/test_cases_test.go
+++ b/tests/lifecycle/test_cases_test.go
@@ -63,7 +63,7 @@ func filter(
 	//map
 	filtered := testCases[:0]
 	for _, testCase := range testCases {
-		_, ok := filters[testCase.getModule().GetName()]
+		_, ok := filters[testCase.module.GetName()]
 		if ok {
 			filtered = append(filtered, testCase)
 		}

--- a/tests/lifecycle/test_cases_test.go
+++ b/tests/lifecycle/test_cases_test.go
@@ -3,6 +3,10 @@
 package lifecycle
 
 import (
+	"log"
+	"os"
+	"strings"
+
 	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
 )
 
@@ -31,13 +35,47 @@ func getTestCases(resourceGroup string) ([]serviceLifecycleTestCase, error) {
 		getStorageCases,
 	}
 
+	testFilters := getTestFilters()
+
 	for _, getTestCaseFunc := range getTestCaseFuncs {
 		if tcs, err := getTestCaseFunc(armDeployer, resourceGroup); err == nil {
-			testCases = append(testCases, tcs...)
+			testCases = filter(append(testCases, tcs...), testFilters)
 		} else {
 			return nil, err
 		}
 	}
-
+	if len(testCases) == 0 {
+		log.Print("No test cases selected. Please check TEST_MODULES variable.")
+	}
 	return testCases, nil
+}
+
+func filter(testCases []serviceLifecycleTestCase, filters map[string]struct{}) []serviceLifecycleTestCase {
+	//If filters is empty, we are not filtering so include ethe testcase
+	if len(filters) == 0 {
+		return testCases
+	}
+
+	//If filters is not empty, see if the testcase's module name is in the filter
+	//map
+	filtered := testCases[:0]
+	for _, testCase := range testCases {
+		_, ok := filters[testCase.getModule().GetName()]
+		if ok {
+			filtered = append(filtered, testCase)
+		}
+	}
+	return filtered
+}
+
+func getTestFilters() map[string]struct{} {
+	f := make(map[string]struct{})
+	if env := os.Getenv("TEST_MODULES"); env != "" {
+		filters := strings.Split(env, ",")
+		log.Printf("Running tests for modules: %v", filters)
+		for _, filter := range filters {
+			f[filter] = struct{}{}
+		}
+	}
+	return f
 }

--- a/tests/lifecycle/test_cases_test.go
+++ b/tests/lifecycle/test_cases_test.go
@@ -50,8 +50,11 @@ func getTestCases(resourceGroup string) ([]serviceLifecycleTestCase, error) {
 	return testCases, nil
 }
 
-func filter(testCases []serviceLifecycleTestCase, filters map[string]struct{}) []serviceLifecycleTestCase {
-	//If filters is empty, we are not filtering so include ethe testcase
+func filter(
+	testCases []serviceLifecycleTestCase,
+	filters map[string]struct{},
+) []serviceLifecycleTestCase {
+	//If filters is empty, we are not filtering so include all the testcases
 	if len(filters) == 0 {
 		return testCases
 	}


### PR DESCRIPTION
This adds the ability to filter lifecycle tests using an environment variable (TEST_MODULES). There are three possible paths when using the variable:
1.) the developer can provide a single module name or comma delimited list of module names and only the test cases matching will be enabled.  
2.) If the variable is empty, all tests will run.
3.) If an invalid module name is provided, no tests will run.

Implements #157 