### PR TITLE
Refactor sqldb module to use parent instances in binding

### DIFF
--- a/pkg/services/sqldb/bind.go
+++ b/pkg/services/sqldb/bind.go
@@ -133,10 +133,10 @@ func (a *allInOneManager) Bind(
 	instance service.Instance,
 	_ service.BindingParameters,
 ) (service.BindingDetails, error) {
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
+	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting instance.Details as *mssqlInstanceDetails",
+			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
 		)
 	}
 
@@ -162,16 +162,22 @@ func (d *dbOnlyManager) Bind(
 	_ service.BindingParameters,
 ) (service.BindingDetails, error) {
 
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
+	dt, ok := instance.Details.(*mssqlDBOnlyInstanceDetails)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting instance.Details as *mssqlInstanceDetails",
+			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
 		)
 	}
-
+	pdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
+	if !ok {
+		return nil, fmt.Errorf(
+			"error casting instance.Parent.Details as " +
+				"*mssqlVMOnlyInstanceDetails",
+		)
+	}
 	return bind(
-		dt.AdministratorLogin,
-		dt.AdministratorLoginPassword,
+		pdt.AdministratorLogin,
+		pdt.AdministratorLoginPassword,
 		dt.FullyQualifiedDomainName,
 		dt.DatabaseName,
 	)
@@ -181,10 +187,10 @@ func (a *allInOneManager) GetCredentials(
 	instance service.Instance,
 	binding service.Binding,
 ) (service.Credentials, error) {
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
+	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting instance.Details as *mssqlInstanceDetails",
+			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
 		)
 	}
 	bd, ok := binding.Details.(*mssqlBindingDetails)
@@ -213,10 +219,10 @@ func (d *dbOnlyManager) GetCredentials(
 	instance service.Instance,
 	binding service.Binding,
 ) (service.Credentials, error) {
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
+	dt, ok := instance.Details.(*mssqlDBOnlyInstanceDetails)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting instance.Details as *mssqlInstanceDetails",
+			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
 		)
 	}
 	bd, ok := binding.Details.(*mssqlBindingDetails)

