### PR TITLE
validate alias and parentAlias

### DIFF
--- a/pkg/service/catalog.go
+++ b/pkg/service/catalog.go
@@ -32,6 +32,7 @@ type ServiceProperties struct { // nolint: golint
 	PlanUpdatable bool     `json:"plan_updateable"` // Misspelling is deliberate
 	// to match the spec
 	ParentServiceID string `json:"-"`
+	ChildServiceID  string `json:"-"`
 }
 
 // Service is an interface to be implemented by types that represent a single
@@ -45,6 +46,7 @@ type Service interface {
 	GetPlans() []Plan
 	GetPlan(planID string) (Plan, bool)
 	GetParentServiceID() string
+	GetChildServiceID() string
 }
 
 type service struct {
@@ -232,6 +234,10 @@ func (s *service) GetPlan(planID string) (Plan, bool) {
 
 func (s *service) GetParentServiceID() string {
 	return s.ParentServiceID
+}
+
+func (s *service) GetChildServiceID() string {
+	return s.ChildServiceID
 }
 
 // NewPlan initializes and returns a new Plan

--- a/pkg/service/instance.go
+++ b/pkg/service/instance.go
@@ -9,22 +9,24 @@ import (
 
 // Instance represents an instance of a service
 type Instance struct {
-	InstanceID                      string                 `json:"instanceId"` // nolint: lll
-	ServiceID                       string                 `json:"serviceId"`  // nolint: lll
-	PlanID                          string                 `json:"planId"`     // nolint: lll
+	InstanceID                      string                 `json:"instanceId"`
+	Alias                           string                 `json:"alias"`
+	ServiceID                       string                 `json:"serviceId"`
+	PlanID                          string                 `json:"planId"`
 	Parent                          *Instance              `json:"-"`
 	EncryptedProvisioningParameters []byte                 `json:"provisioningParameters"` // nolint: lll
 	ProvisioningParameters          ProvisioningParameters `json:"-"`
 	EncryptedUpdatingParameters     []byte                 `json:"updatingParameters"` // nolint: lll
 	UpdatingParameters              UpdatingParameters     `json:"-"`
-	Status                          string                 `json:"status"`        // nolint: lll
-	StatusReason                    string                 `json:"statusReason"`  // nolint: lll
-	Location                        string                 `json:"location"`      // nolint: lll
-	ResourceGroup                   string                 `json:"resourceGroup"` // nolint: lll
+	Status                          string                 `json:"status"`
+	StatusReason                    string                 `json:"statusReason"`
+	Location                        string                 `json:"location"`
+	ResourceGroup                   string                 `json:"resourceGroup"`
+	ParentAlias                     string                 `json:"parentAlias"`
 	Tags                            map[string]string      `json:"tags"`
-	EncryptedDetails                []byte                 `json:"details"` // nolint: lll
+	EncryptedDetails                []byte                 `json:"details"`
 	Details                         InstanceDetails        `json:"-"`
-	Created                         time.Time              `json:"created"` // nolint: lll
+	Created                         time.Time              `json:"created"`
 }
 
 // NewInstanceFromJSON returns a new Instance unmarshalled from the provided

--- a/pkg/service/instance_test.go
+++ b/pkg/service/instance_test.go
@@ -17,10 +17,12 @@ var (
 
 func init() {
 	instanceID := "test-instance-id"
+	alias := "test-alias"
 	serviceID := "test-service-id"
 	planID := "test-plan-id"
 	location := "test-location"
 	resourceGroup := "test-rg"
+	parentAlias := "test-parent-alias"
 	tagKey := "foo"
 	tagVal := "bar"
 	provisioningParameters := &ArbitraryType{
@@ -43,6 +45,7 @@ func init() {
 
 	testInstance = Instance{
 		InstanceID: instanceID,
+		Alias:      alias,
 		ServiceID:  serviceID,
 		PlanID:     planID,
 		EncryptedProvisioningParameters: encryptedProvisiongingParameters,
@@ -53,6 +56,7 @@ func init() {
 		StatusReason:                    statusReason,
 		Location:                        location,
 		ResourceGroup:                   resourceGroup,
+		ParentAlias:                     parentAlias,
 		Tags:                            map[string]string{tagKey: tagVal},
 		EncryptedDetails:                encryptedDetails,
 		Details:                         details,
@@ -72,6 +76,7 @@ func init() {
 	testInstanceJSONStr := fmt.Sprintf(
 		`{
 			"instanceId":"%s",
+			"alias":"%s",
 			"serviceId":"%s",
 			"planId":"%s",
 			"provisioningParameters":"%s",
@@ -80,11 +85,13 @@ func init() {
 			"statusReason":"%s",
 			"location":"%s",
 			"resourceGroup":"%s",
+			"parentAlias":"%s",
 			"tags":{"%s":"%s"},
 			"details":"%s",
 			"created":"%s"
 		}`,
 		instanceID,
+		alias,
 		serviceID,
 		planID,
 		b64EncryptedProvisioningParameters,
@@ -93,6 +100,7 @@ func init() {
 		statusReason,
 		location,
 		resourceGroup,
+		parentAlias,
 		tagKey,
 		tagVal,
 		b64EncryptedDetails,

--- a/pkg/services/sqldb/catalog.go
+++ b/pkg/services/sqldb/catalog.go
@@ -151,11 +151,12 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 		// vm only service
 		service.NewService(
 			&service.ServiceProperties{
-				ID:          "a7454e0e-be2c-46ac-b55f-8c4278117525",
-				Name:        "azure-sqldb-vm-only",
-				Description: "Azure SQL Server VM (Experimental)",
-				Bindable:    false,
-				Tags:        []string{"Azure", "SQL", "Server", "VM"},
+				ID:             "a7454e0e-be2c-46ac-b55f-8c4278117525",
+				Name:           "azure-sqldb-vm-only",
+				Description:    "Azure SQL Server VM (Experimental)",
+				Bindable:       false,
+				Tags:           []string{"Azure", "SQL", "Server", "VM"},
+				ChildServiceID: "2bbc160c-e279-4757-a6b6-4c0a4822d0aa",
 			},
 			m.vmOnlyServiceManager,
 			service.NewPlan(&service.PlanProperties{


### PR DESCRIPTION
This should require an `alias` parameter during provisioning if the service type is one that has children and require a `parentAlias` parameter during provisioning if the service type has a parent.

What is still missing after this is that storage isn't indexing instances by alias and we're not yet retrieving parent instance info by alias when we retrieve a child. These will come next.
  