### PR TITLE
fix async cleaner

### DIFF
--- a/pkg/async/redis/engine_test.go
+++ b/pkg/async/redis/engine_test.go
@@ -21,14 +21,14 @@ func TestRunBlocksUntilCleanReturnsError(t *testing.T) {
 	e := getTestEngine()
 
 	// Override the engine's clean function so it just returns an error
-	e.clean = func(context.Context, string, string, string) error {
+	e.clean = func(context.Context, string, string, string, time.Duration) error {
 		return errSome
 	}
 
 	// Override the engine's runHeart function so it just communicates when the
 	// context it was passed has been canceled
 	contextCanceledCh := make(chan struct{})
-	e.runHeart = func(ctx context.Context) error {
+	e.runHeart = func(ctx context.Context, _ time.Duration) error {
 		<-ctx.Done()
 		close(contextCanceledCh)
 		return ctx.Err()
@@ -69,14 +69,20 @@ func TestRunBlocksUntilRunHeartReturnsError(t *testing.T) {
 	// Override the engine's clean function so it just communicates when the
 	// context it was passed has been canceled
 	contextCanceledCh := make(chan struct{})
-	e.clean = func(ctx context.Context, _ string, _ string, _ string) error {
+	e.clean = func(
+		ctx context.Context,
+		_ string,
+		_ string,
+		_ string,
+		_ time.Duration,
+	) error {
 		<-ctx.Done()
 		close(contextCanceledCh)
 		return ctx.Err()
 	}
 
 	// Override the engine's runHeart function so it just returns an error
-	e.runHeart = func(context.Context) error {
+	e.runHeart = func(context.Context, time.Duration) error {
 		return errSome
 	}
 
@@ -115,7 +121,13 @@ func TestRunBlocksUntilReceivePendingTasksSendsError(t *testing.T) {
 	// Override the engine's clean function so it just communicates when the
 	// context it was passed has been canceled
 	contextCanceledCh := make(chan struct{})
-	e.clean = func(ctx context.Context, _ string, _ string, _ string) error {
+	e.clean = func(
+		ctx context.Context,
+		_ string,
+		_ string,
+		_ string,
+		_ time.Duration,
+	) error {
 		<-ctx.Done()
 		close(contextCanceledCh)
 		return ctx.Err()
@@ -179,7 +191,13 @@ func TestRunBlocksUntilExecuteTasksSendsError(t *testing.T) {
 	// Override the engine's clean function so it just communicates when the
 	// context it was passed has been canceled
 	contextCanceledCh := make(chan struct{})
-	e.clean = func(ctx context.Context, _ string, _ string, _ string) error {
+	e.clean = func(
+		ctx context.Context,
+		_ string,
+		_ string,
+		_ string,
+		_ time.Duration,
+	) error {
 		<-ctx.Done()
 		close(contextCanceledCh)
 		return ctx.Err()
@@ -241,7 +259,13 @@ func TestRunBlocksUntilReceiveDeferredTasksSendError(t *testing.T) {
 	// Override the engine's clean function so it just communicates when the
 	// context it was passed has been canceled
 	contextCanceledCh := make(chan struct{})
-	e.clean = func(ctx context.Context, _ string, _ string, _ string) error {
+	e.clean = func(
+		ctx context.Context,
+		_ string,
+		_ string,
+		_ string,
+		_ time.Duration,
+	) error {
 		<-ctx.Done()
 		close(contextCanceledCh)
 		return ctx.Err()
@@ -374,7 +398,13 @@ func TestRunRespondsToCanceledContext(t *testing.T) {
 	// Override the engine's clean function so it just communicates when the
 	// context it was passed has been canceled
 	contextCanceledCh := make(chan struct{})
-	e.clean = func(ctx context.Context, _ string, _ string, _ string) error {
+	e.clean = func(
+		ctx context.Context,
+		_ string,
+		_ string,
+		_ string,
+		_ time.Duration,
+	) error {
 		<-ctx.Done()
 		close(contextCanceledCh)
 		return ctx.Err()
@@ -412,12 +442,18 @@ func TestRunRespondsToCanceledContext(t *testing.T) {
 func getTestEngine() *engine {
 	e := NewEngine(redisClient).(*engine)
 	// Cleaner loop
-	e.clean = func(ctx context.Context, _ string, _ string, _ string) error {
+	e.clean = func(
+		ctx context.Context,
+		_ string,
+		_ string,
+		_ string,
+		_ time.Duration,
+	) error {
 		<-ctx.Done()
 		return ctx.Err()
 	}
 	// Heartbeat loop
-	e.runHeart = func(ctx context.Context) error {
+	e.runHeart = func(ctx context.Context, _ time.Duration) error {
 		<-ctx.Done()
 		return ctx.Err()
 	}

--- a/pkg/async/redis/heart_test.go
+++ b/pkg/async/redis/heart_test.go
@@ -12,7 +12,7 @@ func TestDefaultRunHeartBlocksUntilBeatErrors(t *testing.T) {
 	e := NewEngine(redisClient).(*engine)
 
 	// Override default heartbeat function so it just returns an error
-	e.heartbeat = func() error {
+	e.heartbeat = func(time.Duration) error {
 		return errSome
 	}
 
@@ -23,7 +23,7 @@ func TestDefaultRunHeartBlocksUntilBeatErrors(t *testing.T) {
 	// does, we don't want the test to stall.
 	errCh := make(chan error)
 	go func() {
-		errCh <- e.defaultRunHeart(ctx)
+		errCh <- e.defaultRunHeart(ctx, time.Second)
 	}()
 
 	// Assert that the error received from the defaultRunHeart function is the
@@ -46,7 +46,7 @@ func TestDefaultRunHeartRespondsToCanceledContext(t *testing.T) {
 	// does, we don't want the test to stall.
 	errCh := make(chan error)
 	go func() {
-		errCh <- e.defaultRunHeart(ctx)
+		errCh <- e.defaultRunHeart(ctx, time.Second)
 	}()
 
 	cancel()
@@ -67,7 +67,7 @@ func TestDefaultRunHeartRespondsToCanceledContext(t *testing.T) {
 func TestDefaultHeartbeat(t *testing.T) {
 	e := NewEngine(redisClient).(*engine)
 
-	err := e.defaultHeartbeat()
+	err := e.defaultHeartbeat(time.Second)
 	assert.Nil(t, err)
 
 	// Assert that the heartbeat is visible, with a TTL, in Redis.


### PR DESCRIPTION
This is a critical bug fix.

After #219, the function the (default) implements the async engine's dead worker cleanup is mistakenly not a loop. This being the case, and with nothing to clean, the cleaner returns a nil error right away. The engine is designed to stop if any one component stops. So, in this case, the cleaner returning quickly prevents the engine from running for more than a split second.

And that's not to mention that _not_ cleaning at regular intervals (e.g. in a loop) is obviously wrong to begin with.

Also, make note of some related changes:

The default cleaning interval is 30 seconds. Waiting 30 seconds for the first cleanup to take place can really slow down tests, so I've made it that the cleaning interval can be passed into the clean function. For the sake of keeping things tidy and similar, it made sense to give the heart the same treatment-- especially since the intervals passed to the cleaner and heart are related.