### PR TITLE
[docs] remove kube-system serviceaccount cluster-admin role

### DIFF
--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -178,10 +178,6 @@ Next we will create a local cluster using Minikube. You can also [try OSBA on th
     ```console
     minikube start --extra-config=apiserver.Authorization.Mode=RBAC
     ```
-1. Grant the `cluster-admin` role to the default system account:
-    ```console
-    kubectl create clusterrolebinding cluster-admin:kube-system --clusterrole=cluster-admin --serviceaccount=kube-system:default
-    ```
 
 ### Configure the cluster with Open Service Broker for Azure
 


### PR DESCRIPTION
Looks like this isn't really needed. The only reason it may have been there, from what I can tell, is for Tiller but the following steps install Tiller with a specific service account. Nothing else is installed in the kube-system namespace.