### PR TITLE
add deferred task execution to async package

### DIFF
--- a/pkg/async/cleaner.go
+++ b/pkg/async/cleaner.go
@@ -9,23 +9,38 @@ import (
 	"github.com/go-redis/redis"
 )
 
-type cleanFunction func(workerSetName, mainWorkQueueName string) error
+type cleanFn func(
+	ctx context.Context,
+	workerSetName string,
+	pendingTaskQueueName string,
+	deferredTaskQueueName string,
+) error
 
-type cleanWorkerFunction func(workerID, mainWorkQueueName string) error
+type cleanWorkerQueueFn func(
+	ctx context.Context,
+	workerID string,
+	pendingTaskQueueName string,
+	deferredTaskQueueName string,
+) error
 
-// Cleaner is an interface to be implemented by components that re-queue work
+// Cleaner is an interface to be implemented by components that re-queue tasks
 // assigned to dead workers
 type Cleaner interface {
-	Clean(context.Context) error
+	// Run causes the cleaner to clean up after dead worker. It blocks until a
+	// fatal error is encountered or the context passed to it has been canceled.
+	// Run always returns a non-nil error.
+	Run(context.Context) error
 }
 
 // cleaner is a Redis-based implementation of the Cleaner interface
 type cleaner struct {
 	redisClient *redis.Client
 	// This allows tests to inject an alternative implementation of this function
-	clean cleanFunction
+	clean cleanFn
 	// This allows tests to inject an alternative implementation of this function
-	cleanWorker cleanWorkerFunction
+	cleanActiveTaskQueue cleanWorkerQueueFn
+	// This allows tests to inject an alternative implementation of this function
+	cleanWatchedTaskQueue cleanWorkerQueueFn
 }
 
 func newCleaner(redisClient *redis.Client) Cleaner {
@@ -33,17 +48,26 @@ func newCleaner(redisClient *redis.Client) Cleaner {
 		redisClient: redisClient,
 	}
 	c.clean = c.defaultClean
-	c.cleanWorker = c.defaultCleanWorker
+	c.cleanActiveTaskQueue = c.defaultCleanWorkerQueue
+	c.cleanWatchedTaskQueue = c.defaultCleanWorkerQueue
 	return c
 }
 
