### PR TITLE
[Proposal] Add migration plan for vm/db only manager for sqldb

### DIFF
--- a/pkg/services/sqldb/catalog.go
+++ b/pkg/services/sqldb/catalog.go
@@ -165,6 +165,12 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				Description: "Azure SQL Server VM Only",
 				Free:        false,
 			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "2bff6bfc-8ee4-4893-8a99-db092928436d",
+				Name:        "migration",
+				Description: "Base on existing server on Azure",
+				Free:        false,
+			}),
 		),
 		// db only service
 		service.NewService(
@@ -308,6 +314,12 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 					"requestedServiceObjectiveName": "DW1200",
 					"maxSizeBytes":                  "1099511627776",
 				},
+			}),
+			service.NewPlan(&service.PlanProperties{
+				ID:          "35dc0d0b-04a2-4101-a4c3-ee9ef0df04b6",
+				Name:        "migration",
+				Description: "Base on existing database on Azure",
+				Free:        false,
 			}),
 		),
 	}), nil

--- a/pkg/services/sqldb/types.go
+++ b/pkg/services/sqldb/types.go
@@ -5,12 +5,17 @@ import "github.com/Azure/open-service-broker-azure/pkg/service"
 // ServerProvisioningParams encapsulates MSSQL-server specific provisioning
 //options
 type ServerProvisioningParams struct {
-	FirewallIPStart string `json:"firewallStartIPAddress"`
-	FirewallIPEnd   string `json:"firewallEndIPAddress"`
+	FirewallIPStart            string `json:"firewallStartIPAddress"`
+	FirewallIPEnd              string `json:"firewallEndIPAddress"`
+	ResourceGroup              string `json:"resourceGroup"`
+	ServerName                 string `json:"serverName"`
+	AdministratorLogin         string `json:"administratorLogin"`
+	AdministratorLoginPassword string `json:"administratorLoginPassword"`
 }
 
 // DBProvisioningParams encapsulates MSSQL-specific provisioning options
 type DBProvisioningParams struct {
+	DatabaseName string `json:"databaseName"`
 }
 
 type mssqlAllInOneInstanceDetails struct {


### PR DESCRIPTION
Hi @krancour and @arschles,
This PR is not requesting merging but only to better describe what we propose to add.
Just like what we discussed in the email thread, we can still support the migration from MASB based on your design for https://github.com/Azure/open-service-broker-azure/issues/124 by adding migration plans.
Besides the migration from MASB, users who want to integrate their existing Azure SQL services into the broker also benefit from it. We may consider that the operator already created an advanced configured server (e.g. with auditing output to a storage).
What do you think? I would like to work on it when you finish your works and merge the feature branch into master, if you like the idea.