### PR TITLE
add support for CF to configure basic auth via tiles

### DIFF
--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -136,8 +136,8 @@ func main() {
 		filterChain,
 		modules,
 		modulesConfig.GetMinStability(),
-		azureConfig.DefaultLocation,
-		azureConfig.DefaultResourceGroup,
+		azureConfig.GetDefaultLocation(),
+		azureConfig.GetDefaultResourceGroup(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -105,7 +105,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	codec, err := aes256.NewCodec([]byte(cryptoConfig.AES256Key))
+	codec, err := aes256.NewCodec([]byte(cryptoConfig.GetAES256Key()))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -135,7 +135,7 @@ func main() {
 		codec,
 		filterChain,
 		modules,
-		modulesConfig.MinStability,
+		modulesConfig.GetMinStability(),
 		azureConfig.DefaultLocation,
 		azureConfig.DefaultResourceGroup,
 	)

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -40,11 +40,12 @@ func main() {
 		log.Fatal(err)
 	}
 	log.SetLevel(log.InfoLevel)
+	logLevel := logConfig.GetLevel()
 	log.WithField(
 		"logLevel",
-		strings.ToUpper(logConfig.Level.String()),
+		strings.ToUpper(logLevel.String()),
 	).Info("setting log level")
-	log.SetLevel(logConfig.Level)
+	log.SetLevel(logLevel)
 
 	azureConfig, err := config.GetAzureConfig()
 	if err != nil {

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -117,8 +117,8 @@ func main() {
 	}
 	filterChain := filter.NewChain(
 		filters.NewBasicAuthFilter(
-			basicAuthConfig.Username,
-			basicAuthConfig.Password,
+			basicAuthConfig.GetUsername(),
+			basicAuthConfig.GetPassword(),
 		),
 		apiFilters.NewAPIVersionFilter(),
 	)

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -70,23 +70,31 @@ func main() {
 		log.Fatal(err)
 	}
 	storageRedisOpts := &redis.Options{
-		Addr:       fmt.Sprintf("%s:%d", redisConfig.Host, redisConfig.Port),
-		Password:   redisConfig.Password,
-		DB:         redisConfig.StorageDB,
+		Addr: fmt.Sprintf(
+			"%s:%d",
+			redisConfig.GetHost(),
+			redisConfig.GetPort(),
+		),
+		Password:   redisConfig.GetPassword(),
+		DB:         redisConfig.GetStorageDB(),
 		MaxRetries: 5,
 	}
 	asyncRedisOpts := &redis.Options{
-		Addr:       fmt.Sprintf("%s:%d", redisConfig.Host, redisConfig.Port),
-		Password:   redisConfig.Password,
-		DB:         redisConfig.AsyncDB,
+		Addr: fmt.Sprintf(
+			"%s:%d",
+			redisConfig.GetHost(),
+			redisConfig.GetPort(),
+		),
+		Password:   redisConfig.GetPassword(),
+		DB:         redisConfig.GetAsyncDB(),
 		MaxRetries: 5,
 	}
-	if redisConfig.EnableTLS {
+	if redisConfig.IsTLSEnabled() {
 		storageRedisOpts.TLSConfig = &tls.Config{
-			ServerName: redisConfig.Host,
+			ServerName: redisConfig.GetHost(),
 		}
 		asyncRedisOpts.TLSConfig = &tls.Config{
-			ServerName: redisConfig.Host,
+			ServerName: redisConfig.GetHost(),
 		}
 	}
 	storageRedisClient := redis.NewClient(storageRedisOpts)

--- a/cmd/broker/modules.go
+++ b/cmd/broker/modules.go
@@ -37,25 +37,28 @@ import (
 var modules []service.Module
 
 func initModules(azureConfig config.AzureConfig) error {
+	azureEnvironment := azureConfig.GetEnvironment()
+	azureSubscriptionID := azureConfig.GetSubscriptionID()
+
 	authorizer, err := az.GetBearerTokenAuthorizer(
-		azureConfig.Environment,
-		azureConfig.TenantID,
-		azureConfig.ClientID,
-		azureConfig.ClientSecret,
+		azureEnvironment,
+		azureConfig.GetTenantID(),
+		azureConfig.GetClientID(),
+		azureConfig.GetClientSecret(),
 	)
 	if err != nil {
 		return fmt.Errorf("error getting bearer token authorizer: %s", err)
 	}
 
 	resourceGroupsClient := resources.NewGroupsClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	resourceGroupsClient.Authorizer = authorizer
 	resourceGroupsClient.UserAgent = getUserAgent(resourceGroupsClient.Client)
 	resourceDeploymentsClient := resources.NewDeploymentsClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	resourceDeploymentsClient.Authorizer = authorizer
 	resourceDeploymentsClient.UserAgent =
@@ -66,86 +69,86 @@ func initModules(azureConfig config.AzureConfig) error {
 	)
 
 	aciClient := aciSDK.NewContainerGroupsClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	aciClient.Authorizer = authorizer
 	aciClient.UserAgent = getUserAgent(aciClient.Client)
 
 	cosmosdbAccountsClient := cosmosSDK.NewDatabaseAccountsClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	cosmosdbAccountsClient.Authorizer = authorizer
 	cosmosdbAccountsClient.UserAgent = getUserAgent(cosmosdbAccountsClient.Client)
 
 	eventHubNamespacesClient := eventHubSDK.NewNamespacesClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	eventHubNamespacesClient.Authorizer = authorizer
 	eventHubNamespacesClient.UserAgent =
 		getUserAgent(eventHubNamespacesClient.Client)
 
 	keyVaultsClient := keyVaultSDK.NewVaultsClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	keyVaultsClient.Authorizer = authorizer
 	keyVaultsClient.UserAgent = getUserAgent(keyVaultsClient.Client)
 
 	mysqlServersClient := mysqlSDK.NewServersClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	mysqlServersClient.Authorizer = authorizer
 	mysqlServersClient.UserAgent = getUserAgent(mysqlServersClient.Client)
 
 	postgresServersClient := postgresSDK.NewServersClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	postgresServersClient.Authorizer = authorizer
 	postgresServersClient.UserAgent = getUserAgent(postgresServersClient.Client)
 
 	sqlServersClient := sqlSDK.NewServersClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	sqlServersClient.Authorizer = authorizer
 	sqlServersClient.UserAgent = getUserAgent(sqlServersClient.Client)
 	sqlDatabasesClient := sqlSDK.NewDatabasesClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	sqlDatabasesClient.Authorizer = authorizer
 	sqlDatabasesClient.UserAgent = getUserAgent(sqlDatabasesClient.Client)
 
 	redisGroupClient := redisSDK.NewGroupClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	redisGroupClient.Authorizer = authorizer
 	redisGroupClient.UserAgent = getUserAgent(redisGroupClient.Client)
 
 	searchServicesClient := searchSDK.NewServicesClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	searchServicesClient.Authorizer = authorizer
 	searchServicesClient.UserAgent = getUserAgent(searchServicesClient.Client)
 
 	serviceBusNamespacesClient := servicebusSDK.NewNamespacesClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	serviceBusNamespacesClient.Authorizer = authorizer
 	serviceBusNamespacesClient.UserAgent =
 		getUserAgent(serviceBusNamespacesClient.Client)
 
 	storageAccountsClient := storageSDK.NewAccountsClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	storageAccountsClient.Authorizer = authorizer
 	storageAccountsClient.UserAgent = getUserAgent(storageAccountsClient.Client)
@@ -153,12 +156,12 @@ func initModules(azureConfig config.AzureConfig) error {
 	modules = []service.Module{
 		postgresqldb.New(armDeployer, postgresServersClient),
 		rediscache.New(armDeployer, redisGroupClient),
-		mysqldb.New(azureConfig.Environment, armDeployer, mysqlServersClient),
+		mysqldb.New(azureEnvironment, armDeployer, mysqlServersClient),
 		servicebus.New(armDeployer, serviceBusNamespacesClient),
 		eventhubs.New(armDeployer, eventHubNamespacesClient),
-		keyvault.New(azureConfig.TenantID, armDeployer, keyVaultsClient),
+		keyvault.New(azureConfig.GetTenantID(), armDeployer, keyVaultsClient),
 		sqldb.New(
-			azureConfig.Environment,
+			azureEnvironment,
 			armDeployer,
 			sqlServersClient,
 			sqlDatabasesClient,

--- a/pkg/config/azure.go
+++ b/pkg/config/azure.go
@@ -1,20 +1,9 @@
 package config
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/kelseyhightower/envconfig"
 )
-
-// ModulesConfig represents details re: which modules should be included or
-// excluded when the broker is started
-type ModulesConfig struct {
-	MinStabilityStr string `envconfig:"MIN_STABILITY" default:"EXPERIMENTAL"`
-	MinStability    service.Stability
-}
 
 // AzureConfig represents details necessary for the broker to interact with
 // an Azure subscription
@@ -27,30 +16,6 @@ type AzureConfig struct {
 	ClientSecret         string `envconfig:"AZURE_CLIENT_SECRET" required:"true"`
 	DefaultLocation      string `envconfig:"AZURE_DEFAULT_LOCATION"`
 	DefaultResourceGroup string `envconfig:"AZURE_DEFAULT_RESOURCE_GROUP"`
-}
-
-// GetModulesConfig returns modules configuration
-func GetModulesConfig() (ModulesConfig, error) {
-	mc := ModulesConfig{}
-	err := envconfig.Process("", &mc)
-	if err != nil {
-		return mc, err
-	}
-	minStabilityStr := strings.ToUpper(mc.MinStabilityStr)
-	switch minStabilityStr {
-	case "EXPERIMENTAL":
-		mc.MinStability = service.StabilityExperimental
-	case "PREVIEW":
-		mc.MinStability = service.StabilityPreview
-	case "STABLE":
-		mc.MinStability = service.StabilityStable
-	default:
-		return mc, fmt.Errorf(
-			`unrecognized stability level "%s"`,
-			minStabilityStr,
-		)
-	}
-	return mc, nil
 }
 
 // GetAzureConfig returns Azure subscription configuration

--- a/pkg/config/azure.go
+++ b/pkg/config/azure.go
@@ -7,7 +7,17 @@ import (
 
 // AzureConfig represents details necessary for the broker to interact with
 // an Azure subscription
-type AzureConfig struct {
+type AzureConfig interface {
+	GetEnvironment() azure.Environment
+	GetSubscriptionID() string
+	GetTenantID() string
+	GetClientID() string
+	GetClientSecret() string
+	GetDefaultLocation() string
+	GetDefaultResourceGroup() string
+}
+
+type azureConfig struct {
 	EnvironmentStr       string `envconfig:"AZURE_ENVIRONMENT" default:"AzurePublicCloud"` // nolint: lll
 	Environment          azure.Environment
 	SubscriptionID       string `envconfig:"AZURE_SUBSCRIPTION_ID" required:"true"` // nolint: lll
@@ -20,11 +30,39 @@ type AzureConfig struct {
 
 // GetAzureConfig returns Azure subscription configuration
 func GetAzureConfig() (AzureConfig, error) {
-	ac := AzureConfig{}
+	ac := azureConfig{}
 	err := envconfig.Process("", &ac)
 	if err != nil {
 		return ac, err
 	}
 	ac.Environment, err = azure.EnvironmentFromName(ac.EnvironmentStr)
 	return ac, err
+}
+
+func (a azureConfig) GetEnvironment() azure.Environment {
+	return a.Environment
+}
+
+func (a azureConfig) GetSubscriptionID() string {
+	return a.SubscriptionID
+}
+
+func (a azureConfig) GetTenantID() string {
+	return a.TenantID
+}
+
+func (a azureConfig) GetClientID() string {
+	return a.ClientID
+}
+
+func (a azureConfig) GetClientSecret() string {
+	return a.ClientSecret
+}
+
+func (a azureConfig) GetDefaultLocation() string {
+	return a.DefaultLocation
+}
+
+func (a azureConfig) GetDefaultResourceGroup() string {
+	return a.DefaultResourceGroup
 }

--- a/pkg/config/basic_auth.go
+++ b/pkg/config/basic_auth.go
@@ -1,0 +1,30 @@
+package config
+
+import "github.com/kelseyhightower/envconfig"
+
+// BasicAuthConfig represents details such as username and password that will
+// be used to secure the broker using basic auth
+type BasicAuthConfig interface {
+	GetUsername() string
+	GetPassword() string
+}
+
+type basicAuthConfig struct {
+	Username string `envconfig:"BASIC_AUTH_USERNAME" required:"true"`
+	Password string `envconfig:"BASIC_AUTH_PASSWORD" required:"true"`
+}
+
+// GetBasicAuthConfig returns basic auth configuration
+func GetBasicAuthConfig() (BasicAuthConfig, error) {
+	bac := basicAuthConfig{}
+	err := envconfig.Process("", &bac)
+	return bac, err
+}
+
+func (b basicAuthConfig) GetUsername() string {
+	return b.Username
+}
+
+func (b basicAuthConfig) GetPassword() string {
+	return b.Password
+}

--- a/pkg/config/basic_auth.go
+++ b/pkg/config/basic_auth.go
@@ -1,6 +1,8 @@
 package config
 
-import "github.com/kelseyhightower/envconfig"
+import (
+	"github.com/kelseyhightower/envconfig"
+)
 
 // BasicAuthConfig represents details such as username and password that will
 // be used to secure the broker using basic auth
@@ -10,14 +12,28 @@ type BasicAuthConfig interface {
 }
 
 type basicAuthConfig struct {
-	Username string `envconfig:"BASIC_AUTH_USERNAME" required:"true"`
-	Password string `envconfig:"BASIC_AUTH_PASSWORD" required:"true"`
+	Username   string `envconfig:"BASIC_AUTH_USERNAME"`
+	CFUsername string `envconfig:"SECURITY_USER_NAME"`
+	Password   string `envconfig:"BASIC_AUTH_PASSWORD"`
+	CFPassword string `envconfig:"SECURITY_USER_PASSWORD"`
 }
 
 // GetBasicAuthConfig returns basic auth configuration
 func GetBasicAuthConfig() (BasicAuthConfig, error) {
 	bac := basicAuthConfig{}
 	err := envconfig.Process("", &bac)
+	if bac.Username == "" && bac.CFUsername == "" {
+		return bac, &errBasicAuthUsernameNotSpecified{}
+	}
+	if bac.Username == "" && bac.CFUsername != "" {
+		bac.Username = bac.CFUsername
+	}
+	if bac.Password == "" && bac.CFPassword == "" {
+		return bac, &errBasicAuthPasswordNotSpecified{}
+	}
+	if bac.Password == "" && bac.CFPassword != "" {
+		bac.Password = bac.CFPassword
+	}
 	return bac, err
 }
 

--- a/pkg/config/basic_auth_errors.go
+++ b/pkg/config/basic_auth_errors.go
@@ -1,0 +1,15 @@
+package config
+
+type errBasicAuthUsernameNotSpecified struct{}
+
+func (e *errBasicAuthUsernameNotSpecified) Error() string {
+	return "neither environment variable BASIC_AUTH_USERNAME nor " +
+		"SECURITY_USER_NAME was specified; please specify one or the other"
+}
+
+type errBasicAuthPasswordNotSpecified struct{}
+
+func (e *errBasicAuthPasswordNotSpecified) Error() string {
+	return "neither environment variable BASIC_AUTH_PASSWORD nor " +
+		"SECURITY_USER_PASSWORD was specified; please specify one or the other"
+}

--- a/pkg/config/basic_auth_test.go
+++ b/pkg/config/basic_auth_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicAuthUsernameNotSpecified(t *testing.T) {
+	err := os.Setenv("BASIC_AUTH_USERNAME", "")
+	assert.Nil(t, err)
+	err = os.Setenv("SECURITY_USER_NAME", "")
+	assert.Nil(t, err)
+	_, err = GetBasicAuthConfig()
+	assert.IsType(t, &errBasicAuthUsernameNotSpecified{}, err)
+}
+
+func TestBasicAuthPasswordNotSpecified(t *testing.T) {
+	err := os.Setenv("BASIC_AUTH_USERNAME", "foo")
+	assert.Nil(t, err)
+	err = os.Setenv("BASIC_AUTH_PASSWORD", "")
+	assert.Nil(t, err)
+	err = os.Setenv("SECURITY_USER_PASSWORD", "")
+	assert.Nil(t, err)
+	_, err = GetBasicAuthConfig()
+	assert.IsType(t, &errBasicAuthPasswordNotSpecified{}, err)
+}
+
+func TestBasicAuthUsernamePasswordPrecedence(t *testing.T) {
+	err := os.Setenv("BASIC_AUTH_USERNAME", "foo")
+	assert.Nil(t, err)
+	err = os.Setenv("SECURITY_USER_NAME", "foo2")
+	assert.Nil(t, err)
+	err = os.Setenv("BASIC_AUTH_PASSWORD", "bar")
+	assert.Nil(t, err)
+	err = os.Setenv("SECURITY_USER_PASSWORD", "bar2")
+	assert.Nil(t, err)
+	bac, err := GetBasicAuthConfig()
+	assert.Nil(t, err)
+	assert.Equal(t, "foo", bac.GetUsername())
+	assert.Equal(t, "bar", bac.GetPassword())
+}
+
+func TestBasicAuthUsernamePasswordFallback(t *testing.T) {
+	err := os.Setenv("BASIC_AUTH_USERNAME", "")
+	assert.Nil(t, err)
+	err = os.Setenv("SECURITY_USER_NAME", "foo2")
+	assert.Nil(t, err)
+	err = os.Setenv("BASIC_AUTH_PASSWORD", "")
+	assert.Nil(t, err)
+	err = os.Setenv("SECURITY_USER_PASSWORD", "bar2")
+	assert.Nil(t, err)
+	bac, err := GetBasicAuthConfig()
+	assert.Nil(t, err)
+	assert.Equal(t, "foo2", bac.GetUsername())
+	assert.Equal(t, "bar2", bac.GetPassword())
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,12 +9,6 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-// CryptoConfig represents details (e.g. key) for encrypting and decrypting any
-// (potentially) sensitive information
-type CryptoConfig struct {
-	AES256Key string `envconfig:"AES256_KEY" required:"true"`
-}
-
 // BasicAuthConfig represents details such as username and password that will
 // be used to secure the broker using basic auth
 type BasicAuthConfig struct {
@@ -40,13 +34,6 @@ type AzureConfig struct {
 	ClientSecret         string `envconfig:"AZURE_CLIENT_SECRET" required:"true"`
 	DefaultLocation      string `envconfig:"AZURE_DEFAULT_LOCATION"`
 	DefaultResourceGroup string `envconfig:"AZURE_DEFAULT_RESOURCE_GROUP"`
-}
-
-// GetCryptoConfig returns crypto configuration
-func GetCryptoConfig() (CryptoConfig, error) {
-	cc := CryptoConfig{}
-	err := envconfig.Process("", &cc)
-	return cc, err
 }
 
 // GetBasicAuthConfig returns basic auth configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,15 +6,8 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
-	log "github.com/Sirupsen/logrus"
 	"github.com/kelseyhightower/envconfig"
 )
-
-// LogConfig represents configuration options for the broker's leveled logging
-type LogConfig struct {
-	LevelStr string `envconfig:"LOG_LEVEL" default:"INFO"`
-	Level    log.Level
-}
 
 // RedisConfig represents details for connecting to the Redis instance that
 // the broker itself relies on for storing state and orchestrating asynchronous
@@ -59,17 +52,6 @@ type AzureConfig struct {
 	ClientSecret         string `envconfig:"AZURE_CLIENT_SECRET" required:"true"`
 	DefaultLocation      string `envconfig:"AZURE_DEFAULT_LOCATION"`
 	DefaultResourceGroup string `envconfig:"AZURE_DEFAULT_RESOURCE_GROUP"`
-}
-
-// GetLogConfig returns log configuration
-func GetLogConfig() (LogConfig, error) {
-	lc := LogConfig{}
-	err := envconfig.Process("", &lc)
-	if err != nil {
-		return lc, err
-	}
-	lc.Level, err = log.ParseLevel(lc.LevelStr)
-	return lc, err
 }
 
 // GetRedisConfig returns Redis configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,18 +9,6 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-// RedisConfig represents details for connecting to the Redis instance that
-// the broker itself relies on for storing state and orchestrating asynchronous
-// processes
-type RedisConfig struct {
-	Host      string `envconfig:"REDIS_HOST" required:"true"`
-	Port      int    `envconfig:"REDIS_PORT" default:"6379"`
-	Password  string `envconfig:"REDIS_PASSWORD" default:""`
-	StorageDB int    `envconfig:"REDIS_STORAGE_DB" default:"0"`
-	AsyncDB   int    `envconfig:"REDIS_ASYNC_DB" default:"1"`
-	EnableTLS bool   `envconfig:"REDIS_ENABLE_TLS" default:"false"`
-}
-
 // CryptoConfig represents details (e.g. key) for encrypting and decrypting any
 // (potentially) sensitive information
 type CryptoConfig struct {
@@ -52,13 +40,6 @@ type AzureConfig struct {
 	ClientSecret         string `envconfig:"AZURE_CLIENT_SECRET" required:"true"`
 	DefaultLocation      string `envconfig:"AZURE_DEFAULT_LOCATION"`
 	DefaultResourceGroup string `envconfig:"AZURE_DEFAULT_RESOURCE_GROUP"`
-}
-
-// GetRedisConfig returns Redis configuration
-func GetRedisConfig() (RedisConfig, error) {
-	rc := RedisConfig{}
-	err := envconfig.Process("", &rc)
-	return rc, err
 }
 
 // GetCryptoConfig returns crypto configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,13 +9,6 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-// BasicAuthConfig represents details such as username and password that will
-// be used to secure the broker using basic auth
-type BasicAuthConfig struct {
-	Username string `envconfig:"BASIC_AUTH_USERNAME" required:"true"`
-	Password string `envconfig:"BASIC_AUTH_PASSWORD" required:"true"`
-}
-
 // ModulesConfig represents details re: which modules should be included or
 // excluded when the broker is started
 type ModulesConfig struct {
@@ -34,13 +27,6 @@ type AzureConfig struct {
 	ClientSecret         string `envconfig:"AZURE_CLIENT_SECRET" required:"true"`
 	DefaultLocation      string `envconfig:"AZURE_DEFAULT_LOCATION"`
 	DefaultResourceGroup string `envconfig:"AZURE_DEFAULT_RESOURCE_GROUP"`
-}
-
-// GetBasicAuthConfig returns basic auth configuration
-func GetBasicAuthConfig() (BasicAuthConfig, error) {
-	bac := BasicAuthConfig{}
-	err := envconfig.Process("", &bac)
-	return bac, err
 }
 
 // GetModulesConfig returns modules configuration

--- a/pkg/config/crypto.go
+++ b/pkg/config/crypto.go
@@ -1,0 +1,24 @@
+package config
+
+import "github.com/kelseyhightower/envconfig"
+
+// CryptoConfig represents details (e.g. key) for encrypting and decrypting any
+// (potentially) sensitive information
+type CryptoConfig interface {
+	GetAES256Key() string
+}
+
+type cryptoConfig struct {
+	AES256Key string `envconfig:"AES256_KEY" required:"true"`
+}
+
+// GetCryptoConfig returns crypto configuration
+func GetCryptoConfig() (CryptoConfig, error) {
+	cc := cryptoConfig{}
+	err := envconfig.Process("", &cc)
+	return cc, err
+}
+
+func (c cryptoConfig) GetAES256Key() string {
+	return c.AES256Key
+}

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// LogConfig represents configuration options for the broker's leveled logging
+type LogConfig interface {
+	GetLevel() log.Level
+}
+
+type logConfig struct {
+	LevelStr string `envconfig:"LOG_LEVEL" default:"INFO"`
+	Level    log.Level
+}
+
+// GetLogConfig returns log configuration
+func GetLogConfig() (LogConfig, error) {
+	lc := logConfig{}
+	err := envconfig.Process("", &lc)
+	if err != nil {
+		return lc, err
+	}
+	lc.Level, err = log.ParseLevel(lc.LevelStr)
+	return lc, err
+}
+
+func (l logConfig) GetLevel() log.Level {
+	return l.Level
+}

--- a/pkg/config/modules.go
+++ b/pkg/config/modules.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// ModulesConfig represents details re: which modules should be included or
+// excluded when the broker is started
+type ModulesConfig interface {
+	GetMinStability() service.Stability
+}
+
+type modulesConfig struct {
+	MinStabilityStr string `envconfig:"MIN_STABILITY" default:"EXPERIMENTAL"`
+	MinStability    service.Stability
+}
+
+// GetModulesConfig returns modules configuration
+func GetModulesConfig() (ModulesConfig, error) {
+	mc := modulesConfig{}
+	err := envconfig.Process("", &mc)
+	if err != nil {
+		return mc, err
+	}
+	minStabilityStr := strings.ToUpper(mc.MinStabilityStr)
+	switch minStabilityStr {
+	case "EXPERIMENTAL":
+		mc.MinStability = service.StabilityExperimental
+	case "PREVIEW":
+		mc.MinStability = service.StabilityPreview
+	case "STABLE":
+		mc.MinStability = service.StabilityStable
+	default:
+		return mc, fmt.Errorf(
+			`unrecognized stability level "%s"`,
+			minStabilityStr,
+		)
+	}
+	return mc, nil
+}
+
+func (m modulesConfig) GetMinStability() service.Stability {
+	return m.MinStability
+}

--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -1,0 +1,55 @@
+package config
+
+import "github.com/kelseyhightower/envconfig"
+
+// RedisConfig represents details for connecting to the Redis instance that
+// the broker itself relies on for storing state and orchestrating asynchronous
+// processes
+type RedisConfig interface {
+	GetHost() string
+	GetPort() int
+	GetPassword() string
+	GetStorageDB() int
+	GetAsyncDB() int
+	IsTLSEnabled() bool
+}
+
+type redisConfig struct {
+	Host      string `envconfig:"REDIS_HOST" required:"true"`
+	Port      int    `envconfig:"REDIS_PORT" default:"6379"`
+	Password  string `envconfig:"REDIS_PASSWORD" default:""`
+	StorageDB int    `envconfig:"REDIS_STORAGE_DB" default:"0"`
+	AsyncDB   int    `envconfig:"REDIS_ASYNC_DB" default:"1"`
+	EnableTLS bool   `envconfig:"REDIS_ENABLE_TLS" default:"false"`
+}
+
+// GetRedisConfig returns Redis configuration
+func GetRedisConfig() (RedisConfig, error) {
+	rc := redisConfig{}
+	err := envconfig.Process("", &rc)
+	return rc, err
+}
+
+func (r redisConfig) GetHost() string {
+	return r.Host
+}
+
+func (r redisConfig) GetPort() int {
+	return r.Port
+}
+
+func (r redisConfig) GetPassword() string {
+	return r.Password
+}
+
+func (r redisConfig) GetStorageDB() int {
+	return r.StorageDB
+}
+
+func (r redisConfig) GetAsyncDB() int {
+	return r.AsyncDB
+}
+
+func (r redisConfig) IsTLSEnabled() bool {
+	return r.EnableTLS
+}

--- a/tests/lifecycle/groups_client_test.go
+++ b/tests/lifecycle/groups_client_test.go
@@ -43,14 +43,14 @@ func getGroupsClient() (*resources.GroupsClient, error) {
 		return nil, err
 	}
 	groupsClient := resources.NewGroupsClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureConfig.GetEnvironment().ResourceManagerEndpoint,
+		azureConfig.GetSubscriptionID(),
 	)
 	authorizer, err := az.GetBearerTokenAuthorizer(
-		azureConfig.Environment,
-		azureConfig.TenantID,
-		azureConfig.ClientID,
-		azureConfig.ClientSecret,
+		azureConfig.GetEnvironment(),
+		azureConfig.GetTenantID(),
+		azureConfig.GetClientID(),
+		azureConfig.GetClientSecret(),
 	)
 	if err != nil {
 		return nil, err

--- a/tests/lifecycle/keyvault_cases_test.go
+++ b/tests/lifecycle/keyvault_cases_test.go
@@ -23,12 +23,16 @@ func getKeyvaultCases(
 	}
 	vaultsClient := keyVaultSDK.NewVaultsClientWithBaseURI(
 		azureEnvironment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureConfig.GetSubscriptionID(),
 	)
 	vaultsClient.Authorizer = authorizer
 	return []serviceLifecycleTestCase{
 		{
-			module:    keyvault.New(azureConfig.TenantID, armDeployer, vaultsClient),
+			module: keyvault.New(
+				azureConfig.GetTenantID(),
+				armDeployer,
+				vaultsClient,
+			),
 			serviceID: "d90c881e-c9bb-4e07-a87b-fcfe87e03276",
 			planID:    "3577ee4a-75fc-44b3-b354-9d33d52ef486",
 			location:  "southcentralus",

--- a/tests/lifecycle/test_cases_test.go
+++ b/tests/lifecycle/test_cases_test.go
@@ -21,24 +21,27 @@ func getTestCases() ([]serviceLifecycleTestCase, error) {
 		return nil, err
 	}
 
+	azureEnvironment := azureConfig.GetEnvironment()
+	azureSubscriptionID := azureConfig.GetSubscriptionID()
+
 	authorizer, err := az.GetBearerTokenAuthorizer(
-		azureConfig.Environment,
-		azureConfig.TenantID,
-		azureConfig.ClientID,
-		azureConfig.ClientSecret,
+		azureEnvironment,
+		azureConfig.GetTenantID(),
+		azureConfig.GetClientID(),
+		azureConfig.GetClientSecret(),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	resourceGroupsClient := resources.NewGroupsClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	resourceGroupsClient.Authorizer = authorizer
 	resourceDeploymentsClient := resources.NewDeploymentsClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
 	)
 	resourceDeploymentsClient.Authorizer = authorizer
 	armDeployer := arm.NewDeployer(
@@ -71,8 +74,8 @@ func getTestCases() ([]serviceLifecycleTestCase, error) {
 
 	for _, getTestCaseFunc := range getTestCaseFuncs {
 		if tcs, err := getTestCaseFunc(
-			azureConfig.Environment,
-			azureConfig.SubscriptionID,
+			azureEnvironment,
+			azureSubscriptionID,
 			authorizer,
 			armDeployer,
 		); err == nil {


### PR DESCRIPTION
Fixes #129 

What I wanted to do here was add this option, as requested, without fully allowing CF to dictate the environment variables we choose to use. As such, I've made it that the original environment variables `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` are respected and take precedence, but when those aren't set, we fall back to `SECURITY_USER_NAME` and `SECURITY_USER_PASSWORD`.

This increases the complexity of the basic auth config struct a bit, since it contains exported fields (`envconfig` requires this) that we would have preferred to be internal and maybe we don't actually want clients of our `config` package reading. Honestly, this was already a problem in a few other spots as well...

So, as a pre-requisite for fixing this, I've added exported interfaces for each type of config struct, while the config structs themselves remain unexported. Bonus-- the `GetX()` functions that need to be added to those interfaces and their respective implementation make this approach tenable _also_ effectively make the config structs immutable by clients that use them. Win, win, win. 