-func (c *cleaner) Clean(ctx context.Context) error {
+// Run causes the cleaner to clean up after dead worker. It blocks until a fatal
+// error is encountered or the context passed to it has been canceled. Run
+// always returns a non-nil error.
+func (c *cleaner) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	ticker := time.NewTicker(time.Second * 10)
 	defer ticker.Stop()
 	for {
-		if err := c.clean("workers", mainWorkQueueName); err != nil {
+		if err := c.clean(
+			ctx,
+			workerSetName,
+			pendingTaskQueueName,
+			deferredTaskQueueName,
+		); err != nil {
 			return &errCleaning{err: err}
 		}
 		select {
@@ -55,62 +79,92 @@ func (c *cleaner) Clean(ctx context.Context) error {
 	}
 }
 
-func (c *cleaner) defaultClean(workerSetName, mainWorkQueueName string) error {
-	strsCmd := c.redisClient.SMembers(workerSetName)
-	if strsCmd.Err() == nil {
-		workerIDs, err := strsCmd.Result()
-		if err != nil {
-			return fmt.Errorf("error retrieving workers: %s", err)
-		}
-		for _, workerID := range workerIDs {
-			strCmd := c.redisClient.Get(getHeartbeatKey(workerID))
-			if strCmd.Err() == nil {
+func (c *cleaner) defaultClean(
+	ctx context.Context,
+	workerSetName string,
+	pendingTaskQueueName string,
+	deferredTaskQueueName string,
+) error {
+	workerIDs, err := c.redisClient.SMembers(workerSetName).Result()
+	if err == redis.Nil {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error retrieving workers: %s", err)
+	}
+	for _, workerID := range workerIDs {
+		err := c.redisClient.Get(getHeartbeatKey(workerID)).Err()
+		if err == nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
 				continue
 			}
-			if strCmd.Err() != redis.Nil {
-				return fmt.Errorf(
-					`error checking health of worker: "%s": %s`,
-					workerID,
-					strCmd.Err(),
-				)
-			}
-			// If we get to here, we have a dead worker on our hands
-			if err := c.cleanWorker(workerID, mainWorkQueueName); err != nil {
-				return fmt.Errorf(
-					`error cleaning up after dead worker "%s": %s`,
-					workerID,
-					err,
-				)
-			}
-			intCmd := c.redisClient.SRem("workers", workerID)
-			if intCmd.Err() != nil && intCmd.Err() != redis.Nil {
-				return fmt.Errorf(
-					`error removing dead worker "%s" from worker set: %s`,
-					workerID,
-					intCmd.Err(),
-				)
-			}
 		}
-	} else if strsCmd.Err() != redis.Nil {
-		return fmt.Errorf("error retrieving workers: %s", strsCmd.Err())
+		if err != redis.Nil {
+			return fmt.Errorf(
+				`error checking health of worker: "%s": %s`,
+				workerID,
+				err,
+			)
+		}
+		// If we get to here, we have a dead worker on our hands
+		if err := c.cleanActiveTaskQueue(
+			ctx,
+			workerID,
+			getActiveTaskQueueName(workerID),
+			pendingTaskQueueName,
+		); err != nil {
+			return err
+		}
+		if err := c.cleanWatchedTaskQueue(
+			ctx,
+			workerID,
+			getWatchedTaskQueueName(workerID),
+			deferredTaskQueueName,
+		); err != nil {
+			return err
+		}
+		err = c.redisClient.SRem(workerSetName, workerID).Err()
+		if err != nil && err != redis.Nil {
+			return fmt.Errorf(
+				`error removing dead worker "%s" from worker set: %s`,
+				workerID,
+				err,
+			)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 	}
 	return nil
 }
 
-func (c *cleaner) defaultCleanWorker(workerID, mainWorkQueueName string) error {
+func (c *cleaner) defaultCleanWorkerQueue(
+	ctx context.Context,
+	workerID string,
+	sourceQueueName string,
+	destinationQueueName string,
+) error {
 	for {
-		strCmd := c.redisClient.RPopLPush(
-			getWorkerQueueName(workerID),
-			mainWorkQueueName,
-		)
-		if strCmd.Err() == redis.Nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		err := c.redisClient.RPopLPush(sourceQueueName, destinationQueueName).Err()
+		if err == redis.Nil {
 			return nil
 		}
-		if strCmd.Err() != nil {
+		if err != nil {
 			return fmt.Errorf(
-				`error cleaning up after dead worker "%s": %s`,
+				`error cleaning up after dead worker "%s" queue "%s": %s`,
 				workerID,
-				strCmd.Err(),
+				sourceQueueName,
+				err,
 			)
 		}
 	}

--- a/pkg/async/cleaner_test.go
+++ b/pkg/async/cleaner_test.go
@@ -8,88 +8,294 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCleanerCleanBlocksUntilCleanInternalErrors(t *testing.T) {
+func TestCleanerRunBlocksUntilCleanErrors(t *testing.T) {
 	c := newCleaner(redisClient).(*cleaner)
-	c.clean = func(string, string) error {
+
+	// Override the default clean function to just return an error
+	c.clean = func(context.Context, string, string, string) error {
 		return errSome
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := c.Clean(ctx)
-	assert.Equal(t, &errCleaning{err: errSome}, err)
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- c.Run(ctx)
+	}()
+
+	// Assert that the error returned from the Run function is the error that
+	// the overridden clean function generated
+	select {
+	case err := <-errCh:
+		assert.Equal(t, &errCleaning{err: errSome}, err)
+	case <-time.After(time.Second):
+		assert.Fail(
+			t,
+			"an error error should have been returned, but wasn't",
+		)
+	}
 }
 
-func TestCleanerCleanBlocksUntilContextCanceled(t *testing.T) {
+func TestCleanerRunRespondsToCanceledContext(t *testing.T) {
 	c := newCleaner(redisClient).(*cleaner)
-	c.clean = func(string, string) error {
+
+	// Override the default clean function to be a no-op
+	c.clean = func(context.Context, string, string, string) error {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := c.Clean(ctx)
-	assert.Equal(t, ctx.Err(), err)
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- c.Run(ctx)
+	}()
+
+	cancel()
+
+	// Assert that the error returned from Work indicates that the context was
+	// canceled
+	select {
+	case err := <-errCh:
+		assert.Equal(t, ctx.Err(), err)
+	case <-time.After(time.Second):
+		assert.Fail(
+			t,
+			"a context canceled error should have been returned, but wasn't",
+		)
+	}
 }
 
-func TestCleanerCleanInternalCleansDeadWorkers(t *testing.T) {
-	queueName := getDisposableQueueName()
-	workerSetName := getDisposableWorkerSetName()
-	const expectedCount = 5
-	for range [expectedCount]struct{}{} {
-		intCmd := redisClient.SAdd(workerSetName, getDisposableWorkerID())
-		assert.Nil(t, intCmd.Err())
-	}
+func TestDefaultCleanCleansDeadWorkers(t *testing.T) {
 	c := newCleaner(redisClient).(*cleaner)
-	var cleanWorkerCallCount int
-	c.cleanWorker = func(string, string) error {
-		cleanWorkerCallCount++
+
+	// Add some workers to the worker set, but do not add any heartbeats for these
+	// workers. i.e. They should appear dead.
+	const workerCount = 5
+	workerSetName := getDisposableWorkerSetName()
+	for range [workerCount]struct{}{} {
+		err := redisClient.SAdd(workerSetName, getDisposableWorkerID()).Err()
+		assert.Nil(t, err)
+	}
+
+	// Override the default cleanActiveTaskQueue function to just count how many
+	// times it is invoked
+	var cleanActiveTaskQueueCallCount int
+	c.cleanActiveTaskQueue = func(context.Context, string, string, string) error {
+		cleanActiveTaskQueueCallCount++
 		return nil
 	}
-	err := c.clean(workerSetName, queueName)
-	assert.Nil(t, err)
-	assert.Equal(t, expectedCount, cleanWorkerCallCount)
-}
 
-func TestCleanerCleanInternalDoesNotCleanLiveWorkers(t *testing.T) {
-	mainQueueName := getDisposableQueueName()
-	workerSetName := getDisposableWorkerSetName()
-	for range [5]struct{}{} {
-		workerID := getDisposableWorkerID()
-		intCmd := redisClient.SAdd(workerSetName, workerID)
-		assert.Nil(t, intCmd.Err())
-		statusCmd := redisClient.Set(getHeartbeatKey(workerID), aliveIndicator, 0)
-		assert.Nil(t, statusCmd.Err())
-	}
-	c := newCleaner(redisClient).(*cleaner)
-	var cleanWorkerCallCount int
-	c.cleanWorker = func(string, string) error {
-		cleanWorkerCallCount++
+	// Override the default cleanWatchedTaskQueue function to just count how many
+	// times it is invoked
+	var cleanWatchedTaskQueueCallCount int
+	c.cleanWatchedTaskQueue = func(
+		context.Context,
+		string,
+		string,
+		string,
+	) error {
+		cleanWatchedTaskQueueCallCount++
 		return nil
 	}
-	err := c.clean(workerSetName, mainQueueName)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := c.defaultClean(
+		ctx,
+		workerSetName,
+		getDisposableQueueName(),
+		getDisposableQueueName(),
+	)
 	assert.Nil(t, err)
-	assert.Equal(t, 0, cleanWorkerCallCount)
+
+	// Assert cleanActiveTaskQueue and cleanWatchedTaskQueue were each invoked
+	// once per dead worker
+	assert.Equal(t, workerCount, cleanActiveTaskQueueCallCount)
+	assert.Equal(t, workerCount, cleanWatchedTaskQueueCallCount)
 }
 
-func TestCleanerCleanWorker(t *testing.T) {
-	mainQueueName := getDisposableQueueName()
+func TestDefaultCleanDoesNotCleanLiveWorkers(t *testing.T) {
+	c := newCleaner(redisClient).(*cleaner)
+
+	// Add a worker to the worker set. Also add a heartbeat so this worker appears
+	// to be alive.
+	workerSetName := getDisposableWorkerSetName()
 	workerID := getDisposableWorkerID()
-	workerQueueName := getWorkerQueueName(workerID)
-	const taskCount = 5
-	for range [taskCount]struct{}{} {
-		intCmd := redisClient.LPush(workerQueueName, "foo")
-		assert.Nil(t, intCmd.Err())
+	err := redisClient.SAdd(workerSetName, workerID).Err()
+	assert.Nil(t, err)
+	err = redisClient.Set(getHeartbeatKey(workerID), aliveIndicator, 0).Err()
+	assert.Nil(t, err)
+
+	// Override the default cleanActiveTaskQueue function to just count how many
+	// times it is invoked
+	var cleanActiveTaskQueueCallCount int
+	c.cleanActiveTaskQueue = func(context.Context, string, string, string) error {
+		cleanActiveTaskQueueCallCount++
+		return nil
 	}
+
+	// Override the default cleanWatchedTaskQueue function to just count how many
+	// times it is invoked
+	var cleanWatchedTaskQueueCallCount int
+	c.cleanWatchedTaskQueue = func(
+		context.Context,
+		string,
+		string,
+		string,
+	) error {
+		cleanWatchedTaskQueueCallCount++
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = c.defaultClean(
+		ctx,
+		workerSetName,
+		getDisposableQueueName(),
+		getDisposableQueueName(),
+	)
+	assert.Nil(t, err)
+
+	// Assert neither cleanActiveTaskQueue and cleanWatchedTaskQueue were ever
+	// invoked
+	assert.Equal(t, 0, cleanActiveTaskQueueCallCount)
+	assert.Equal(t, 0, cleanWatchedTaskQueueCallCount)
+}
+
+func TestDefaultCleanRespondsToContextCanceled(t *testing.T) {
 	c := newCleaner(redisClient).(*cleaner)
-	err := c.cleanWorker(workerID, mainQueueName)
+
+	// Add one worker to the worker set. Do not add a heartbeat. This should
+	// guarantee that some cleanup must take place. This is imporant because
+	// we'll override the default cleanActiveTaskQueue function to block us for a
+	// while, giving us the opportunity to test that defaultClean responds to
+	// context cancelation.
+	workerSetName := getDisposableWorkerSetName()
+	workerID := getDisposableWorkerID()
+	err := redisClient.SAdd(workerSetName, workerID).Err()
 	assert.Nil(t, err)
-	intCmd := redisClient.LLen(mainQueueName)
-	assert.Nil(t, intCmd.Err())
-	mainQueueDepth, err := intCmd.Result()
+
+	// Override the default cleanActiveTaskQueue function to block until the
+	// context it is passed is canceled.
+	c.cleanActiveTaskQueue = func(
+		ctx context.Context,
+		_ string,
+		_ string,
+		_ string,
+	) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// defaultClean doesn't normally have a possibility of blocking indefinitely,
+	// but we've overridden the default cleanActiveTaskQueue function that
+	// defaultClean calls. We've done this so we can test our ability to
+	// short-circuit defaultClean with a canceled context, but in doing so, we've
+	// created the possibility for defaultClean to block indefinitely if it does
+	// not responds to the canceled context as we hope it does. So, here, we
+	// invoke defaultClean in a goroutine so that, in the worst case, the test
+	// won't stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- c.defaultClean(
+			ctx,
+			workerSetName,
+			getDisposableQueueName(),
+			getDisposableQueueName(),
+		)
+	}()
+
+	cancel()
+
+	// Assert that the error returned from defaultClean indicates that the context
+	// was canceled
+	select {
+	case err := <-errCh:
+		assert.Equal(t, ctx.Err(), err)
+	case <-time.After(time.Second):
+		assert.Fail(
+			t,
+			"a context canceled error should have been returned, but wasn't",
+		)
+	}
+}
+
+func TestDefaultCleanWorkerQueue(t *testing.T) {
+	c := newCleaner(redisClient).(*cleaner)
+
+	sourceQueueName := getDisposableQueueName()
+	destinationQueueName := getDisposableQueueName()
+
+	const taskCount int64 = 5
+	for range [taskCount]struct{}{} {
+		// Put some dummy tasks onto the source queue
+		err := redisClient.LPush(sourceQueueName, "foo").Err()
+		assert.Nil(t, err)
+	}
+
+	// Assert that the source queue is precisely taskCount deep
+	sourceQueueDepth, err := redisClient.LLen(sourceQueueName).Result()
 	assert.Nil(t, err)
-	assert.Equal(t, int64(taskCount), mainQueueDepth)
-	intCmd = redisClient.LLen(workerQueueName)
-	assert.Nil(t, intCmd.Err())
-	workerQueueDepth, err := intCmd.Result()
+	assert.Equal(t, taskCount, sourceQueueDepth)
+
+	// Assert that the destination queue starts out empty
+	destinationQueueDepth, err := redisClient.LLen(destinationQueueName).Result()
 	assert.Nil(t, err)
-	assert.Empty(t, workerQueueDepth)
+	assert.Empty(t, destinationQueueDepth)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = c.defaultCleanWorkerQueue(
+		ctx,
+		getDisposableWorkerID(),
+		sourceQueueName,
+		destinationQueueName,
+	)
+	assert.Nil(t, err)
+
+	// Assert that the source queue has been drained
+	sourceQueueDepth, err = redisClient.LLen(sourceQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, sourceQueueDepth)
+
+	// Assert that the destination queue now has precisely taskCount tasks
+	destinationQueueDepth, err = redisClient.LLen(destinationQueueName).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, taskCount, destinationQueueDepth)
+}
+
+func TestDefaultCleanWorkerQueueRespondsToContextCanceled(t *testing.T) {
+	c := newCleaner(redisClient).(*cleaner)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Cancel before we even call defaultCleanWorkerQueue. In this case, its
+	// the only way we can guarantee the function won't return before we have
+	// a chance to cancel the context.
+	cancel()
+
+	err := c.defaultCleanWorkerQueue(
+		ctx,
+		getDisposableWorkerID(),
+		getDisposableQueueName(),
+		getDisposableQueueName(),
+	)
+
+	// Assert that the error returned indicates that the context was canceled
+	assert.Equal(t, ctx.Err(), err)
 }

--- a/pkg/async/common.go
+++ b/pkg/async/common.go
@@ -2,8 +2,17 @@ package async
 
 import "fmt"
 
-const mainWorkQueueName = "work"
+const (
+	workerSetName         = "workers"
+	aliveIndicator        = "alive"
+	pendingTaskQueueName  = "pendingTasks"
+	deferredTaskQueueName = "deferredTasks"
+)
 
-func getWorkerQueueName(workerID string) string {
-	return fmt.Sprintf("worker-queues:%s", workerID)
+func getActiveTaskQueueName(workerID string) string {
+	return fmt.Sprintf("active-tasks:%s", workerID)
+}
+
+func getWatchedTaskQueueName(workerID string) string {
+	return fmt.Sprintf("watched-tasks:%s", workerID)
 }

--- a/pkg/async/engine_test.go
+++ b/pkg/async/engine_test.go
@@ -9,117 +9,160 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEngineStartBlocksUntilCleanerErrors(t *testing.T) {
+func TestEngineRunBlocksUntilCleanerStops(t *testing.T) {
 	e := NewEngine(redisClient).(*engine)
+
+	// Create a fake cleaner that will just return an error when it runs
 	c := fakeAsync.NewCleaner()
 	c.RunBehavior = func(context.Context) error {
 		return errSome
 	}
+
+	// Make the engine use the fake cleaner
 	e.cleaner = c
-	workerStopped := false
+
+	// Create a fake worker that will just communicate when the context it was
+	// passed has been canceled
+	contextCanceledCh := make(chan struct{})
 	w := fakeAsync.NewWorker()
 	w.RunBehavior = func(ctx context.Context) error {
 		<-ctx.Done()
-		workerStopped = true
+		close(contextCanceledCh)
 		return ctx.Err()
 	}
+
+	// Make the engine use the fake worker
 	e.worker = w
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := e.Start(ctx)
-	assert.Equal(t, &errCleanerStopped{err: errSome}, err)
-	time.Sleep(time.Second)
-	assert.True(t, workerStopped)
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- e.Run(ctx)
+	}()
+
+	// Assert that the error returned from the Run function wraps the error that
+	// the fake heart generated
+	select {
+	case err := <-errCh:
+		assert.Equal(t, &errCleanerStopped{err: errSome}, err)
+	case <-time.After(time.Second):
+		assert.Fail(t, "an error should have been received, but wasn't")
+	}
+
+	// Assert that the context got canceled. It's helpful to know that when the
+	// cleaner stops, the rest of the engine components are also signaled to shut
+	// down.
+	select {
+	case <-contextCanceledCh:
+	case <-time.After(time.Second):
+		assert.Fail(t, "context should have been canceled, but it was not")
+	}
 }
 
-func TestEngineStartBlocksUntilCleanerReturns(t *testing.T) {
+func TestEngineRunBlocksUntilWorkerStops(t *testing.T) {
 	e := NewEngine(redisClient).(*engine)
-	c := fakeAsync.NewCleaner()
-	c.RunBehavior = func(context.Context) error {
-		return nil
-	}
-	e.cleaner = c
-	workerStopped := false
-	w := fakeAsync.NewWorker()
-	w.RunBehavior = func(ctx context.Context) error {
-		<-ctx.Done()
-		workerStopped = true
-		return ctx.Err()
-	}
-	e.worker = w
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	err := e.Start(ctx)
-	assert.Equal(t, &errCleanerStopped{}, err)
-	time.Sleep(time.Second)
-	assert.True(t, workerStopped)
-}
 
-func TestEngineStartBlocksUntilWorkerErrors(t *testing.T) {
-	e := NewEngine(redisClient).(*engine)
-	cleanerStopped := false
+	// Create a fake cleaner that will just communicate when the context it was
+	// passed has been canceled
+	contextCanceledCh := make(chan struct{})
 	c := fakeAsync.NewCleaner()
 	c.RunBehavior = func(ctx context.Context) error {
 		<-ctx.Done()
-		cleanerStopped = true
+		close(contextCanceledCh)
 		return ctx.Err()
 	}
+
+	// Make the engine use the fake cleaner
 	e.cleaner = c
+
+	// Create a fake worker that will just return an error when it runs
 	w := fakeAsync.NewWorker()
 	w.RunBehavior = func(context.Context) error {
 		return errSome
 	}
+
+	// Make the engine use the fake worker
 	e.worker = w
-	err := e.Start(context.Background())
-	assert.Equal(t, &errWorkerStopped{workerID: w.GetID(), err: errSome}, err)
-	time.Sleep(time.Second)
-	assert.True(t, cleanerStopped)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- e.Run(ctx)
+	}()
+
+	// Assert that the error returned from the Run function wraps the error that
+	// the fake heart generated
+	select {
+	case err := <-errCh:
+		assert.Equal(t, &errWorkerStopped{workerID: w.GetID(), err: errSome}, err)
+	case <-time.After(time.Second):
+		assert.Fail(t, "an error should have been received, but wasn't")
+	}
+
+	// Assert that the context got canceled. It's helpful to know that when the
+	// worker stops, the rest of the engine components are also signaled to shut
+	// down.
+	select {
+	case <-contextCanceledCh:
+	case <-time.After(time.Second):
+		assert.Fail(t, "context should have been canceled, but it was not")
+	}
 }
 
-func TestEngineStartBlocksUntilWorkerReturns(t *testing.T) {
+func TestEngineRunRespondsToContextCanceled(t *testing.T) {
 	e := NewEngine(redisClient).(*engine)
-	cleanerStopped := false
+
+	// Create a fake cleaner that will just run until the context it was passed
+	// is canceled
 	c := fakeAsync.NewCleaner()
 	c.RunBehavior = func(ctx context.Context) error {
 		<-ctx.Done()
-		cleanerStopped = true
 		return ctx.Err()
 	}
-	e.cleaner = c
-	w := fakeAsync.NewWorker()
-	w.RunBehavior = func(context.Context) error {
-		return nil
-	}
-	e.worker = w
-	err := e.Start(context.Background())
-	assert.Equal(t, &errWorkerStopped{workerID: w.GetID()}, err)
-	time.Sleep(time.Second)
-	assert.True(t, cleanerStopped)
-}
 
-func TestEngineStartBlocksUntilContextCanceled(t *testing.T) {
-	e := NewEngine(redisClient).(*engine)
-	cleanerStopped := false
-	c := fakeAsync.NewCleaner()
-	c.RunBehavior = func(ctx context.Context) error {
-		<-ctx.Done()
-		cleanerStopped = true
-		return ctx.Err()
-	}
+	// Make the engine use the fake cleaner
 	e.cleaner = c
-	workerStopped := false
+
+	// Create a fake worker that will just run until the context it was passed
+	// is canceled
 	w := fakeAsync.NewWorker()
 	w.RunBehavior = func(ctx context.Context) error {
 		<-ctx.Done()
-		workerStopped = true
 		return ctx.Err()
 	}
+
+	// Make the engine use the fake worker
 	e.worker = w
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := e.Start(ctx)
-	assert.Equal(t, ctx.Err(), err)
-	time.Sleep(time.Second)
-	assert.True(t, cleanerStopped)
-	assert.True(t, workerStopped)
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- e.Run(ctx)
+	}()
+
+	cancel()
+
+	// Assert that the error returned from Run indicates that the context was
+	// canceled
+	select {
+	case err := <-errCh:
+		assert.Equal(t, ctx.Err(), err)
+	case <-time.After(time.Second):
+		assert.Fail(
+			t,
+			"a context canceled error should have been returned, but wasn't",
+		)
+	}
 }

--- a/pkg/async/errors.go
+++ b/pkg/async/errors.go
@@ -26,10 +26,11 @@ type errCleanerStopped struct {
 }
 
 func (e *errCleanerStopped) Error() string {
+	baseMsg := "cleaner stopped"
 	if e.err == nil {
-		return "cleaner stopped"
+		return baseMsg
 	}
-	return fmt.Sprintf("cleaner stopped: %s", e.err)
+	return fmt.Sprintf("%s: %s", baseMsg, e.err)
 }
 
 type errWorkerStopped struct {
@@ -38,10 +39,11 @@ type errWorkerStopped struct {
 }
 
 func (e *errWorkerStopped) Error() string {
+	baseMsg := fmt.Sprintf(`worker "%s" stopped`, e.workerID)
 	if e.err == nil {
-		return fmt.Sprintf(`worker "%s" stopped`, e.workerID)
+		return baseMsg
 	}
-	return fmt.Sprintf(`worker "%s" stopped: %s`, e.workerID, e.err)
+	return fmt.Sprintf("%s: %s", baseMsg, e.err)
 }
 
 type errHeartStopped struct {
@@ -50,26 +52,58 @@ type errHeartStopped struct {
 }
 
 func (e *errHeartStopped) Error() string {
+	baseMsg := fmt.Sprintf(`worker "%s" heart stopped`, e.workerID)
 	if e.err == nil {
-		return fmt.Sprintf(`worker "%s" heart stopped`, e.workerID)
+		return baseMsg
 	}
-	return fmt.Sprintf(`worker "%s" heart stopped: %s`, e.workerID, e.err)
+	return fmt.Sprintf("%s: %s", baseMsg, e.err)
 }
 
-type errReceiveAndWorkStopped struct {
+type errReceiverStopped struct {
+	workerID  string
+	queueName string
+	err       error
+}
+
+func (e *errReceiverStopped) Error() string {
+	baseMsg := fmt.Sprintf(
+		`worker "%s" receiver for queue "%s" stopped`,
+		e.workerID,
+		e.queueName,
+	)
+	if e.err == nil {
+		return baseMsg
+	}
+	return fmt.Sprintf("%s: %s", baseMsg, e.err)
+}
+
+type errTaskExecutorStopped struct {
 	workerID string
 	err      error
 }
 
-func (e *errReceiveAndWorkStopped) Error() string {
+func (e *errTaskExecutorStopped) Error() string {
+	baseMsg := fmt.Sprintf(`worker "%s" task executor stopped`, e.workerID)
 	if e.err == nil {
-		return fmt.Sprintf(`worker "%s" errReceiveAndWork stopped`, e.workerID)
+		return baseMsg
 	}
-	return fmt.Sprintf(
-		`worker "%s" errReceiveAndWork stopped: %s`,
+	return fmt.Sprintf("%s: %s", baseMsg, e.err)
+}
+
+type errDeferredTaskWatcherStopped struct {
+	workerID string
+	err      error
+}
+
+func (e *errDeferredTaskWatcherStopped) Error() string {
+	baseMsg := fmt.Sprintf(
+		`worker "%s" deferred task watcher stopped`,
 		e.workerID,
-		e.err,
 	)
+	if e.err == nil {
+		return baseMsg
+	}
+	return fmt.Sprintf("%s: %s", baseMsg, e.err)
 }
 
 type errDuplicateJob struct {
@@ -80,10 +114,15 @@ func (e *errDuplicateJob) Error() string {
 	return fmt.Sprintf(`duplicate job name "%s"`, e.name)
 }
 
-type errJobNotFound struct {
-	name string
+type errHeartbeat struct {
+	workerID string
+	err      error
 }
 
-func (e *errJobNotFound) Error() string {
-	return fmt.Sprintf(`no job named "%s" is registered with the worker`, e.name)
+func (e *errHeartbeat) Error() string {
+	return fmt.Sprintf(
+		`error sending heartbeat for worker "%s": %s`,
+		e.workerID,
+		e.err,
+	)
 }

--- a/pkg/async/fake/cleaner.go
+++ b/pkg/async/fake/cleaner.go
@@ -4,7 +4,7 @@ import "context"
 
 // Cleaner is a fake implementation of async.Cleaner used for testing
 type Cleaner struct {
-	RunBehavior RunFunction
+	RunBehavior RunFn
 }
 
 // NewCleaner returns a new, fake implementation of async.Cleaner used for
@@ -15,8 +15,8 @@ func NewCleaner() *Cleaner {
 	}
 }
 
-// Clean causes the cleaner to begin cleaning up after dead workers
-func (c *Cleaner) Clean(ctx context.Context) error {
+// Run causes the cleaner to clean up after dead workers
+func (c *Cleaner) Run(ctx context.Context) error {
 	return c.RunBehavior(ctx)
 }
 

--- a/pkg/async/fake/common.go
+++ b/pkg/async/fake/common.go
@@ -2,6 +2,6 @@ package fake
 
 import "context"
 
-// RunFunction describes a function used to provide pluggable runtime behavior
-// to various fake implementations of interfaces from the async package
-type RunFunction func(context.Context) error
+// RunFn describes a function used to provide pluggable runtime behavior to
+// various fake implementations of interfaces from the async package
+type RunFn func(context.Context) error

--- a/pkg/async/fake/engine.go
+++ b/pkg/async/fake/engine.go
@@ -9,7 +9,7 @@ import (
 // Engine is a fake implementation of async.Engine used for testing
 type Engine struct {
 	SubmittedTasks map[string]model.Task
-	RunBehavior    RunFunction
+	RunBehavior    RunFn
 }
 
 // NewEngine returns a new, fake implementation of async.Engine used for testing
@@ -21,7 +21,7 @@ func NewEngine() *Engine {
 }
 
 // RegisterJob registers a new Job with the async engine
-func (e *Engine) RegisterJob(name string, fn model.JobFunction) error {
+func (e *Engine) RegisterJob(name string, fn model.JobFn) error {
 	return nil
 }
 
@@ -32,8 +32,10 @@ func (e *Engine) SubmitTask(task model.Task) error {
 	return nil
 }
 
-// Start causes the async engine to begin executing queued tasks
-func (e *Engine) Start(ctx context.Context) error {
+// Run causes the async engine to carry out all of its functions. It blocks
+// until a fatal error is encountered or the context passed to it has been
+// canceled. Run always returns a non-nil error.
+func (e *Engine) Run(ctx context.Context) error {
 	return e.RunBehavior(ctx)
 }
 

--- a/pkg/async/fake/heart.go
+++ b/pkg/async/fake/heart.go
@@ -4,7 +4,7 @@ import "context"
 
 // Heart is a fake implementation of async.Heart used for testing
 type Heart struct {
-	RunBehavior RunFunction
+	RunBehavior RunFn
 }
 
 // NewHeart returns a new, fake implementation of async.Heart used for testing
@@ -19,8 +19,8 @@ func (*Heart) Beat() error {
 	return nil
 }
 
-// Start sends heartbeats at regular intervals
-func (h *Heart) Start(ctx context.Context) error {
+// Run sends heartbeats at regular intervals
+func (h *Heart) Run(ctx context.Context) error {
 	return h.RunBehavior(ctx)
 }
 

--- a/pkg/async/fake/worker.go
+++ b/pkg/async/fake/worker.go
@@ -8,7 +8,7 @@ import (
 
 // Worker is a fake implementation of async.Worker used for testing
 type Worker struct {
-	RunBehavior RunFunction
+	RunBehavior RunFn
 }
 
 // NewWorker returns a new, fake implementation of async.Worker used for testing
@@ -24,12 +24,12 @@ func (w *Worker) GetID() string {
 }
 
 // RegisterJob registers a new Job with the worker
-func (w *Worker) RegisterJob(name string, fn model.JobFunction) error {
+func (w *Worker) RegisterJob(name string, fn model.JobFn) error {
 	return nil
 }
 
-// Work causes the worker to begin processing tags
-func (w *Worker) Work(ctx context.Context) error {
+// Run causes the worker to process tasks
+func (w *Worker) Run(ctx context.Context) error {
 	return w.RunBehavior(ctx)
 }
 

--- a/pkg/async/heart_test.go
+++ b/pkg/async/heart_test.go
@@ -8,43 +8,89 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHeartBeatError(t *testing.T) {
-	workerID := getDisposableWorkerID()
-	h := newHeart(workerID, time.Second, redisClient).(*heart)
+func TestBeatError(t *testing.T) {
+	h := newHeart(getDisposableWorkerID(), time.Second, redisClient).(*heart)
+
+	// Override the default beat function to just returns an error
 	h.beat = func() error {
 		return errSome
 	}
+
 	err := h.Beat()
-	assert.Equal(t, &errHeartbeat{workerID: workerID, err: errSome}, err)
+
+	// Assert that the error returned from the Beat function wraps the error that
+	// the fake beat function generated
+	assert.Equal(t, &errHeartbeat{workerID: h.workerID, err: errSome}, err)
 }
 
-func TestHeartBeat(t *testing.T) {
+func TestHeartRunBlocksUntilBeatErrors(t *testing.T) {
 	h := newHeart(getDisposableWorkerID(), time.Second, redisClient).(*heart)
-	err := h.Beat()
+
+	h.beat = func() error {
+		return errSome
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- h.Run(ctx)
+	}()
+
+	// Assert that the error received from the Run function wraps the error that
+	// the overridden watchDeferredTask function generated
+	select {
+	case err := <-errCh:
+		assert.Equal(t, &errHeartbeat{workerID: h.workerID, err: errSome}, err)
+	case <-time.After(time.Second):
+		assert.Fail(t, "an error should have been received, but wasn't")
+	}
+}
+
+func TestHeartRunRespondsToContextCanceled(t *testing.T) {
+	h := newHeart(getDisposableWorkerID(), time.Second, redisClient).(*heart)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- h.Run(ctx)
+	}()
+
+	cancel()
+
+	// Assert that the error returned from Run indicates that the context was
+	// canceled
+	select {
+	case err := <-errCh:
+		assert.Equal(t, ctx.Err(), err)
+	case <-time.After(time.Second):
+		assert.Fail(
+			t,
+			"a context canceled error should have been returned, but wasn't",
+		)
+	}
+}
+
+// TestDefaultBeat tests the happy path for sending a single heartbeat. The
+// expected result is that the heartnbeat is visible, with a TTL, in Redis.
+func TestDefaultBeat(t *testing.T) {
+	h := newHeart(getDisposableWorkerID(), time.Second, redisClient).(*heart)
+
+	err := h.defaultBeat()
 	assert.Nil(t, err)
-	strCmd := redisClient.Get(getHeartbeatKey(h.workerID))
-	assert.Nil(t, strCmd.Err())
-	str, err := strCmd.Result()
+
+	// Assert that the heartbeat is visible, with a TTL, in Redis.
+	str, err := redisClient.Get(getHeartbeatKey(h.workerID)).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, aliveIndicator, str)
-}
-
-func TestHeartStartBlocksUntilBeatErrors(t *testing.T) {
-	workerID := getDisposableWorkerID()
-	h := newHeart(workerID, time.Second, redisClient).(*heart)
-	h.beat = func() error {
-		return errSome
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	err := h.Start(ctx)
-	assert.Equal(t, &errHeartbeat{workerID: workerID, err: errSome}, err)
-}
-
-func TestHeartStartBlocksUntilContextCanceled(t *testing.T) {
-	h := newHeart(getDisposableWorkerID(), time.Second, redisClient).(*heart)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	err := h.Start(ctx)
-	assert.Equal(t, ctx.Err(), err)
+	ttl, err := redisClient.TTL(getHeartbeatKey(h.workerID)).Result()
+	assert.Nil(t, err)
+	assert.True(t, ttl > 0)
 }

--- a/pkg/async/model/job.go
+++ b/pkg/async/model/job.go
@@ -2,6 +2,6 @@ package model
 
 import "context"
 
-// JobFunction is the signature for functions that workers can call to
-// asynchronously execute a job
-type JobFunction func(ctx context.Context, args map[string]string) error
+// JobFn is the signature for functions that workers can call to asynchronously
+// execute a job
+type JobFn func(ctx context.Context, args map[string]string) error

--- a/pkg/async/model/task_test.go
+++ b/pkg/async/model/task_test.go
@@ -30,7 +30,8 @@ func init() {
 			"id":"%s",
 			"jobName":"%s",
 			"args":{"%s":"%s"},
-			"workerRejectionCount": %d
+			"workerRejectionCount": %d,
+			"executeTime": null
 		}`,
 		testTask.GetID(),
 		jobName,

--- a/pkg/async/worker.go
+++ b/pkg/async/worker.go
@@ -12,8 +12,31 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-type receiveAndWorkFunction func(ctx context.Context, queueName string) error
-type workFunction func(ctx context.Context, task model.Task) error
+// receiveTasksFn defines functions used to receive tasks from one queue and
+// dispatch them to another
+type receiveTasksFn func(
+	ctx context.Context,
+	sourceQueueName string,
+	destinationQueueName string,
+	retCh chan []byte,
+	errCh chan error,
+)
+
+// executeTasksFn defines functions used to execute pending tasks
+type executeTasksFn func(
+	ctx context.Context,
+	inputCh chan []byte,
+	pendingTaskQueueName string,
+	errCh chan error,
+)
+
+// watchDeferredTaskFn defines functions used to watch a deferred task
+type watchDeferredTaskFn func(
+	ctx context.Context,
+	taskJSON []byte,
+	pendingTaskQueueName string,
+	errCh chan error,
+)
 
 // Worker is an interface to be implemented by components that receive and
 // asynchronously complete provisioning and deprovisioning tasks
@@ -21,9 +44,11 @@ type Worker interface {
 	// GetID returns the worker's ID
 	GetID() string
 	// RegisterJob registers a new Job with the worker
-	RegisterJob(name string, fn model.JobFunction) error
-	// Work causes the worker to begin completing tasks
-	Work(context.Context) error
+	RegisterJob(name string, fn model.JobFn) error
+	// Run causes the worker to complete tasks. It blocks until a fatal error is
+	// encountered or the context passed to it has been canceled. Run always
+	// returns a non-nil error.
+	Run(context.Context) error
 }
 
 // worker is a Redis-based implementation of the Worker interface
@@ -32,25 +57,31 @@ type worker struct {
 	redisClient *redis.Client
 	// This allows tests to inject an alternative implementation
 	heart        Heart
-	jobsFns      map[string]model.JobFunction
+	jobsFns      map[string]model.JobFn
 	jobsFnsMutex sync.RWMutex
 	// This allows tests to inject an alternative implementation of this function
-	receiveAndWork receiveAndWorkFunction
+	receivePendingTasks receiveTasksFn
 	// This allows tests to inject an alternative implementation of this function
-	work workFunction
+	receiveDeferredTasks receiveTasksFn
+	// This allows tests to inject an alternative implementation of this function
+	executeTasks executeTasksFn
+	// This allows tests to inject an alternative implementation of this function
+	watchDeferredTask watchDeferredTaskFn
 }
 
-// newWorker returns a new Reids-based implementation of the Worker interface
+// newWorker returns a new Redis-based implementation of the Worker interface
 func newWorker(redisClient *redis.Client) Worker {
 	workerID := uuid.NewV4().String()
 	w := &worker{
 		id:          workerID,
 		redisClient: redisClient,
 		heart:       newHeart(workerID, time.Second*30, redisClient),
-		jobsFns:     make(map[string]model.JobFunction),
+		jobsFns:     make(map[string]model.JobFn),
 	}
-	w.receiveAndWork = w.defaultReceiveAndWork
-	w.work = w.defaultWork
+	w.receivePendingTasks = w.defaultReceiveTasks
+	w.receiveDeferredTasks = w.defaultReceiveTasks
+	w.executeTasks = w.defaultExecuteTasks
+	w.watchDeferredTask = w.defaultWatchDeferredTask
 	return w
 }
 
@@ -60,7 +91,7 @@ func (w *worker) GetID() string {
 }
 
 // RegisterJob registers a new Job with the worker
-func (w *worker) RegisterJob(name string, fn model.JobFunction) error {
+func (w *worker) RegisterJob(name string, fn model.JobFn) error {
 	w.jobsFnsMutex.Lock()
 	defer w.jobsFnsMutex.Unlock()
 	if _, ok := w.jobsFns[name]; ok {
@@ -70,11 +101,13 @@ func (w *worker) RegisterJob(name string, fn model.JobFunction) error {
 	return nil
 }
 
-// Work causes the worker to begin completing tasks
-func (w *worker) Work(ctx context.Context) error {
+// Run causes the worker to complete tasks. It blocks until a fatal error is
+// encountered or the context passed to it has been canceled. Run always returns
+// a non-nil error.
+func (w *worker) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	errChan := make(chan error)
+	errCh := make(chan error)
 	// As soon as we add the worker to the workers set, it's eligible for the
 	// cleaner to clean up after it, so it's important that we guarantee the
 	// cleaner will see this worker as alive. We can't trust that the heartbeat
@@ -87,126 +120,217 @@ func (w *worker) Work(ctx context.Context) error {
 	// Heartbeat loop
 	go func() {
 		select {
-		case errChan <- &errHeartStopped{workerID: w.id, err: w.heart.Start(ctx)}:
+		case errCh <- &errHeartStopped{workerID: w.id, err: w.heart.Run(ctx)}:
 		case <-ctx.Done():
 		}
 	}()
 	// Announce this worker's existence
-	intCmd := w.redisClient.SAdd("workers", w.id)
-	if intCmd.Err() != nil {
+	err := w.redisClient.SAdd(workerSetName, w.id).Err()
+	if err != nil {
 		return fmt.Errorf(
 			`error adding worker "%s" to worker set: %s`,
 			w.id,
-			intCmd.Err(),
+			err,
 		)
 	}
-	// Receive and do work
-	for range [5]struct{}{} {
+	// Assemble and execute a pipeline to receive and execute pending tasks...
+	go func() {
+		pendingReceiverRetCh := make(chan []byte)
+		pendingReceiverErrCh := make(chan error)
+		executorErrCh := make(chan error)
+		go w.receivePendingTasks(
+			ctx,
+			pendingTaskQueueName,
+			getActiveTaskQueueName(w.id),
+			pendingReceiverRetCh,
+			pendingReceiverErrCh,
+		)
+		// Fan out to 5 executors
+		for range [5]struct{}{} {
+			go w.executeTasks(
+				ctx,
+				pendingReceiverRetCh,
+				pendingTaskQueueName,
+				executorErrCh,
+			)
+		}
+		select {
+		case err := <-pendingReceiverErrCh:
+			errCh <- &errReceiverStopped{
+				workerID:  w.id,
+				queueName: pendingTaskQueueName,
+				err:       err,
+			}
+		case err := <-executorErrCh:
+			errCh <- &errTaskExecutorStopped{workerID: w.id, err: err}
+		case <-ctx.Done():
+		}
+	}()
+	// Assemble and execute a pipeline to receive and watch deferred tasks...
+	go func() {
+		deferredReceiverRetCh := make(chan []byte)
+		deferredReceiverErrCh := make(chan error)
+		watcherErrCh := make(chan error)
+		go w.receiveDeferredTasks(
+			ctx,
+			deferredTaskQueueName,
+			getWatchedTaskQueueName(w.id),
+			deferredReceiverRetCh,
+			deferredReceiverErrCh,
+		)
+		// Fan out to as many watchers as we need
 		go func() {
-			select {
-			case errChan <- &errReceiveAndWorkStopped{
-				workerID: w.id,
-				err:      w.receiveAndWork(ctx, mainWorkQueueName),
-			}:
-			case <-ctx.Done():
+			for {
+				select {
+				case taskJSON := <-deferredReceiverRetCh:
+					w.watchDeferredTask(
+						ctx,
+						taskJSON,
+						pendingTaskQueueName,
+						watcherErrCh,
+					)
+				case <-ctx.Done():
+					return
+				}
 			}
 		}()
-	}
+		select {
+		case err := <-deferredReceiverErrCh:
+			errCh <- &errReceiverStopped{
+				workerID:  w.id,
+				queueName: deferredTaskQueueName,
+				err:       err,
+			}
+		case err := <-watcherErrCh:
+			errCh <- &errDeferredTaskWatcherStopped{workerID: w.id, err: err}
+		case <-ctx.Done():
+		}
+	}()
+	// Now wait...
 	select {
+	case err := <-errCh:
+		return err
 	case <-ctx.Done():
 		log.Debug("context canceled; async worker shutting down")
 		return ctx.Err()
-	case err := <-errChan:
-		return err
 	}
 }
 
-// defaultReceiveAndWork synchronously receives and completes work. By combining
-// these two operations, a worker never receives more work than it currently
-// has the capacity to process.
-func (w *worker) defaultReceiveAndWork(
+// defaultReceive receives tasks from a source queue and dispatches them to a
+// to both a destination queue and a return channel.
+func (w *worker) defaultReceiveTasks(
 	ctx context.Context,
-	queueName string,
-) error {
+	sourceQueueName string,
+	destinationQueueName string,
+	retCh chan []byte,
+	errCh chan error,
+) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	for {
-		strCmd := w.redisClient.BRPopLPush(
-			queueName,
-			getWorkerQueueName(w.id),
+		taskJSON, err := w.redisClient.BRPopLPush(
+			sourceQueueName,
+			destinationQueueName,
 			time.Second*5,
-		)
-		if strCmd.Err() != redis.Nil {
-			if strCmd.Err() != nil {
-				return fmt.Errorf("error receiving task: %s", strCmd.Err())
+		).Bytes()
+		if err == redis.Nil {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				continue
 			}
-			taskJSON, err := strCmd.Bytes()
-			if err != nil {
-				return fmt.Errorf("error receiving task: %s", err)
+		}
+		if err != nil {
+			select {
+			case errCh <- fmt.Errorf(
+				`error receiving task from queue "%s": %s`,
+				sourceQueueName,
+				err,
+			):
+				continue
+			case <-ctx.Done():
+				return
 			}
-			task, err := model.NewTaskFromJSON(taskJSON)
+		}
+		select {
+		case retCh <- taskJSON:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (w *worker) defaultExecuteTasks(
+	ctx context.Context,
+	inputCh chan []byte,
+	pendingTaskQueueName string,
+	errCh chan error,
+) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	for {
+		select {
+		case taskJSON := <-inputCh:
+			task, err := w.getTaskFromJSON(taskJSON, getActiveTaskQueueName(w.id))
 			if err != nil {
-				// If the JSON is invalid, remove the message from this worker's queue,
-				// log this and move on. No other worker is going to be able to process
-				// this-- there's nothing we can do and there's no sense letting this
-				// whole process die over this.
-				log.WithFields(log.Fields{
-					"taskJSON": taskJSON,
-					"error":    err,
-				}).Error("error decoding task")
-				intCmd := w.redisClient.LRem(
-					getWorkerQueueName(w.id),
-					0,
-					taskJSON,
-				)
-				if intCmd.Err() != nil {
-					return fmt.Errorf(
-						"error removing malformed task from the worker's work queue; "+
-							"task: %s: %s",
-						taskJSON,
+				select {
+				case errCh <- err:
+					continue
+				case <-ctx.Done():
+					return
+				}
+			}
+			if task == nil {
+				continue
+			}
+			w.jobsFnsMutex.RLock()
+			defer w.jobsFnsMutex.RUnlock()
+			jobFn, ok := w.jobsFns[task.GetJobName()]
+			if !ok {
+				// This worker doesn't know how to process this task. That doesn't mean
+				// another worker doesn't know how. Re-queue the task.
+				// krancour: This behavior is something we can revisit in the future,
+				// if and when we extract the async package into its own library.
+				// Construct and execute a transaction that removes the task from this
+				// worker's queue and re-queues it in the pending task queue.
+				task.IncrementWorkerRejectionCount()
+				newTaskJSON, err := task.ToJSON()
+				if err != nil {
+					select {
+					case errCh <- fmt.Errorf(
+						`error moving unprocessable task "%s" back to queue "%s": %s`,
+						task.GetID(),
+						pendingTaskQueueName,
 						err,
-					)
+					):
+						continue
+					case <-ctx.Done():
+						return
+					}
+				}
+				pipeline := w.redisClient.TxPipeline()
+				pipeline.LPush(pendingTaskQueueName, newTaskJSON)
+				pipeline.LRem(getActiveTaskQueueName(w.id), -1, taskJSON)
+				_, err = pipeline.Exec()
+				if err != nil {
+					select {
+					case errCh <- fmt.Errorf(
+						`error moving unprocessable task "%s" back to queue "%s": %s`,
+						task.GetID(),
+						pendingTaskQueueName,
+						err,
+					):
+					case <-ctx.Done():
+						return
+					}
 				}
 				continue
 			}
-			if err := w.work(ctx, task); err != nil {
-				if _, ok := err.(*errJobNotFound); ok {
-					// The error is that this worker doesn't know how to process this
-					// task. That doesn't mean another worker doesn't know how. Re-queue
-					// the task.
-					// krancour: This behavior is something we can revisit in the future
-					// if and when we extract the async package into its own library.
-					// Construct and execute a transaction that removes the task from this
-					// worker's queue and re-queues it in the main work queue.
-					task.IncrementWorkerRejectionCount()
-					newTaskJSON, err := task.ToJSON()
-					if err != nil {
-						return fmt.Errorf(
-							"error moving unprocessable task back to main work queue; task: %#v: %s",
-							task,
-							err,
-						)
-					}
-					pipeline := w.redisClient.TxPipeline()
-					pipeline.LPush(queueName, newTaskJSON)
-					pipeline.LRem(
-						getWorkerQueueName(w.id),
-						0,
-						taskJSON,
-					)
-					_, err = pipeline.Exec()
-					if err != nil {
-						return fmt.Errorf(
-							"error moving unprocessable task back to main work queue; task: %#v: %s",
-							task,
-							err,
-						)
-					}
-					continue
-				}
+			if err := jobFn(ctx, task.GetArgs()); err != nil {
 				// If we get to here, we have a legitimate failure executing the task.
 				// This isn't the worker's fault. Simply log this.
-				// krancour: This behavior is something we can revisit in the future if
+				// krancour: This behavior is something we can revisit in the future, if
 				// and when we extract the async package into its own library.
 				log.WithFields(log.Fields{
 					"job":    task.GetJobName(),
@@ -214,36 +338,119 @@ func (w *worker) defaultReceiveAndWork(
 					"error":  err,
 				}).Error("error executing job")
 			}
-			intCmd := w.redisClient.LRem(
-				getWorkerQueueName(w.id),
-				0,
-				taskJSON,
-			)
-			if intCmd.Err() != nil {
-				return fmt.Errorf(
-					`error removing task %s from worker "%s" work queue: %s`,
-					taskJSON,
+			// Regardless of success or failure, we're done with this task. Remove it
+			// from the active work queue.
+			err = w.redisClient.LRem(getActiveTaskQueueName(w.id), -1, taskJSON).Err()
+			if err != nil {
+				select {
+				case errCh <- fmt.Errorf(
+					`error removing task "%s" from queue "%s": %s`,
 					w.id,
+					getActiveTaskQueueName(w.id),
 					err,
-				)
+				):
+					continue
+				case <-ctx.Done():
+					return
+				}
 			}
-		}
-		select {
 		case <-ctx.Done():
-			return ctx.Err()
-		default:
+			return
 		}
 	}
 }
 
-func (w *worker) defaultWork(ctx context.Context, task model.Task) error {
+func (w *worker) defaultWatchDeferredTask(
+	ctx context.Context,
+	taskJSON []byte,
+	pendingTaskQueueName string,
+	errCh chan error,
+) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	w.jobsFnsMutex.RLock()
-	defer w.jobsFnsMutex.RUnlock()
-	jobFn, ok := w.jobsFns[task.GetJobName()]
-	if !ok {
-		return &errJobNotFound{name: task.GetJobName()}
+	task, err := w.getTaskFromJSON(taskJSON, getWatchedTaskQueueName(w.id))
+	if err != nil {
+		select {
+		case errCh <- err:
+		case <-ctx.Done():
+		}
+		return
 	}
-	return jobFn(ctx, task.GetArgs())
+	if task == nil {
+		return
+	}
+	executeTime := task.GetExecuteTime()
+	if executeTime == nil {
+		err := w.redisClient.LRem(getWatchedTaskQueueName(w.id), -1, taskJSON).Err()
+		if err != nil {
+			select {
+			case errCh <- fmt.Errorf(
+				`error removing task "%s" with no executeTime from queue "%s": %s`,
+				task.GetID(),
+				getWatchedTaskQueueName(w.id),
+				err,
+			):
+			case <-ctx.Done():
+			}
+			return
+		}
+		log.WithFields(log.Fields{
+			"task":  task.GetID(),
+			"queue": getWatchedTaskQueueName(w.id),
+		}).Error("deferred task had no executeTime and was removed from the queue")
+		return
+	}
+	// Note if the duration passed to the timer is 0 or negative, it should go
+	// off immediately
+	timer := time.NewTimer(time.Until(*executeTime))
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		// Move the task to the pending queue
+		pipeline := w.redisClient.TxPipeline()
+		pipeline.LPush(pendingTaskQueueName, taskJSON)
+		pipeline.LRem(getWatchedTaskQueueName(w.id), -1, taskJSON)
+		_, err := pipeline.Exec()
+		if err != nil {
+			select {
+			case errCh <- fmt.Errorf(
+				`error moving deferred task "%s" to queue "%s": %s`,
+				task.GetID(),
+				pendingTaskQueueName,
+				err,
+			):
+			case <-ctx.Done():
+			}
+		}
+	case <-ctx.Done():
+	}
+}
+
+func (w *worker) getTaskFromJSON(
+	taskJSON []byte,
+	queueName string,
+) (model.Task, error) {
+	task, err := model.NewTaskFromJSON(taskJSON)
+	if err != nil {
+		// If the JSON is invalid, remove the message from the queue, log this and
+		// move on. No other worker is going to be able to process this-- there's
+		// nothing we can do and there's no sense treating this as a fatal
+		// condition.
+		err := w.redisClient.LRem(queueName, -1, taskJSON).Err()
+		if err != nil {
+			return nil, fmt.Errorf(
+				`error removing malformed task from queue "%s"; task: %s: %s`,
+				queueName,
+				taskJSON,
+				err,
+			)
+		}
+		log.WithFields(log.Fields{
+			"queue":    queueName,
+			"taskJSON": taskJSON,
+			"error":    err,
+		}).Error("error decoding malformed task from queue")
+		return nil, nil
+	}
+	return task, nil
 }

--- a/pkg/async/worker_test.go
+++ b/pkg/async/worker_test.go
@@ -2,6 +2,7 @@ package async
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,221 +11,831 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWorkerGetsUniqueID(t *testing.T) {
-	// Create two workers-- make sure their IDs are at least different from one
-	// another
+func TestNewWorkersHaveUniqueIDs(t *testing.T) {
+	// Create two workers
 	w1 := newWorker(redisClient).(*worker)
 	w2 := newWorker(redisClient).(*worker)
+
+	// Assert that their IDs are at least different from one another
 	assert.NotEqual(t, w1.id, w2.id)
 }
 
-func TestWorkerWorkBlocksUntilHeartErrors(t *testing.T) {
+// TestWorkerRunBlocksUntilHeartStops tests what happens when a worker's heart
+// stops beating.
+func TestWorkerRunBlocksUntilHeartStops(t *testing.T) {
+	// Use a fake heart
 	h := fakeAsync.NewHeart()
+
+	// Specify the fake heart's runtime behavior should just return an error
 	h.RunBehavior = func(context.Context) error {
 		return errSome
 	}
+
 	w := newWorker(redisClient).(*worker)
+
+	// Make the worker use the fake heart
 	w.heart = h
-	receiveAndWorkStopped := false
-	w.receiveAndWork = func(ctx context.Context, queueName string) error {
+
+	// Override the worker's default receivePendingTasks function so it just
+	// communicates when the context it was passed has been canceled
+	contextCanceledCh := make(chan struct{})
+	w.receivePendingTasks = func(
+		ctx context.Context,
+		_ string,
+		_ string,
+		_ chan []byte,
+		_ chan error,
+	) {
 		<-ctx.Done()
-		receiveAndWorkStopped = true
-		return ctx.Err()
+		close(contextCanceledCh)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := w.Work(ctx)
-	assert.Equal(
-		t,
-		&errHeartStopped{workerID: w.id, err: errSome},
-		err,
-	)
-	time.Sleep(time.Second)
-	assert.True(t, receiveAndWorkStopped)
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- w.Run(ctx)
+	}()
+
+	// Assert that the error returned from the Run function wraps the error that
+	// the fake heart generated
+	select {
+	case err := <-errCh:
+		assert.Equal(t, &errHeartStopped{workerID: w.id, err: errSome}, err)
+	case <-time.After(time.Second):
+		assert.Fail(t, "an error should have been received, but wasn't")
+	}
+
+	// Assert that the context got canceled. It's helpful to know that when the
+	// heart stops, the rest of the worker components are also signaled to shut
+	// down.
+	select {
+	case <-contextCanceledCh:
+	case <-time.After(time.Second):
+		assert.Fail(t, "context should have been canceled, but it was not")
+	}
 }
 
-func TestWorkerWorkBlocksUntilHeartReturns(t *testing.T) {
+// TestWorkerRunBlocksUntilPendingReceiverStops tests what happens when a
+// worker's goroutine that receives pending tasks stops running.
+func TestWorkerRunBlocksUntilPendingReceiverStops(t *testing.T) {
+	// Use a fake heart
 	h := fakeAsync.NewHeart()
-	h.RunBehavior = func(context.Context) error {
-		return nil
-	}
-	w := newWorker(redisClient).(*worker)
-	w.heart = h
-	receiveAndWorkStopped := false
-	w.receiveAndWork = func(ctx context.Context, queueName string) error {
-		<-ctx.Done()
-		receiveAndWorkStopped = true
-		return ctx.Err()
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	err := w.Work(ctx)
-	assert.Equal(
-		t,
-		&errHeartStopped{workerID: w.id},
-		err,
-	)
-	time.Sleep(time.Second)
-	assert.True(t, receiveAndWorkStopped)
-}
 
-func TestWorkerWorkBlocksUntilReceiveAndWorkErrors(t *testing.T) {
-	h := fakeAsync.NewHeart()
-	heartStopped := false
+	// Specify the fake heart's runtime behavior should just communicates when the
+	// context it was passed has been canceled
+	contextCanceledCh := make(chan struct{})
 	h.RunBehavior = func(ctx context.Context) error {
 		<-ctx.Done()
-		heartStopped = true
+		close(contextCanceledCh)
 		return ctx.Err()
 	}
+
 	w := newWorker(redisClient).(*worker)
+
+	// Make the worker use the fake heart
 	w.heart = h
-	w.receiveAndWork = func(context.Context, string) error {
-		return errSome
+
+	// Override the worker's default receivePendingTasks function so it just
+	// returns an error and then blocks until the context it was passed is
+	// canceled
+	w.receivePendingTasks = func(
+		ctx context.Context,
+		_ string,
+		_ string,
+		_ chan []byte,
+		errCh chan error,
+	) {
+		select {
+		case errCh <- errSome:
+		case <-ctx.Done():
+		}
+		<-ctx.Done()
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := w.Work(ctx)
-	assert.Equal(
-		t,
-		&errReceiveAndWorkStopped{workerID: w.id, err: errSome},
-		err,
-	)
-	time.Sleep(time.Second)
-	assert.True(t, heartStopped)
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- w.Run(ctx)
+	}()
+
+	// Assert that the error received from the Run function wraps the error that
+	// the overridden receivePendingTasks function generated
+	select {
+	case err := <-errCh:
+		assert.Equal(
+			t,
+			&errReceiverStopped{
+				workerID:  w.id,
+				queueName: pendingTaskQueueName,
+				err:       errSome,
+			},
+			err,
+		)
+	case <-time.After(time.Second):
+		assert.Fail(t, "an error should have been received, but wasn't")
+	}
+
+	// Assert that the context got canceled. It's helpful to know that when the
+	// pending task receiver stops, the rest of the worker components are also
+	// signaled to shut down.
+	select {
+	case <-contextCanceledCh:
+	case <-time.After(time.Second):
+		assert.Fail(t, "context should have been canceled, but it was not")
+	}
 }
 
-func TestWorkerWorkBlocksUntilReceiveAndWorkReturns(t *testing.T) {
+// TestWorkerRunBlocksUntilExecuteTasksStops tests what happens when a worker's
+// goroutine that executes pending tasks stops.
+func TestWorkerRunBlocksUntilExecuteTasksStop(t *testing.T) {
+	// Use a fake heart
 	h := fakeAsync.NewHeart()
-	heartStopped := false
+
+	// Specify the fake heart's runtime behavior should just communicates when the
+	// context it was passed has been canceled
+	contextCanceledCh := make(chan struct{})
 	h.RunBehavior = func(ctx context.Context) error {
 		<-ctx.Done()
-		heartStopped = true
+		close(contextCanceledCh)
 		return ctx.Err()
 	}
+
 	w := newWorker(redisClient).(*worker)
+
+	// Make the worker use the fake heart
 	w.heart = h
-	w.receiveAndWork = func(context.Context, string) error {
-		return nil
+
+	// Override the worker's default executeTasks function so it just sends an
+	// error and then blocks until the context it was passed is canceled
+	w.executeTasks = func(
+		ctx context.Context,
+		_ chan []byte,
+		_ string,
+		errCh chan error,
+	) {
+		select {
+		case errCh <- errSome:
+		case <-ctx.Done():
+		}
+		<-ctx.Done()
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := w.Work(ctx)
-	assert.Equal(
-		t,
-		&errReceiveAndWorkStopped{workerID: w.id},
-		err,
-	)
-	time.Sleep(time.Second)
-	assert.True(t, heartStopped)
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- w.Run(ctx)
+	}()
+
+	// Assert that the error received from the Run function wraps the error that
+	// the overridden executeTasks function generated
+	select {
+	case err := <-errCh:
+		assert.Equal(t, &errTaskExecutorStopped{workerID: w.id, err: errSome}, err)
+	case <-time.After(time.Second):
+		assert.Fail(t, "an error should have been received, but wasn't")
+	}
+
+	// Assert that the context got canceled. It's helpful to know that when the
+	// task executor stops, the rest of the worker components are also signaled to
+	// shut down.
+	select {
+	case <-contextCanceledCh:
+	case <-time.After(time.Second):
+		assert.Fail(t, "context should have been canceled, but it was not")
+	}
 }
 
-func TestWorkerWorkBlocksUntilContextCanceled(t *testing.T) {
+// TestWorkerRunBlocksUntilDeferredReceiverStops tests what happens when a
+// worker's goroutine that receives deferred tasks stops.
+func TestWorkerRunBlocksUntilDeferredReceiverStops(t *testing.T) {
+	// Use a fake heart
 	h := fakeAsync.NewHeart()
-	heartStopped := false
+
+	// Specify the fake heart's runtime behavior should just communicates when the
+	// context it was passed has been canceled
+	contextCanceledCh := make(chan struct{})
 	h.RunBehavior = func(ctx context.Context) error {
 		<-ctx.Done()
-		heartStopped = true
+		close(contextCanceledCh)
 		return ctx.Err()
 	}
+
 	w := newWorker(redisClient).(*worker)
+
+	// Make the worker use the fake heart
 	w.heart = h
-	receiveAndWorkStopped := false
-	w.receiveAndWork = func(ctx context.Context, queueName string) error {
+
+	// Override the worker's default receiveDeferredTasks function so it just
+	// sends an error and then blocks until the context it was passed is canceled
+	w.receiveDeferredTasks = func(
+		ctx context.Context,
+		_ string,
+		_ string,
+		_ chan []byte,
+		errCh chan error,
+	) {
+		select {
+		case errCh <- errSome:
+		case <-ctx.Done():
+		}
 		<-ctx.Done()
-		receiveAndWorkStopped = true
-		return ctx.Err()
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := w.Work(ctx)
-	assert.Equal(t, ctx.Err(), err)
-	time.Sleep(time.Second)
-	assert.True(t, heartStopped)
-	assert.True(t, receiveAndWorkStopped)
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- w.Run(ctx)
+	}()
+
+	// Assert that the error received from the Run function wraps the error that
+	// the overridden receiveDeferredTasks function generated
+	select {
+	case err := <-errCh:
+		assert.Equal(
+			t,
+			&errReceiverStopped{
+				workerID:  w.id,
+				queueName: deferredTaskQueueName,
+				err:       errSome,
+			},
+			err,
+		)
+	case <-time.After(time.Second):
+		assert.Fail(t, "an error should have been received, but wasn't")
+	}
+
+	// Assert that the context got canceled. It's helpful to know that when the
+	// deferred task receiver stops, the rest of the worker components are also
+	// signaled to shut down.
+	select {
+	case <-contextCanceledCh:
+	case <-time.After(time.Second):
+		assert.Fail(t, "context should have been canceled, but it was not")
+	}
 }
 
-func TestReceiveAndWorkCallsWorkOncePerTask(t *testing.T) {
-	queueName := getDisposableQueueName()
-	const expectedCount = 5
-	for range [expectedCount]struct{}{} {
-		taskJSON, err := model.NewTask("foo", nil).ToJSON()
+// TestWorkerRunBlocksUntilWatchDeferredTaskErrors tests what happens when a
+// worker's goroutine that watches a deferred task errors.
+func TestWorkerRunBlocksUntilWatchDeferredTaskErrors(t *testing.T) {
+	// Use a fake heart
+	h := fakeAsync.NewHeart()
+
+	// Specify the fake heart's runtime behavior should just communicates when the
+	// context it was passed has been canceled
+	contextCanceledCh := make(chan struct{})
+	h.RunBehavior = func(ctx context.Context) error {
+		<-ctx.Done()
+		close(contextCanceledCh)
+		return ctx.Err()
+	}
+
+	w := newWorker(redisClient).(*worker)
+
+	// Make the worker use the fake heart
+	w.heart = h
+
+	// Override the worker's default receiveDeferredTasks function so it just
+	// sends a result (to trigger a new goroutine running the watchDeferredTask
+	// function) and then it blocks until the context it was passed is canceled.
+	w.receiveDeferredTasks = func(
+		ctx context.Context,
+		_ string,
+		_ string,
+		retCh chan []byte,
+		_ chan error,
+	) {
+		select {
+		case retCh <- []byte{}: // A dummy value is fine
+		case <-ctx.Done():
+		}
+		<-ctx.Done()
+	}
+
+	// Override the worker's default watchDeferredTask function so it just sends
+	// an error and then blocks until the context it was passed is canceled
+	w.watchDeferredTask = func(
+		ctx context.Context,
+		_ []byte,
+		_ string,
+		errCh chan error,
+	) {
+		select {
+		case errCh <- errSome:
+		case <-ctx.Done():
+		}
+		<-ctx.Done()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- w.Run(ctx)
+	}()
+
+	// Assert that the error received from the Run function wraps the error that
+	// the overridden watchDeferredTask function generated
+	select {
+	case err := <-errCh:
+		assert.Equal(
+			t,
+			&errDeferredTaskWatcherStopped{workerID: w.id, err: errSome},
+			err,
+		)
+	case <-time.After(time.Second):
+		assert.Fail(t, "an error should have been received, but wasn't")
+	}
+
+	// Assert that the context got canceled. It's helpful to know that when the
+	// a deferred task watcher errors, the rest of the worker components are also
+	// signaled to shut down.
+	select {
+	case <-contextCanceledCh:
+	case <-time.After(time.Second):
+		assert.Fail(t, "context should have been canceled, but it was not")
+	}
+}
+
+// TestWorkerRunRespondsToContextCanceled tests that canceling the context
+// passed to the Run function causes the Run function to return.
+func TestWorkerRunRespondsToContextCanceled(t *testing.T) {
+	// Use a fake heart
+	h := fakeAsync.NewHeart()
+
+	// Specify the fake heart's runtime behavior should just block until its
+	// context is canceled
+	h.RunBehavior = func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	w := newWorker(redisClient).(*worker)
+
+	// Make the worker use the fake heart
+	w.heart = h
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Call Run in a goroutine. If it never unblocks, as we hope it does, we don't
+	// want the test to stall.
+	errCh := make(chan error)
+	go func() {
+		errCh <- w.Run(ctx)
+	}()
+
+	cancel()
+
+	// Assert that the error returned from Run indicates that the context was
+	// canceled
+	select {
+	case err := <-errCh:
+		assert.Equal(t, ctx.Err(), err)
+	case <-time.After(time.Second):
+		assert.Fail(
+			t,
+			"a context canceled error should have been returned, but wasn't",
+		)
+	}
+}
+
+// TestDefaultReceiveTasks tests the happy path for the defaultReceiveTasks
+// function that transplants tasks from a source queue into a destination queue.
+func TestDefaultReceiveTasks(t *testing.T) {
+	w := newWorker(redisClient).(*worker)
+
+	sourceQueueName := getDisposableQueueName()
+	destinationQueueName := getDisposableQueueName()
+
+	// Put some tasks on the source task queue
+	const taskCount int64 = 5
+	for range [taskCount]struct{}{} {
+		// Dummy tasks are fine. This test won't ever parse them.
+		err := redisClient.LPush(sourceQueueName, "foo").Err()
 		assert.Nil(t, err)
-		intCmd := redisClient.LPush(queueName, taskJSON)
-		assert.Nil(t, intCmd.Err())
 	}
-	w := newWorker(redisClient).(*worker)
-	var workCount int
-	w.work = func(context.Context, model.Task) error {
-		workCount++
-		return nil
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
-	defer cancel()
-	err := w.receiveAndWork(ctx, queueName)
-	assert.Equal(t, ctx.Err(), err)
-	assert.Equal(t, expectedCount, workCount)
-	intCmd := redisClient.LLen(queueName)
-	assert.Nil(t, intCmd.Err())
-	currentMainQueueDepth, err := intCmd.Result()
-	assert.Nil(t, err)
-	assert.Empty(t, currentMainQueueDepth)
-	intCmd = redisClient.LLen(getWorkerQueueName(w.id))
-	assert.Nil(t, intCmd.Err())
-	currentWorkerQueueDepth, err := intCmd.Result()
-	assert.Nil(t, err)
-	assert.Empty(t, currentWorkerQueueDepth)
-}
 
-func TestWorkerReceiveAndWorkBlocksEvenAfterInvalidTask(t *testing.T) {
-	queueName := getDisposableQueueName()
-	intCmd := redisClient.LPush(queueName, "bogus")
-	assert.Nil(t, intCmd.Err())
-	w := newWorker(redisClient).(*worker)
-	workCalled := false
-	w.work = func(context.Context, model.Task) error {
-		workCalled = true
-		return nil
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
-	defer cancel()
-	err := w.receiveAndWork(ctx, queueName)
-	assert.Equal(t, ctx.Err(), err)
-	assert.False(t, workCalled)
-	intCmd = redisClient.LLen(queueName)
-	assert.Nil(t, intCmd.Err())
-	currentMainQueueDepth, err := intCmd.Result()
+	// Assert that the source queue has precisely taskCount tasks
+	sourceQueueDepth, err := redisClient.LLen(sourceQueueName).Result()
 	assert.Nil(t, err)
-	assert.Empty(t, currentMainQueueDepth)
-	intCmd = redisClient.LLen(getWorkerQueueName(w.id))
-	assert.Nil(t, intCmd.Err())
-	currentWorkerQueueDepth, err := intCmd.Result()
-	assert.Nil(t, err)
-	assert.Empty(t, currentWorkerQueueDepth)
-}
+	assert.Equal(t, taskCount, sourceQueueDepth)
 
-func TestWorkerReceiveAndWorkBlocksEvenAfterWorkError(t *testing.T) {
-	queueName := getDisposableQueueName()
-	taskJSON, err := model.NewTask("foo", nil).ToJSON()
+	// Assert that the destination queue is empty
+	destinationQueueDepth, err := redisClient.LLen(destinationQueueName).Result()
 	assert.Nil(t, err)
-	intCmd := redisClient.LPush(queueName, taskJSON)
-	assert.Nil(t, intCmd.Err())
-	w := newWorker(redisClient).(*worker)
-	workCalled := false
-	w.work = func(context.Context, model.Task) error {
-		workCalled = true
-		return errSome
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
-	defer cancel()
-	err = w.receiveAndWork(ctx, queueName)
-	assert.Equal(t, ctx.Err(), err)
-	assert.True(t, workCalled)
-}
+	assert.Empty(t, destinationQueueDepth)
 
-func TestWorkerReceiveAndWorkBlocksUntilContextCanceled(t *testing.T) {
-	w := newWorker(redisClient).(*worker)
+	// Under nominal conditions, defaultReceiveTasks blocks until the context it
+	// is passed is canceled. Use a context that will cancel itself after 1 second
+	// to make defaultReceiveTasks STOP working so we can then examine what it
+	// accomplished.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err := w.receiveAndWork(ctx, getDisposableQueueName())
-	assert.Equal(t, ctx.Err(), err)
+
+	retCh := make(chan []byte)
+	errCh := make(chan error)
+	go w.defaultReceiveTasks(
+		ctx,
+		sourceQueueName,
+		destinationQueueName,
+		retCh,
+		errCh,
+	)
+
+	// Start another goroutine to receive and count results
+	var resCount int64
+	go func() {
+		for {
+			select {
+			case <-retCh:
+				resCount++
+			case <-ctx.Done():
+			}
+		}
+	}()
+
+	select {
+	case <-errCh:
+		assert.Fail(t, "should not have received any error, but did")
+	case <-ctx.Done():
+	}
+
+	// Assert that precisely taskCount tasks were placed onto the return channel
+	assert.Equal(t, taskCount, resCount)
+
+	// Assert that the source task queue has been drained
+	sourceQueueDepth, err = redisClient.LLen(sourceQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, sourceQueueDepth)
+
+	// Assert that the destination queue now has precisely taskCount tasks
+	destinationQueueDepth, err = redisClient.LLen(destinationQueueName).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, taskCount, destinationQueueDepth)
+}
+
+func TestDefaultExecuteTasks(t *testing.T) {
+	w := newWorker(redisClient).(*worker)
+
+	pendingTaskQueueName := getDisposableQueueName()
+	activeTaskQueueName := getActiveTaskQueueName(w.id)
+
+	// Register some jobs with the worker
+	var badJobCallCount int
+	err := w.RegisterJob(
+		"badJob",
+		func(_ context.Context, _ map[string]string) error {
+			badJobCallCount++
+			return errors.New("a deliberate error")
+		},
+	)
+	assert.Nil(t, err)
+	var goodJobCallCount int
+	err = w.RegisterJob(
+		"goodJob",
+		func(_ context.Context, _ map[string]string) error {
+			goodJobCallCount++
+			return nil
+		},
+	)
+	assert.Nil(t, err)
+
+	// Define some tasks
+	invalidTaskJSON := []byte("bogus")
+	unregisteredTask := model.NewTask("nonExistingJob", map[string]string{})
+	unregisteredTaskJSON, err := unregisteredTask.ToJSON()
+	assert.Nil(t, err)
+	badTask := model.NewTask("badJob", map[string]string{})
+	badTaskJSON, err := badTask.ToJSON()
+	assert.Nil(t, err)
+	goodTask := model.NewTask("goodJob", map[string]string{})
+	goodTaskJSON, err := goodTask.ToJSON()
+	assert.Nil(t, err)
+	assert.Nil(t, err)
+	tasks := [][]byte{
+		invalidTaskJSON,
+		unregisteredTaskJSON,
+		badTaskJSON,
+		goodTaskJSON,
+	}
+
+	// Put all the tasks on the worker's active task queue
+	for _, task := range tasks {
+		err := redisClient.LPush(activeTaskQueueName, task).Err()
+		assert.Nil(t, err)
+	}
+
+	// Assert that the pending task queue is empty
+	pendingTaskQueueDepth, err := redisClient.LLen(pendingTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, pendingTaskQueueDepth)
+
+	// Assert that worker's active task queue has precisely len(tasks) tasks
+	activeTaskQueueDepth, err := redisClient.LLen(activeTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(len(tasks)), activeTaskQueueDepth)
+
+	// Under nominal conditions, defaultExecuteTasks blocks until the context it
+	// is passed is canceled. Use a context that will cancel itself after 1 second
+	// to make defaultExecuteTasks STOP working so we can then examine what it
+	// accomplished.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// Put all the tasks on the defaultExecuteTasks function's input channel
+	inputCh := make(chan []byte)
+	go func() {
+		for _, task := range tasks {
+			select {
+			case inputCh <- task:
+			case <-ctx.Done():
+			}
+		}
+	}()
+
+	errCh := make(chan error)
+	go w.defaultExecuteTasks(ctx, inputCh, pendingTaskQueueName, errCh)
+
+	select {
+	case <-errCh:
+		assert.Fail(t, "should not have received any error, but did")
+	case <-ctx.Done():
+	}
+
+	// Assert that the pending task queue has precisely one task-- the
+	// unprocessable task, which should have been returned to it
+	pendingTaskQueueDepth, err = redisClient.LLen(pendingTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), pendingTaskQueueDepth)
+
+	// Assert that the worker's active task queue is empty-- in all cases, the
+	// tasks should have been removed from this queue
+	activeTaskQueueDepth, err = redisClient.LLen(activeTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, activeTaskQueueDepth)
+
+	// Assert that the indicated jobs were invoked the appropriate number of times
+	assert.Equal(t, 1, badJobCallCount)
+	assert.Equal(t, 1, goodJobCallCount)
+}
+
+// TestDefaultWatchDeferredTaskWithInvalidTask tests a specific failure
+// condition for the defaultWatchDeferredTask function. The expected behavior is
+// that the task is discarded and the defaultWatchDeferredTask function adds no
+// error to its error channel.
+func TestDefaultWatchDeferredTaskWithInvalidTask(t *testing.T) {
+	w := newWorker(redisClient).(*worker)
+
+	pendingTaskQueueName := getDisposableQueueName()
+	watchedTaskQueueName := getWatchedTaskQueueName(w.id)
+
+	// Assert that the pending task queue is empty
+	pendingTaskQueueDepth, err := redisClient.LLen(pendingTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, pendingTaskQueueDepth)
+
+	// Put an invalid task (it isn't even JSON) on the worker's watched task queue
+	invalidTaskJSON := []byte("bogus")
+	err = redisClient.LPush(watchedTaskQueueName, invalidTaskJSON).Err()
+	assert.Nil(t, err)
+
+	// Assert that queue now has precisely 1 task
+	watchedTaskQueueDepth, err := redisClient.LLen(watchedTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), watchedTaskQueueDepth)
+
+	// Under nominal conditions, defaultWatchDeferredTask could block for a very
+	// long time, unless the context it is passed is canceled. Use a context that
+	// will cancel itself after 1 second to make defaultWatchDeferredTask STOP
+	// working so we can then examine what it accomplished.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// Call defaultWatchDeferredTask in a goroutine. Under nominal conditions,
+	// this function has the potential to run for a long time. In case the
+	// function doesn't handle the failure case we're testing properly and return
+	// quickly, we do not want to stall this test.
+	errCh := make(chan error)
+	go w.defaultWatchDeferredTask(
+		ctx,
+		invalidTaskJSON,
+		pendingTaskQueueName,
+		errCh,
+	)
+	select {
+	case <-errCh:
+		assert.Fail(t, "should not have received any error, but did")
+	case <-ctx.Done():
+	}
+
+	// Assert that the pending task queue is STILL empty
+	pendingTaskQueueDepth, err = redisClient.LLen(pendingTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, pendingTaskQueueDepth)
+
+	// And so is the worker's watched task queue
+	watchedTaskQueueDepth, err = redisClient.LLen(watchedTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, watchedTaskQueueDepth)
+}
+
+// TestDefaultWatchDeferredTaskWithTaskWithoutExecuteTime tests a specific
+// failure condition for the defaultWatchDeferredTask function. The expected
+// behavior is that the task is discarded and the defaultWatchDeferredTask
+// function adds no error to its error channel.
+func TestDefaultWatchDeferredTaskWithTaskWithoutExecuteTime(t *testing.T) {
+	w := newWorker(redisClient).(*worker)
+
+	pendingTaskQueueName := getDisposableQueueName()
+	watchedTaskQueueName := getWatchedTaskQueueName(w.id)
+
+	// Assert that the pending task queue is empty
+	pendingTaskQueueDepth, err := redisClient.LLen(pendingTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, pendingTaskQueueDepth)
+
+	// Put a task with no execute time on the worker's watched task queue
+	task := model.NewTask("foo", nil)
+	taskJSON, err := task.ToJSON()
+	assert.Nil(t, err)
+	err = redisClient.LPush(watchedTaskQueueName, taskJSON).Err()
+	assert.Nil(t, err)
+
+	// Assert that queue now has precisely 1 task
+	watchedTaskQueueDepth, err := redisClient.LLen(watchedTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), watchedTaskQueueDepth)
+
+	// Under nominal conditions, defaultWatchDeferredTask could block for a very
+	// long time, unless the context it is passed is canceled. Use a context that
+	// will cancel itself after 1 second to make defaultWatchDeferredTask STOP
+	// working so we can then examine what it accomplished.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// Call defaultWatchDeferredTask in a goroutine. Under nominal conditions,
+	// this function has the potential to run for a long time. In case the
+	// function doesn't handle the failure case we're testing properly and return
+	// quickly, we do not want to stall this test.
+	errCh := make(chan error)
+	go w.defaultWatchDeferredTask(
+		ctx,
+		taskJSON,
+		pendingTaskQueueName,
+		errCh,
+	)
+	select {
+	case <-errCh:
+		assert.Fail(t, "should not have received any error, but did")
+	case <-ctx.Done():
+	}
+
+	// Assert that the pending task queue is STILL empty
+	pendingTaskQueueDepth, err = redisClient.LLen(pendingTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, pendingTaskQueueDepth)
+
+	// And so is the worker's watched task queue
+	watchedTaskQueueDepth, err = redisClient.LLen(watchedTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, watchedTaskQueueDepth)
+}
+
+// TestDefaultWatchDeferredTaskWithLapsedTask tests that when
+// defaultWatchDeferredTask is invoked for a task whose execute time has already
+// lapsed, that task is moved IMMEDIATELY to the pending task queue.
+func TestDefaultWatchDeferredTaskWithLapsedTask(t *testing.T) {
+	w := newWorker(redisClient).(*worker)
+
+	pendingTaskQueueName := getDisposableQueueName()
+	watchedTaskQueueName := getWatchedTaskQueueName(w.id)
+
+	// Assert that the pending task queue is empty
+	pendingTaskQueueDepth, err := redisClient.LLen(pendingTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, pendingTaskQueueDepth)
+
+	// Put a lapsed task on the worker's watched task queue
+	task := model.NewDelayedTask("foo", nil, time.Second*-1)
+	taskJSON, err := task.ToJSON()
+	assert.Nil(t, err)
+	err = redisClient.LPush(watchedTaskQueueName, taskJSON).Err()
+	assert.Nil(t, err)
+
+	// Assert that queue now has precisely 1 task
+	watchedTaskQueueDepth, err := redisClient.LLen(watchedTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), watchedTaskQueueDepth)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Call defaultWatchDeferredTask in a goroutine. Under nominal conditions,
+	// this function has the potential to run for a long time, although in this
+	// edge case, it should not. In case the function doesn't handle the edge case
+	// we're testing properly and return quickly, we do not want to stall this
+	// test.
+	errCh := make(chan error)
+	go w.defaultWatchDeferredTask(
+		ctx,
+		taskJSON,
+		pendingTaskQueueName,
+		errCh,
+	)
+	select {
+	case <-errCh:
+		assert.Fail(t, "should not have received any error, but did")
+	case <-time.After(time.Second):
+	}
+
+	// Assert that the pending task queue now has precisely 1 task
+	pendingTaskQueueDepth, err = redisClient.LLen(pendingTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), pendingTaskQueueDepth)
+
+	// And the worker's watched task queue is now empty
+	watchedTaskQueueDepth, err = redisClient.LLen(watchedTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, watchedTaskQueueDepth)
+}
+
+// TestDefaultWatchDeferredTaskRespondsToCanceledContext tests that when
+// defaultWatchDeferredTask is waiting for a tasks execute time to lapse, it
+// will abort if context is canceled.
+func TestDefaultWatchDeferredTaskRespondsToCanceledContext(t *testing.T) {
+	w := newWorker(redisClient).(*worker)
+
+	pendingTaskQueueName := getDisposableQueueName()
+	watchedTaskQueueName := getWatchedTaskQueueName(w.id)
+
+	// Assert that the pending task queue is empty
+	pendingTaskQueueDepth, err := redisClient.LLen(pendingTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, pendingTaskQueueDepth)
+
+	// Put task with a future execute time on the worker's watched tasks queue
+	task := model.NewDelayedTask("foo", nil, time.Second*5)
+	taskJSON, err := task.ToJSON()
+	assert.Nil(t, err)
+	err = redisClient.LPush(watchedTaskQueueName, taskJSON).Err()
+	assert.Nil(t, err)
+
+	// Assert that queue now has precisely 1 task
+	watchedTaskQueueDepth, err := redisClient.LLen(watchedTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), watchedTaskQueueDepth)
+
+	// Use a context that will cancel itself in 1 second to put a time limit
+	// on the test. This context will be canceled BEFORE the execute time lapses.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// Call defaultWatchDeferredTask in a goroutine. Under nominal conditions,
+	// this function has the potential to run for a long time. In case the
+	// function doesn't handle context cancelation properly and return quickly, we
+	// do not want to stall this test.
+	errCh := make(chan error)
+	go w.defaultWatchDeferredTask(
+		ctx,
+		taskJSON,
+		pendingTaskQueueName,
+		errCh,
+	)
+	select {
+	case <-errCh:
+		assert.Fail(t, "should not have received any error, but did")
+	case <-ctx.Done():
+	}
+
+	// Because the context was canceled BEFORE the execute time lapsed, nothing
+	// should have changed in the queues....
+
+	// Assert that the pending task queue is STILL empty
+	pendingTaskQueueDepth, err = redisClient.LLen(pendingTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Empty(t, pendingTaskQueueDepth)
+
+	// And the worker's watched task STILL has precisely 1 task
+	watchedTaskQueueDepth, err = redisClient.LLen(watchedTaskQueueName).Result()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), watchedTaskQueueDepth)
 }

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -139,7 +139,7 @@ func (b *broker) Start(ctx context.Context) error {
 	// Start async engine
 	go func() {
 		select {
-		case errChan <- &errAsyncEngineStopped{err: b.asyncEngine.Start(ctx)}:
+		case errChan <- &errAsyncEngineStopped{err: b.asyncEngine.Run(ctx)}:
 		case <-ctx.Done():
 		}
 	}()

--- a/tests/lifecycle/driver_test.go
+++ b/tests/lifecycle/driver_test.go
@@ -14,7 +14,7 @@ func TestServices(t *testing.T) {
 	resourceGroup := "test-" + uuid.NewV4().String()
 
 	log.Printf("----> creating resource group \"%s\"\n", resourceGroup)
-	err := ensureResourceGroup(resourceGroup, "eastus")
+	err := ensureResourceGroup(resourceGroup)
 	assert.Nil(t, err)
 	log.Printf("----> created resource group \"%s\"\n", resourceGroup)
 

--- a/tests/lifecycle/groups_client_test.go
+++ b/tests/lifecycle/groups_client_test.go
@@ -8,11 +8,12 @@ import (
 	az "github.com/Azure/open-service-broker-azure/pkg/azure"
 )
 
-func ensureResourceGroup(resourceGroup string, location string) error {
+func ensureResourceGroup(resourceGroup string) error {
 	groupsClient, err := getGroupsClient()
 	if err != nil {
 		return err
 	}
+	location := "eastus"
 	_, err = groupsClient.CreateOrUpdate(
 		resourceGroup,
 		resources.Group{


### PR DESCRIPTION
Achieving this (_cleanly_) involved a significant refactor of the entire package. The good news is that the tests are improved beyond what we had before (and liberally annotated now), so i think we can be more confident in the refactored package than the original.

Note to @jeremyrickard. After this is merged into master, we should merge the latest from master into the branch for #124, then rebase #204. #204 should be updated to deal _only_ with deferred child provisioning / deferred parent deprovisioning, and not concern itself with the internals of the async engine.