### PR TITLE
fix 404 error checking when deprovisioning cosmos

### DIFF
--- a/pkg/services/cosmosdb/deprovision.go
+++ b/pkg/services/cosmosdb/deprovision.go
@@ -57,16 +57,16 @@ func (s *serviceManager) deleteCosmosDBServer(
 		dt.DatabaseAccountName,
 	)
 	if err != nil {
-		// Workaround for https://github.com/Azure/azure-sdk-for-go/issues/759
-		if strings.Contains(err.Error(), "StatusCode=404") {
-			return dt, nil
-		}
 		return dt, fmt.Errorf("error deleting cosmosdb server: %s", err)
 	}
 	if err := result.WaitForCompletion(
 		ctx,
 		s.databaseAccountsClient.Client,
 	); err != nil {
+		// Workaround for https://github.com/Azure/azure-sdk-for-go/issues/759
+		if strings.Contains(err.Error(), "StatusCode=404") {
+			return dt, nil
+		}
 		return dt, fmt.Errorf("error deleting cosmosdb server: %s", err)
 	}
 	return dt, nil


### PR DESCRIPTION
When deprovisioning CosmosDB, I believe we are checking for 404s in the wrong place. I'm still trying to determine whether this is a factor in recent perceived slowness in deprovisioning CosmosDB, but this is incorrect and needs fixing regardless.