### PR TITLE
use redis namespaces

### DIFF
--- a/pkg/async/cleaner.go
+++ b/pkg/async/cleaner.go
@@ -63,7 +63,7 @@ func (c *cleaner) defaultClean(workerSetName, mainWorkQueueName string) error {
 			return fmt.Errorf("error retrieving workers: %s", err)
 		}
 		for _, workerID := range workerIDs {
-			strCmd := c.redisClient.Get(workerID)
+			strCmd := c.redisClient.Get(getHeartbeatKey(workerID))
 			if strCmd.Err() == nil {
 				continue
 			}

--- a/pkg/async/cleaner_test.go
+++ b/pkg/async/cleaner_test.go
@@ -49,14 +49,14 @@ func TestCleanerCleanInternalCleansDeadWorkers(t *testing.T) {
 	assert.Equal(t, expectedCount, cleanWorkerCallCount)
 }
 
-func TestCleanerCleanInternalDoesNotCleansLiveWorkers(t *testing.T) {
-	queueName := getDisposableQueueName()
+func TestCleanerCleanInternalDoesNotCleanLiveWorkers(t *testing.T) {
+	mainQueueName := getDisposableQueueName()
 	workerSetName := getDisposableWorkerSetName()
 	for range [5]struct{}{} {
 		workerID := getDisposableWorkerID()
 		intCmd := redisClient.SAdd(workerSetName, workerID)
 		assert.Nil(t, intCmd.Err())
-		statusCmd := redisClient.Set(workerID, aliveIndicator, 0)
+		statusCmd := redisClient.Set(getHeartbeatKey(workerID), aliveIndicator, 0)
 		assert.Nil(t, statusCmd.Err())
 	}
 	c := newCleaner(redisClient).(*cleaner)
@@ -65,7 +65,7 @@ func TestCleanerCleanInternalDoesNotCleansLiveWorkers(t *testing.T) {
 		cleanWorkerCallCount++
 		return nil
 	}
-	err := c.clean(workerSetName, queueName)
+	err := c.clean(workerSetName, mainQueueName)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, cleanWorkerCallCount)
 }

--- a/pkg/async/common.go
+++ b/pkg/async/common.go
@@ -5,5 +5,5 @@ import "fmt"
 const mainWorkQueueName = "work"
 
 func getWorkerQueueName(workerID string) string {
-	return fmt.Sprintf("%s-work", workerID)
+	return fmt.Sprintf("worker-queues:%s", workerID)
 }

--- a/pkg/async/heart.go
+++ b/pkg/async/heart.go
@@ -87,7 +87,8 @@ func (h *heart) Start(ctx context.Context) error {
 // This is the default function for sending a heartbeat. It can be overridden
 // to facilitate testing.
 func (h *heart) defaultBeat() error {
-	statusCmd := h.redisClient.Set(h.workerID, aliveIndicator, h.ttl)
+	key := getHeartbeatKey(h.workerID)
+	statusCmd := h.redisClient.Set(key, aliveIndicator, h.ttl)
 	if statusCmd.Err() != nil {
 		return fmt.Errorf(
 			"error sending heartbeat for worker %s: %s",
@@ -96,4 +97,8 @@ func (h *heart) defaultBeat() error {
 		)
 	}
 	return nil
+}
+
+func getHeartbeatKey(workerID string) string {
+	return fmt.Sprintf("heartbeats:%s", workerID)
 }

--- a/pkg/async/heart_test.go
+++ b/pkg/async/heart_test.go
@@ -22,7 +22,7 @@ func TestHeartBeat(t *testing.T) {
 	h := newHeart(getDisposableWorkerID(), time.Second, redisClient).(*heart)
 	err := h.Beat()
 	assert.Nil(t, err)
-	strCmd := redisClient.Get(h.workerID)
+	strCmd := redisClient.Get(getHeartbeatKey(h.workerID))
 	assert.Nil(t, strCmd.Err())
 	str, err := strCmd.Result()
 	assert.Nil(t, err)


### PR DESCRIPTION
This is a precursor to adding an "index" of instance aliases in the feature branch for #124, however, I believe this is a general improvement to the internal organization of the datastore, so I'm PR'ing it to master first.