### PR TITLE
move version info to avoid import cycle later

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty)
 BINARY_DIR := bin
 BINARY_NAME := osba
 
+BASE_PACKAGE_NAME := github.com/Azure/open-service-broker-azure
+
 # This is left as 'azure-service-broker' because we don't yet have a docker repo
 # for 'open-service-broker-azure'
 #
@@ -21,7 +23,7 @@ else
 BROKER_VERSION=$(REL_VERSION)
 endif
 
-LDFLAGS = -w -X main.commit=$(GIT_VERSION) -X main.version=$(BROKER_VERSION)
+LDFLAGS = -w -X $(BASE_PACKAGE_NAME)/pkg/version.commit=$(GIT_VERSION) -X $(BASE_PACKAGE_NAME)/pkg/version.version=$(BROKER_VERSION)
 
 # Checks for the existence of a docker client and prints a nice error message
 # if it isn't present
@@ -121,7 +123,7 @@ test-service-lifecycles: check-docker-compose check-azure-env-vars
 		bash -c 'go test \
 			-parallel 10 \
 		  -timeout 60m \
-			github.com/Azure/open-service-broker-azure/tests/lifecycle -v'
+			$(BASE_PACKAGE_NAME)/tests/lifecycle -v'
 
 
 # Containerized API compliance check via osb-checker. Currently ignores exit code. 

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -13,13 +13,9 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/api/authenticator/basic"
 	"github.com/Azure/open-service-broker-azure/pkg/broker"
 	"github.com/Azure/open-service-broker-azure/pkg/crypto/aes256"
+	"github.com/Azure/open-service-broker-azure/pkg/version"
 	log "github.com/Sirupsen/logrus"
 	"github.com/go-redis/redis"
-)
-
-var (
-	version string
-	commit  string
 )
 
 func init() {
@@ -56,8 +52,8 @@ func init() {
 func main() {
 	log.WithFields(
 		log.Fields{
-			"version": version,
-			"commit":  commit,
+			"version": version.GetVersion(),
+			"commit":  version.GetCommit(),
 		},
 	).Info("Open Service Broker for Azure starting")
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,18 @@
+package version
+
+// Values for these are injected by the build
+var (
+	version string
+	commit  string
+)
+
+// GetVersion returns the OSBA version. This is either a semantic version
+// number or else, in the case of unreleased code, the string "devel".
+func GetVersion() string {
+	return version
+}
+
+// GetCommit returns the git commit SHA for the code that OSBA was built from.
+func GetCommit() string {
+	return commit
+}


### PR DESCRIPTION
Without this change, #172 (once cleaned up) will have an import cycle to contend with.