### PR TITLE
simplify ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,94 +1,53 @@
 version: 2
 jobs:
   lint:
-    working_directory: ~/go/src/github.com/Azure/open-service-broker-azure
-    environment:
-      GOPATH: ~/go
     machine: true
     steps:
       - checkout
-      - run:
-          name: Install Dependencies
-          command: ./scripts/install-deps.sh
       - run:
           name: Run Lint
           command: make lint
   verify-vendored-code:
-    working_directory: ~/go/src/github.com/Azure/open-service-broker-azure
-    environment:
-      GOPATH: ~/go
     machine: true
     steps:
       - checkout
-      - run:
-          name: Install Dependencies
-          command: ./scripts/install-deps.sh
       - run:
           name: Verify Vendored Code
           command: make verify-vendored-code
   test-unit:
-    working_directory: ~/go/src/github.com/Azure/open-service-broker-azure
-    environment:
-      GOPATH: ~/go
     machine: true
     steps:
       - checkout
-      - run:
-          name: Install Dependencies
-          command: ./scripts/install-deps.sh
       - run:
           name: Run Unit Tests
           command: make test-unit
   test-api-compliance:
-    working_directory: ~/go/src/github.com/Azure/open-service-broker-azure
-    environment:
-      GOPATH: ~/go
     machine: true
     steps:
       - checkout
-      - run:
-          name: Install Dependencies
-          command: ./scripts/install-deps.sh
       - run:
           name: Run API Compliance Tests
           command: make test-api-compliance
   build:
-    working_directory: ~/go/src/github.com/Azure/open-service-broker-azure
-    environment:
-      GOPATH: ~/go
     machine: true
     steps:
       - checkout
-      - run:
-          name: Install Dependencies
-          command: ./scripts/install-deps.sh
       - run:
           name: Build Binary & Docker Image
           command: make docker-build
   test-service-lifecycles:
-    working_directory: ~/go/src/github.com/Azure/open-service-broker-azure
-    environment:
-      GOPATH: ~/go
     machine: true
     steps:
       - checkout
-      - run:
-          name: Install Dependencies
-          command: ./scripts/install-deps.sh
       - run:
           name: Run Service Lifecycle Tests
           command: make test-service-lifecycles
   publish-rc-images:
-    working_directory: ~/go/src/github.com/Azure/open-service-broker-azure
     environment:
-      GOPATH: ~/go
       DOCKER_REPO: microsoft/
     machine: true
     steps:
       - checkout
-      - run:
-          name: Install Dependencies
-          command: ./scripts/install-deps.sh
       - run:
           name: Log in to Docker Hub
           command: docker login -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}"

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-DOCKER_COMPOSE_VERSION=1.16.1
-DOCKER_COMPOSE_LOCATION=$(which docker-compose)
-DOCKER_COMPOSE_DL_URL="https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64"
-sudo curl -o ${DOCKER_COMPOSE_LOCATION} -L ${DOCKER_COMPOSE_DL_URL}
-chmod +x ${DOCKER_COMPOSE_LOCATION}
-docker version
-docker-compose version


### PR DESCRIPTION
I've noticed there are many superfluous details in our CI config.

1. Specifying a working directory and `GOPATH` environment variable on each machine executor is wholly unnecessary. These details would be relevant _if_ we were executing `go ...` commands natively on the machine executor, but we're not. All make targets that execute `go ...` commands do so in containers. `GOPATH` and the working directory are set properly in said containers (see `docker-compose.yaml`), and that's what really matters.
1. The `install-deps.sh` script installs docker-compose, however, CircleCI machine executors already have an adequate version of docker-compose pre-installed, making this script unnecessary.

Removing these unnecessary details should sharpen the focus on more relevant aspects of the CI configuration.