### PR TITLE
gitignore .vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .glide/
+.vscode/
 bin/
 _vendor-*/
 vendor.orig/


### PR DESCRIPTION
Discovered recently that this is a common file that exists, depending on what VS Code (common on our team) plugins are installed / enabled. Best to ensure it's .gitignored.