### PR TITLE
Update lifecycle tests to run mssql db only

### DIFF
--- a/pkg/services/sqldb/bind.go
+++ b/pkg/services/sqldb/bind.go
@@ -1,7 +1,6 @@
 package sqldb
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/Azure/open-service-broker-azure/pkg/generate"
@@ -171,7 +170,7 @@ func (d *dbOnlyManager) Bind(
 	}
 	//Parent should be set by the framework, but return an error if it is not set.
 	if instance.Parent == nil {
-		return nil, errors.New("parent instance not set")
+		return nil, fmt.Errorf("parent instance not set")
 	}
 	pdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {

--- a/pkg/services/sqldb/bind.go
+++ b/pkg/services/sqldb/bind.go
@@ -1,6 +1,7 @@
 package sqldb
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Azure/open-service-broker-azure/pkg/generate"
@@ -167,6 +168,10 @@ func (d *dbOnlyManager) Bind(
 		return nil, fmt.Errorf(
 			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
 		)
+	}
+	//Parent should be set by the framework, but return an error if it is not set.
+	if instance.Parent == nil {
+		return nil, errors.New("parent instance not set")
 	}
 	pdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {

--- a/pkg/services/sqldb/deprovision.go
+++ b/pkg/services/sqldb/deprovision.go
@@ -2,7 +2,6 @@ package sqldb
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/Azure/open-service-broker-azure/pkg/service"
@@ -99,7 +98,7 @@ func (d *dbOnlyManager) deleteARMDeployment(
 	}
 	//Parent should be set by the framework, but return an error if it is not set.
 	if instance.Parent == nil {
-		return nil, errors.New("parent instance not set")
+		return nil, fmt.Errorf("parent instance not set")
 	}
 	err := d.armDeployer.Delete(
 		dt.ARMDeploymentName,
@@ -164,7 +163,7 @@ func (d *dbOnlyManager) deleteMsSQLDatabase(
 	}
 	//Parent should be set by the framework, but return an error if it is not set.
 	if instance.Parent == nil {
-		return nil, errors.New("parent instance not set")
+		return nil, fmt.Errorf("parent instance not set")
 	}
 	pdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {

--- a/pkg/services/sqldb/deprovision.go
+++ b/pkg/services/sqldb/deprovision.go
@@ -2,6 +2,7 @@ package sqldb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Azure/open-service-broker-azure/pkg/service"
@@ -96,6 +97,10 @@ func (d *dbOnlyManager) deleteARMDeployment(
 			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
 		)
 	}
+	//Parent should be set by the framework, but return an error if it is not set.
+	if instance.Parent == nil {
+		return nil, errors.New("parent instance not set")
+	}
 	err := d.armDeployer.Delete(
 		dt.ARMDeploymentName,
 		instance.Parent.ResourceGroup,
@@ -156,6 +161,10 @@ func (d *dbOnlyManager) deleteMsSQLDatabase(
 		return nil, fmt.Errorf(
 			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
 		)
+	}
+	//Parent should be set by the framework, but return an error if it is not set.
+	if instance.Parent == nil {
+		return nil, errors.New("parent instance not set")
 	}
 	pdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {

--- a/pkg/services/sqldb/provision.go
+++ b/pkg/services/sqldb/provision.go
@@ -204,6 +204,11 @@ func (d *dbOnlyManager) preProvision(
 			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
 		)
 	}
+
+	//Parent should be set by the framework, but return an error if it is not set.
+	if instance.Parent == nil {
+		return nil, errors.New("parent instance not set")
+	}
 	//Assume refererence instance is a vm only instance. Fail if not
 	pdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {
@@ -221,9 +226,8 @@ func (d *dbOnlyManager) preProvision(
 	if err != nil {
 		return nil, err
 	}
-
+	dt.ARMDeploymentName = uuid.NewV4().String()
 	dt.DatabaseName = generate.NewIdentifier()
-
 	sqlDatabaseDNSSuffix := azureEnvironment.SQLDatabaseDNSSuffix
 	dt.FullyQualifiedDomainName = fmt.Sprintf(
 		"%s.%s",
@@ -363,7 +367,12 @@ func (d *dbOnlyManager) deployARMTemplate(
 			"error casting instance.Details as *mssqlDBOnlyInstanceDetails",
 		)
 	}
-	pdt, ok := instance.Details.(*mssqlVMOnlyInstanceDetails)
+
+	//Parent should be set by the framework, but return an error if it is not set.
+	if instance.Parent == nil {
+		return nil, errors.New("parent instance not set")
+	}
+	pdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {
 		return nil, errors.New(
 			"error casting instance.Parent.Details as " +

--- a/pkg/services/sqldb/unbind.go
+++ b/pkg/services/sqldb/unbind.go
@@ -1,7 +1,6 @@
 package sqldb
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/Azure/open-service-broker-azure/pkg/service"
@@ -112,7 +111,7 @@ func (d *dbOnlyManager) Unbind(
 	}
 	//Parent should be set by the framework, but return an error if it is not set.
 	if instance.Parent == nil {
-		return errors.New("parent instance not set")
+		return fmt.Errorf("parent instance not set")
 	}
 	pdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {

--- a/pkg/services/sqldb/unbind.go
+++ b/pkg/services/sqldb/unbind.go
@@ -1,6 +1,7 @@
 package sqldb
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Azure/open-service-broker-azure/pkg/service"
@@ -108,6 +109,10 @@ func (d *dbOnlyManager) Unbind(
 		return fmt.Errorf(
 			"error casting bindingDetails as *mssqlBindingDetails",
 		)
+	}
+	//Parent should be set by the framework, but return an error if it is not set.
+	if instance.Parent == nil {
+		return errors.New("parent instance not set")
 	}
 	pdt, ok := instance.Parent.Details.(*mssqlVMOnlyInstanceDetails)
 	if !ok {

--- a/tests/lifecycle/driver_test.go
+++ b/tests/lifecycle/driver_test.go
@@ -46,7 +46,7 @@ func TestServices(t *testing.T) {
 			t.Run(tc.getName(), func(t *testing.T) {
 				// Run subtests in parallel!
 				t.Parallel()
-				err := tc.execute(resourceGroup)
+				err := tc.execute(t, resourceGroup)
 				assert.Nil(t, err)
 			})
 		}

--- a/tests/lifecycle/mssql_cases_test.go
+++ b/tests/lifecycle/mssql_cases_test.go
@@ -3,11 +3,9 @@
 package lifecycle
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 	"net/url"
-	"time"
 
 	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
 	ss "github.com/Azure/open-service-broker-azure/pkg/azure/mssql"
@@ -23,47 +21,6 @@ func getMssqlCases(
 	msSQLManager, err := ss.NewManager()
 	if err != nil {
 		return nil, err
-	}
-
-	provisionServerOnly := func() (*service.Instance, error) {
-
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*20)
-		defer cancel()
-
-		s := serviceLifecycleTestCase{
-			module:      sqldb.New(armDeployer, msSQLManager),
-			description: "new server only",
-			serviceID:   "a7454e0e-be2c-46ac-b55f-8c4278117525",
-			planID:      "24f0f42e-1ab3-474e-a5ca-b943b2c48eee",
-			location:    "southcentralus",
-			provisioningParameters: &sqldb.ServerProvisioningParams{
-				FirewallIPStart: "0.0.0.0",
-				FirewallIPEnd:   "255.255.255.255",
-			},
-		}
-
-		svc, plan, err := s.getServiceAndPlan()
-		if err != nil {
-			return nil, err
-		}
-		serviceManager := svc.GetServiceManager()
-
-		p := service.Instance{
-			ServiceID: s.serviceID,
-			PlanID:    s.planID,
-			Location:  s.location,
-			// Force the resource group to be something known to this test executor
-			// to ensure good cleanup
-			ResourceGroup:          resourceGroup,
-			Details:                serviceManager.GetEmptyInstanceDetails(),
-			ProvisioningParameters: s.provisioningParameters,
-		}
-
-		p.Details, err = s.provision(ctx, serviceManager, p, plan)
-		if err != nil {
-			return nil, fmt.Errorf("error creating parent instance %s", err)
-		}
-		return &p, nil
 	}
 
 	return []serviceLifecycleTestCase{
@@ -82,7 +39,7 @@ func getMssqlCases(
 		},
 		{ //server only scenario
 			module:      sqldb.New(armDeployer, msSQLManager),
-			description: "new server only",
+			description: "new server",
 			serviceID:   "a7454e0e-be2c-46ac-b55f-8c4278117525",
 			planID:      "24f0f42e-1ab3-474e-a5ca-b943b2c48eee",
 			location:    "southcentralus",
@@ -90,16 +47,17 @@ func getMssqlCases(
 				FirewallIPStart: "0.0.0.0",
 				FirewallIPEnd:   "255.255.255.255",
 			},
-		},
-		{ // db only scenario
-			module:            sqldb.New(armDeployer, msSQLManager),
-			description:       "database on an existing server",
-			setup:             provisionServerOnly,
-			serviceID:         "2bbc160c-e279-4757-a6b6-4c0a4822d0aa",
-			planID:            "8fa8d759-c142-45dd-ae38-b93482ddc04a",
-			location:          "", // This is actually irrelevant for this test
-			bindingParameters: &sqldb.BindingParameters{},
-			testCredentials:   testMsSQLCreds(),
+			childTestCases: []*serviceLifecycleTestCase{
+				{ // db only scenario
+					module:            sqldb.New(armDeployer, msSQLManager),
+					description:       "database on new server",
+					serviceID:         "2bbc160c-e279-4757-a6b6-4c0a4822d0aa",
+					planID:            "8fa8d759-c142-45dd-ae38-b93482ddc04a",
+					location:          "", // This is actually irrelevant for this test
+					bindingParameters: &sqldb.BindingParameters{},
+					testCredentials:   testMsSQLCreds(),
+				},
+			},
 		},
 	}, nil
 }

--- a/tests/lifecycle/mssql_cases_test.go
+++ b/tests/lifecycle/mssql_cases_test.go
@@ -43,6 +43,9 @@ func getMssqlCases(
 		}
 
 		svc, plan, err := s.getServiceAndPlan()
+		if err != nil {
+			return nil, err
+		}
 		serviceManager := svc.GetServiceManager()
 
 		p := service.Instance{

--- a/tests/lifecycle/mssql_cases_test.go
+++ b/tests/lifecycle/mssql_cases_test.go
@@ -39,7 +39,7 @@ func getMssqlCases(
 		},
 		{ //server only scenario
 			module:      sqldb.New(armDeployer, msSQLManager),
-			description: "new server",
+			description: "new server with database child test",
 			serviceID:   "a7454e0e-be2c-46ac-b55f-8c4278117525",
 			planID:      "24f0f42e-1ab3-474e-a5ca-b943b2c48eee",
 			location:    "southcentralus",

--- a/tests/lifecycle/test_case_test.go
+++ b/tests/lifecycle/test_case_test.go
@@ -177,7 +177,11 @@ func (s serviceLifecycleTestCase) showStatus(ctx context.Context) {
 	}
 }
 
-func (s serviceLifecycleTestCase) getServiceAndPlan() (service.Service, service.Plan, error) {
+func (s serviceLifecycleTestCase) getServiceAndPlan() (
+	service.Service,
+	service.Plan,
+	error,
+) {
 	// Get the service and plan
 	cat, err := s.module.GetCatalog()
 	if err != nil {

--- a/tests/lifecycle/test_case_test.go
+++ b/tests/lifecycle/test_case_test.go
@@ -25,7 +25,7 @@ type serviceLifecycleTestCase struct {
 	planID                 string
 	location               string
 	provisioningParameters service.ProvisioningParameters
-	parentService          *service.Instance
+	parentServiceInstance  *service.Instance
 	childTestCases         []*serviceLifecycleTestCase
 	bindingParameters      service.BindingParameters
 	testCredentials        func(credentials service.Credentials) error
@@ -108,7 +108,7 @@ func (s serviceLifecycleTestCase) execute(
 		ResourceGroup:          resourceGroup,
 		Details:                serviceManager.GetEmptyInstanceDetails(),
 		ProvisioningParameters: s.provisioningParameters,
-		Parent:                 s.parentService,
+		Parent:                 s.parentServiceInstance,
 	}
 
 	// Provision...
@@ -179,7 +179,7 @@ func (s serviceLifecycleTestCase) execute(
 	//Iterate through any child test cases, setting the instnace from this
 	//test case as the parent.
 	for i, test := range s.childTestCases {
-		test.parentService = &instance
+		test.parentServiceInstance = &instance
 		var subTestName string
 		if test.description == "" {
 			subTestName = fmt.Sprintf("subtest-%v", i)
@@ -188,6 +188,7 @@ func (s serviceLifecycleTestCase) execute(
 		}
 		t.Run(subTestName, func(t *testing.T) {
 			tErr := test.execute(t, resourceGroup)
+			//This will fail this subtest, but also the parent lifecycle test
 			assert.Nil(t, tErr)
 		})
 	}


### PR DESCRIPTION
1.) Small refactor to test_case_test.go to break provision into a
reusable function
2.) Modified setup function signature to include a *service.Instance
    to use as a parent instance
3.) Added setup function in mssql tests
4.) Added lifecycle test for DB only
5.) Fixed db only privision bug

Implemnts #124