### PR TITLE
Fixed deprovision of DB only to not kill the server

### DIFF
--- a/cmd/broker/modules.go
+++ b/cmd/broker/modules.go
@@ -106,6 +106,13 @@ func initModules(azureConfig config.AzureConfig) error {
 	mysqlServersClient.Authorizer = authorizer
 	mysqlServersClient.UserAgent = getUserAgent(mysqlServersClient.Client)
 
+	mysqlDatabasesClient := mysqlSDK.NewDatabasesClientWithBaseURI(
+		azureEnvironment.ResourceManagerEndpoint,
+		azureSubscriptionID,
+	)
+	mysqlDatabasesClient.Authorizer = authorizer
+	mysqlDatabasesClient.UserAgent = getUserAgent(mysqlDatabasesClient.Client)
+
 	postgresServersClient := postgresSDK.NewServersClientWithBaseURI(
 		azureEnvironment.ResourceManagerEndpoint,
 		azureSubscriptionID,
@@ -158,7 +165,12 @@ func initModules(azureConfig config.AzureConfig) error {
 	modules = []service.Module{
 		postgresqldb.New(armDeployer, postgresServersClient),
 		rediscache.New(armDeployer, redisClient),
-		mysqldb.New(azureEnvironment, armDeployer, mysqlServersClient),
+		mysqldb.New(
+			azureEnvironment,
+			armDeployer,
+			mysqlServersClient,
+			mysqlDatabasesClient,
+		),
 		servicebus.New(armDeployer, serviceBusNamespacesClient),
 		eventhubs.New(armDeployer, eventHubNamespacesClient),
 		keyvault.New(azureConfig.GetTenantID(), armDeployer, keyVaultsClient),

--- a/pkg/services/mysqldb/deprovision_db_only.go
+++ b/pkg/services/mysqldb/deprovision_db_only.go
@@ -28,7 +28,7 @@ func (d *dbOnlyManager) deleteARMDeployment(
 	}
 	if err := d.armDeployer.Delete(
 		dt.ARMDeploymentName,
-		instance.ResourceGroup,
+		instance.Parent.ResourceGroup,
 	); err != nil {
 		return nil, fmt.Errorf("error deleting ARM deployment: %s", err)
 	}
@@ -53,15 +53,16 @@ func (d *dbOnlyManager) deleteMySQLServer(
 			"error casting instance.Details as *dbOnlyMysqlInstanceDetails",
 		)
 	}
-	result, err := d.serversClient.Delete(
+	result, err := d.databasesClient.Delete(
 		ctx,
-		instance.ResourceGroup,
+		instance.Parent.ResourceGroup,
 		pdt.ServerName,
+		dt.DatabaseName,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error deleting mysql server: %s", err)
 	}
-	if err := result.WaitForCompletion(ctx, d.serversClient.Client); err != nil {
+	if err := result.WaitForCompletion(ctx, d.databasesClient.Client); err != nil {
 		return nil, fmt.Errorf("error deleting mysql server: %s", err)
 	}
 	return dt, nil

--- a/pkg/services/mysqldb/deprovision_db_only.go
+++ b/pkg/services/mysqldb/deprovision_db_only.go
@@ -12,7 +12,7 @@ func (d *dbOnlyManager) GetDeprovisioner(
 ) (service.Deprovisioner, error) {
 	return service.NewDeprovisioner(
 		service.NewDeprovisioningStep("deleteARMDeployment", d.deleteARMDeployment),
-		service.NewDeprovisioningStep("deleteMySQLServer", d.deleteMySQLServer),
+		service.NewDeprovisioningStep("deleteMySQLDatabase", d.deleteMySQLDatabase),
 	)
 }
 
@@ -35,7 +35,7 @@ func (d *dbOnlyManager) deleteARMDeployment(
 	return dt, nil
 }
 
-func (d *dbOnlyManager) deleteMySQLServer(
+func (d *dbOnlyManager) deleteMySQLDatabase(
 	ctx context.Context,
 	instance service.Instance,
 ) (service.InstanceDetails, error) {
@@ -60,10 +60,10 @@ func (d *dbOnlyManager) deleteMySQLServer(
 		dt.DatabaseName,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error deleting mysql server: %s", err)
+		return nil, fmt.Errorf("error deleting mysql database: %s", err)
 	}
 	if err := result.WaitForCompletion(ctx, d.databasesClient.Client); err != nil {
-		return nil, fmt.Errorf("error deleting mysql server: %s", err)
+		return nil, fmt.Errorf("error deleting mysql database: %s", err)
 	}
 	return dt, nil
 }

--- a/pkg/services/mysqldb/mysql.go
+++ b/pkg/services/mysqldb/mysql.go
@@ -28,7 +28,7 @@ type dbmsOnlyManager struct {
 type dbOnlyManager struct {
 	sqlDatabaseDNSSuffix string
 	armDeployer          arm.Deployer
-	serversClient        mysqlSDK.ServersClient
+	databasesClient      mysqlSDK.DatabasesClient
 }
 
 // New returns a new instance of a type that fulfills the service.Module
@@ -38,6 +38,7 @@ func New(
 	azureEnvironment azure.Environment,
 	armDeployer arm.Deployer,
 	serversClient mysqlSDK.ServersClient,
+	databaseClient mysqlSDK.DatabasesClient,
 ) service.Module {
 	return &module{
 		allInOneServiceManager: &allInOneManager{
@@ -53,7 +54,7 @@ func New(
 		dbOnlyServiceManager: &dbOnlyManager{
 			sqlDatabaseDNSSuffix: azureEnvironment.SQLDatabaseDNSSuffix,
 			armDeployer:          armDeployer,
-			serversClient:        serversClient,
+			databasesClient:      databaseClient,
 		},
 	}
 }

--- a/tests/lifecycle/mysql_cases_test.go
+++ b/tests/lifecycle/mysql_cases_test.go
@@ -27,10 +27,17 @@ func getMysqlCases(
 		subscriptionID,
 	)
 	serversClient.Authorizer = authorizer
+
+	databasesClient := mysqlSDK.NewDatabasesClientWithBaseURI(
+		azureEnvironment.ResourceManagerEndpoint,
+		subscriptionID,
+	)
+	databasesClient.Authorizer = authorizer
 	module := mysqldb.New(
 		azureEnvironment,
 		armDeployer,
 		serversClient,
+		databasesClient,
 	)
 	return []serviceLifecycleTestCase{
 		{


### PR DESCRIPTION
Fixes #264 

Replaces use of ServersClient in DB deprovisioning with DatabasesClient. Wired that through from cmd/broker/modules.go 