### PR TITLE
parent child count

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -178,8 +178,8 @@ func getInstanceKey(instanceID string) string {
 	return fmt.Sprintf("instances:%s", instanceID)
 }
 
-func getInstanceAliasKey(instanceID string) string {
-	return fmt.Sprintf("instances:aliases:%s", instanceID)
+func getInstanceAliasKey(alias string) string {
+	return fmt.Sprintf("instances:aliases:%s", alias)
 }
 
 func (s *store) WriteBinding(binding service.Binding) error {


### PR DESCRIPTION
Needs #200 merged first. This allows us to get a count of existing children for any given instance, as identified by its alias. Note, we have no need to know who the children are-- just how many exist. More precisely, we will eventually care that a parent can only be deprovisioned if 0 children remain.