### PR TITLE
sql db deprovisioning bug fix

### DIFF
--- a/pkg/services/sqldb/deprovision.go
+++ b/pkg/services/sqldb/deprovision.go
@@ -174,7 +174,7 @@ func (d *dbOnlyManager) deleteMsSQLDatabase(
 	}
 
 	if _, err := d.databasesClient.Delete(
-		instance.ResourceGroup,
+		instance.Parent.ResourceGroup,
 		pdt.ServerName,
 		dt.DatabaseName,
 	); err != nil {


### PR DESCRIPTION
Critical bug fix.

We're deleting sql db (db only service) based on the wrong resource group. Tests don't catch this because the tests deliberately provision _everything_ in a single resource group anyway (for easy cleanup).