--- a/pkg/services/sqldb/deprovision.go
+++ b/pkg/services/sqldb/deprovision.go
@@ -48,10 +48,10 @@ func (a *allInOneManager) deleteARMDeployment(
 	instance service.Instance,
 	_ service.Plan,
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
+	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting instance.Details as *mssqlInstanceDetails",
+			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
 		)
 	}
 	err := a.armDeployer.Delete(
@@ -90,10 +90,10 @@ func (d *dbOnlyManager) deleteARMDeployment(
 	instance service.Instance,
 	_ service.Plan,
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
+	dt, ok := instance.Details.(*mssqlDBOnlyInstanceDetails)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting instance.Details as *mssqlInstanceDetails",
+			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
 		)
 	}
 	err := d.armDeployer.Delete(
@@ -111,10 +111,10 @@ func (a *allInOneManager) deleteMsSQLServer(
 	instance service.Instance,
 	_ service.Plan,
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
+	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting instance.Details as *mssqlInstanceDetails",
+			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
 		)
 	}
 	if err := a.mssqlManager.DeleteServer(
@@ -151,14 +151,22 @@ func (d *dbOnlyManager) deleteMsSQLDatabase(
 	instance service.Instance,
 	_ service.Plan,
 ) (service.InstanceDetails, error) {
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
+	dt, ok := instance.Details.(*mssqlDBOnlyInstanceDetails)
 	if !ok {
 		return nil, fmt.Errorf(
-			"error casting instance.Details as *mssqlInstanceDetails",
+			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
 		)
 	}
+	pdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
+	if !ok {
+		return nil, fmt.Errorf(
+			"error casting instance.Parent.Details as " +
+				"*mssqlVMOnlyInstanceDetails",
+		)
+	}
+
 	if err := d.mssqlManager.DeleteDatabase(
-		dt.ServerName,
+		pdt.ServerName,
 		dt.DatabaseName,
 		instance.Parent.ResourceGroup,
 	); err != nil {

--- a/pkg/services/sqldb/types.go
+++ b/pkg/services/sqldb/types.go
@@ -13,25 +13,27 @@ type ServerProvisioningParams struct {
 type DBProvisioningParams struct {
 }
 
-// TODO: Fix this...
-// Instance details are common to the DB only and All In One Service.
-// Bind doesn't get passed reference instance info, so we need the
-// Server Name, and Administrator Info in order to complete Binding
-type mssqlInstanceDetails struct {
+type mssqlAllInOneInstanceDetails struct {
 	ARMDeploymentName          string `json:"armDeployment"`
+	FullyQualifiedDomainName   string `json:"fullyQualifiedDomainName"`
 	ServerName                 string `json:"server"`
 	AdministratorLogin         string `json:"administratorLogin"`
 	AdministratorLoginPassword string `json:"administratorLoginPassword"`
 	DatabaseName               string `json:"database"`
-	FullyQualifiedDomainName   string `json:"fullyQualifiedDomainName"`
 }
 
 type mssqlVMOnlyInstanceDetails struct {
 	ARMDeploymentName          string `json:"armDeployment"`
+	FullyQualifiedDomainName   string `json:"fullyQualifiedDomainName"`
 	ServerName                 string `json:"server"`
 	AdministratorLogin         string `json:"administratorLogin"`
 	AdministratorLoginPassword string `json:"administratorLoginPassword"`
-	FullyQualifiedDomainName   string `json:"fullyQualifiedDomainName"`
+}
+
+type mssqlDBOnlyInstanceDetails struct {
+	ARMDeploymentName        string `json:"armDeployment"`
+	FullyQualifiedDomainName string `json:"fullyQualifiedDomainName"`
+	DatabaseName             string `json:"database"`
 }
 
 // UpdatingParameters encapsulates MSSQL-specific updating options
@@ -110,7 +112,7 @@ func (
 func (
 	a *allInOneManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
-	return &mssqlInstanceDetails{}
+	return &mssqlAllInOneInstanceDetails{}
 }
 
 func (
@@ -122,7 +124,7 @@ func (
 func (
 	d *dbOnlyManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
-	return &mssqlInstanceDetails{}
+	return &mssqlDBOnlyInstanceDetails{}
 }
 
 func (

--- a/pkg/services/sqldb/unbind.go
+++ b/pkg/services/sqldb/unbind.go
@@ -112,7 +112,7 @@ func (d *dbOnlyManager) Unbind(
 	pdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {
 		return fmt.Errorf(
-			"error casting Parent Details as" +
+			"error casting instance.Parent.Details as" +
 				"*mssqlVMOnlyInstanceDetails",
 		)
 	}

--- a/pkg/services/sqldb/unbind.go
+++ b/pkg/services/sqldb/unbind.go
@@ -62,10 +62,10 @@ func (a *allInOneManager) Unbind(
 	instance service.Instance,
 	bindingDetails service.BindingDetails,
 ) error {
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
+	dt, ok := instance.Details.(*mssqlAllInOneInstanceDetails)
 	if !ok {
 		return fmt.Errorf(
-			"error casting instance.Details as *mssqlInstanceDetails",
+			"error casting instance.Details as *mssqlAllInOneInstanceDetails",
 		)
 	}
 	bc, ok := bindingDetails.(*mssqlBindingDetails)
@@ -87,7 +87,7 @@ func (a *allInOneManager) Unbind(
 //TODO : Unbind is not valid for VM only.
 //Determine what to do.
 func (v *vmOnlyManager) Unbind(
-	_ service.Instance,
+	instance service.Instance,
 	_ service.BindingDetails,
 ) error {
 	return nil
@@ -97,10 +97,10 @@ func (d *dbOnlyManager) Unbind(
 	instance service.Instance,
 	bindingDetails service.BindingDetails,
 ) error {
-	dt, ok := instance.Details.(*mssqlInstanceDetails)
+	dt, ok := instance.Details.(*mssqlDBOnlyInstanceDetails)
 	if !ok {
 		return fmt.Errorf(
-			"error casting instance.Details as *mssqlInstanceDetails",
+			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
 		)
 	}
 	bc, ok := bindingDetails.(*mssqlBindingDetails)
@@ -109,10 +109,17 @@ func (d *dbOnlyManager) Unbind(
 			"error casting bindingDetails as *mssqlBindingDetails",
 		)
 	}
+	pdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
+	if !ok {
+		return fmt.Errorf(
+			"error casting Parent Details as" +
+				"*mssqlVMOnlyInstanceDetails",
+		)
+	}
 
 	return unbind(
-		dt.AdministratorLogin,
-		dt.AdministratorLoginPassword,
+		pdt.AdministratorLogin,
+		pdt.AdministratorLoginPassword,
 		dt.FullyQualifiedDomainName,
 		dt.DatabaseName,
 		bc,


### PR DESCRIPTION
Small refactor to decouple shared instance details and leverage parent instance for binding/unbinding for the db only service.

Further evolution of #124