### PR TITLE
don't set location and rg on instances with non-root service type

### DIFF
--- a/pkg/api/provision.go
+++ b/pkg/api/provision.go
@@ -143,7 +143,7 @@ func (s *server) provision(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	location = s.getLocation(location)
+	location = s.getLocation(svc, location)
 
 	// Resource group...
 	requestedResourceGroup := ""
@@ -162,7 +162,7 @@ func (s *server) provision(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	resourceGroup := s.getResourceGroup(requestedResourceGroup)
+	resourceGroup := s.getResourceGroup(svc, requestedResourceGroup)
 
 	// Tags...
 	var tags map[string]string
@@ -565,14 +565,27 @@ func (s *server) handlePossibleValidationError(
 	s.writeResponse(w, http.StatusInternalServerError, generateEmptyResponse())
 }
 
-func (s *server) getLocation(location string) string {
+func (s *server) getLocation(svc service.Service, location string) string {
+	// Return an empty location only if this is NOT a "root" service type
+	// (i.e. has a parent)
+	if svc.GetParentServiceID() != "" {
+		return ""
+	}
 	if location != "" {
 		return location
 	}
 	return s.defaultAzureLocation
 }
 
-func (s *server) getResourceGroup(resourceGroup string) string {
+func (s *server) getResourceGroup(
+	svc service.Service,
+	resourceGroup string,
+) string {
+	// Return an empty resource group only if this is NOT a "root" service type
+	// (i.e. has a parent)
+	if svc.GetParentServiceID() != "" {
+		return ""
+	}
 	if resourceGroup != "" {
 		return resourceGroup
 	}

--- a/pkg/api/provision_test.go
+++ b/pkg/api/provision_test.go
@@ -334,10 +334,24 @@ func TestGetLocation(t *testing.T) {
 	const location = "test-location"
 	testCases := []struct {
 		name            string
+		svc             service.Service
 		defaultLocation string
 		location        string
 		assertion       func(*testing.T, string)
 	}{
+		{
+			name: `service is not a "root" service type`,
+			svc: service.NewService(
+				&service.ServiceProperties{
+					ParentServiceID: "foo",
+				},
+				nil,
+			),
+			location: location,
+			assertion: func(t *testing.T, loc string) {
+				assert.Equal(t, "", loc)
+			},
+		},
 		{
 			name:     "location specified with no default location",
 			location: location,
@@ -361,13 +375,19 @@ func TestGetLocation(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
+		if testCase.svc == nil {
+			testCase.svc = service.NewService(
+				&service.ServiceProperties{},
+				nil,
+			)
+		}
 		t.Run(testCase.name, func(t *testing.T) {
 			s, _, err := getTestServer(
 				testCase.defaultLocation,
 				"default-rg",
 			)
 			assert.Nil(t, err)
-			spc := s.getLocation(testCase.location)
+			spc := s.getLocation(testCase.svc, testCase.location)
 			testCase.assertion(t, spc)
 		})
 	}
@@ -378,10 +398,24 @@ func TestGetResourceGroup(t *testing.T) {
 	const resourceGroup = "test-rg"
 	testCases := []struct {
 		name                 string
+		svc                  service.Service
 		defaultResourceGroup string
 		resourceGroup        string
 		assertion            func(*testing.T, string)
 	}{
+		{
+			name: `service is not a "root" service type`,
+			svc: service.NewService(
+				&service.ServiceProperties{
+					ParentServiceID: "foo",
+				},
+				nil,
+			),
+			resourceGroup: resourceGroup,
+			assertion: func(t *testing.T, rg string) {
+				assert.Equal(t, "", rg)
+			},
+		},
 		{
 			name:          "resource group specified with no default resource group",
 			resourceGroup: resourceGroup,
@@ -418,13 +452,19 @@ func TestGetResourceGroup(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
+		if testCase.svc == nil {
+			testCase.svc = service.NewService(
+				&service.ServiceProperties{},
+				nil,
+			)
+		}
 		t.Run(testCase.name, func(t *testing.T) {
 			s, _, err := getTestServer(
 				"default-location",
 				testCase.defaultResourceGroup,
 			)
 			assert.Nil(t, err)
-			spc := s.getResourceGroup(testCase.resourceGroup)
+			spc := s.getResourceGroup(testCase.svc, testCase.resourceGroup)
 			testCase.assertion(t, spc)
 		})
 	}


### PR DESCRIPTION
Fixes #258 