### PR TITLE
Adding to more info to MySQL and PostgreSQL bind credentials and making lifecycle tests better

### DIFF
--- a/pkg/services/mysqldb/bind_all_in_one.go
+++ b/pkg/services/mysqldb/bind_all_in_one.go
@@ -69,7 +69,6 @@ func (a *allInOneManager) GetCredentials(
 		dt.EnforceSSL,
 		dt.ServerName,
 		dt.DatabaseName,
-		a.sqlDatabaseDNSSuffix,
 		bd,
 		sbd,
 	)

--- a/pkg/services/mysqldb/bind_common.go
+++ b/pkg/services/mysqldb/bind_common.go
@@ -75,7 +75,6 @@ func createCredential(
 	sslRequired bool,
 	serverName string,
 	databaseName string,
-	dnsSuffix string,
 	bindingDetails *mysqlBindingDetails,
 	secureBidningDetails *mysqlSecureBindingDetails,
 ) *Credentials {
@@ -96,6 +95,5 @@ func createCredential(
 		Password:    secureBidningDetails.Password,
 		SSLRequired: sslRequired,
 		URI:         connectionString,
-		DNSSuffix:   dnsSuffix,
 	}
 }

--- a/pkg/services/mysqldb/bind_common.go
+++ b/pkg/services/mysqldb/bind_common.go
@@ -2,6 +2,7 @@ package mysqldb
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/Azure/open-service-broker-azure/pkg/generate"
 )
@@ -70,6 +71,10 @@ func createBinding(
 
 }
 
+// Create a credential to be returned for binding purposes. This includes a CF
+// compatible uri string and a flag to indicate if this connection should
+// use ssl. URI is built with the username passed to url.QueryEscape to escape
+// the @ in the username
 func createCredential(
 	fqdn string,
 	sslRequired bool,
@@ -79,10 +84,10 @@ func createCredential(
 	secureBidningDetails *mysqlSecureBindingDetails,
 ) *Credentials {
 	username := fmt.Sprintf("%s@%s", bindingDetails.LoginName, serverName)
-	connectionTemplate := "mysql://%s:%s@%s:3306/%s?allowNativePasswords=true"
+	connectionTemplate := "mysql://%s:%s@%s:3306/%s?useSSL=true&requireSSL=true"
 	connectionString := fmt.Sprintf(
 		connectionTemplate,
-		username,
+		url.QueryEscape(username),
 		secureBidningDetails.Password,
 		fqdn,
 		databaseName,
@@ -95,5 +100,6 @@ func createCredential(
 		Password:    secureBidningDetails.Password,
 		SSLRequired: sslRequired,
 		URI:         connectionString,
+		Tags:        []string{"mysql"},
 	}
 }

--- a/pkg/services/mysqldb/bind_common.go
+++ b/pkg/services/mysqldb/bind_common.go
@@ -1,0 +1,101 @@
+package mysqldb
+
+import (
+	"fmt"
+
+	"github.com/Azure/open-service-broker-azure/pkg/generate"
+)
+
+func createBinding(
+	enforceSSL bool,
+	dnsSuffix string,
+	serverName string,
+	adminPassword string,
+	fqdn string,
+	databaseName string,
+) (*mysqlBindingDetails, *mysqlSecureBindingDetails, error) {
+
+	userName := generate.NewIdentifier()
+	password := generate.NewPassword()
+
+	db, err := createDBConnection(
+		enforceSSL,
+		dnsSuffix,
+		serverName,
+		adminPassword,
+		fqdn,
+		databaseName,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer db.Close() // nolint: errcheck
+
+	// Open doesn't open a connection. Validate DSN data:
+	if err = db.Ping(); err != nil {
+		return nil, nil, err
+	}
+
+	if _, err = db.Exec(
+		fmt.Sprintf("CREATE USER '%s'@'%%' IDENTIFIED BY '%s'", userName, password),
+	); err != nil {
+		return nil, nil, fmt.Errorf(
+			`error creating user "%s": %s`,
+			userName,
+			err,
+		)
+	}
+
+	if _, err = db.Exec(
+		fmt.Sprintf("GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, "+
+			"INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, "+
+			"CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, "+
+			"EXECUTE, REFERENCES, EVENT, "+
+			"TRIGGER ON %s.* TO '%s'@'%%'",
+			databaseName, userName)); err != nil {
+		return nil, nil, fmt.Errorf(
+			`error granting permission to "%s": %s`,
+			userName,
+			err,
+		)
+	}
+
+	return &mysqlBindingDetails{
+			LoginName: userName,
+		},
+		&mysqlSecureBindingDetails{
+			Password: password,
+		},
+		nil
+
+}
+
+func createCredential(
+	fqdn string,
+	sslRequired bool,
+	serverName string,
+	databaseName string,
+	dnsSuffix string,
+	bindingDetails *mysqlBindingDetails,
+	secureBidningDetails *mysqlSecureBindingDetails,
+) *Credentials {
+	username := fmt.Sprintf("%s@%s", bindingDetails.LoginName, serverName)
+	connectionTemplate := "mysql://%s:%s@%s:3306/%s?allowNativePasswords=true"
+	connectionString := fmt.Sprintf(
+		connectionTemplate,
+		username,
+		secureBidningDetails.Password,
+		fqdn,
+		databaseName,
+	)
+	return &Credentials{
+		Host:        fqdn,
+		Port:        3306,
+		Database:    databaseName,
+		Username:    username,
+		Password:    secureBidningDetails.Password,
+		SSLRequired: sslRequired,
+		URI:         connectionString,
+		DNSSuffix:   dnsSuffix,
+	}
+}

--- a/pkg/services/mysqldb/bind_db_only.go
+++ b/pkg/services/mysqldb/bind_db_only.go
@@ -84,7 +84,6 @@ func (d *dbOnlyManager) GetCredentials(
 		pdt.EnforceSSL,
 		pdt.ServerName,
 		dt.DatabaseName,
-		d.sqlDatabaseDNSSuffix,
 		bd,
 		sbd,
 	)

--- a/pkg/services/mysqldb/db_connection.go
+++ b/pkg/services/mysqldb/db_connection.go
@@ -51,32 +51,3 @@ func createDBConnection(
 	}
 	return db, err
 }
-
-func (s *allInOneManager) getDBConnection(
-	dt *allInOneMysqlInstanceDetails,
-	sdt *allInOneMysqlSecureInstanceDetails,
-) (*sql.DB, error) {
-	return createDBConnection(
-		dt.EnforceSSL,
-		s.sqlDatabaseDNSSuffix,
-		dt.ServerName,
-		sdt.AdministratorLoginPassword,
-		dt.FullyQualifiedDomainName,
-		dt.DatabaseName,
-	)
-}
-
-func (d *dbOnlyManager) getDBConnection(
-	pdt *dbmsOnlyMysqlInstanceDetails,
-	spdt *dbmsOnlyMysqlSecureInstanceDetails,
-	dt *dbOnlyMysqlInstanceDetails,
-) (*sql.DB, error) {
-	return createDBConnection(
-		pdt.EnforceSSL,
-		d.sqlDatabaseDNSSuffix,
-		pdt.ServerName,
-		spdt.AdministratorLoginPassword,
-		pdt.FullyQualifiedDomainName,
-		dt.DatabaseName,
-	)
-}

--- a/pkg/services/mysqldb/types.go
+++ b/pkg/services/mysqldb/types.go
@@ -26,9 +26,12 @@ type mysqlSecureBindingDetails struct {
 
 // Credentials encapsulates MySQL-specific coonection details and credentials.
 type Credentials struct {
-	Host     string `json:"host"`
-	Port     int    `json:"port"`
-	Database string `json:"database"`
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Host        string `json:"host"`
+	Port        int    `json:"port"`
+	Database    string `json:"database"`
+	Username    string `json:"username"`
+	Password    string `json:"password"`
+	SSLRequired bool   `json:"sslRequired"`
+	DNSSuffix   string `json:"dnsSuffix"`
+	URI         string `json:"uri"`
 }

--- a/pkg/services/mysqldb/types.go
+++ b/pkg/services/mysqldb/types.go
@@ -26,11 +26,12 @@ type mysqlSecureBindingDetails struct {
 
 // Credentials encapsulates MySQL-specific coonection details and credentials.
 type Credentials struct {
-	Host        string `json:"host"`
-	Port        int    `json:"port"`
-	Database    string `json:"database"`
-	Username    string `json:"username"`
-	Password    string `json:"password"`
-	SSLRequired bool   `json:"sslRequired"`
-	URI         string `json:"uri"`
+	Host        string   `json:"host"`
+	Port        int      `json:"port"`
+	Database    string   `json:"database"`
+	Username    string   `json:"username"`
+	Password    string   `json:"password"`
+	SSLRequired bool     `json:"sslRequired"`
+	URI         string   `json:"uri"`
+	Tags        []string `json:"tags"`
 }

--- a/pkg/services/mysqldb/types.go
+++ b/pkg/services/mysqldb/types.go
@@ -32,6 +32,5 @@ type Credentials struct {
 	Username    string `json:"username"`
 	Password    string `json:"password"`
 	SSLRequired bool   `json:"sslRequired"`
-	DNSSuffix   string `json:"dnsSuffix"`
 	URI         string `json:"uri"`
 }

--- a/pkg/services/mysqldb/unbind_all_in_one.go
+++ b/pkg/services/mysqldb/unbind_all_in_one.go
@@ -30,28 +30,13 @@ func (a *allInOneManager) Unbind(
 		)
 	}
 
-	db, err := a.getDBConnection(dt, sdt)
-	if err != nil {
-		return err
-	}
-	defer db.Close() // nolint: errcheck
-
-	// Open doesn't open a connection. Validate DSN data:
-	err = db.Ping()
-	if err != nil {
-		return err
-	}
-
-	_, err = db.Exec(
-		fmt.Sprintf("DROP USER '%s'@'%%'", bc.LoginName),
+	return unbind(
+		dt.EnforceSSL,
+		a.sqlDatabaseDNSSuffix,
+		dt.ServerName,
+		sdt.AdministratorLoginPassword,
+		dt.FullyQualifiedDomainName,
+		dt.DatabaseName,
+		bc,
 	)
-	if err != nil {
-		return fmt.Errorf(
-			`error dropping user "%s": %s`,
-			bc.LoginName,
-			err,
-		)
-	}
-
-	return nil
 }

--- a/pkg/services/mysqldb/unbind_common.go
+++ b/pkg/services/mysqldb/unbind_common.go
@@ -1,0 +1,47 @@
+package mysqldb
+
+import (
+	"fmt"
+)
+
+func unbind(
+	enforceSSL bool,
+	sqlDatabaseDNSSuffix string,
+	serverName string,
+	administratorLoginPassword string,
+	fullyQualifiedDomainName string,
+	databaseName string,
+	bindingDetails *mysqlBindingDetails,
+
+) error {
+	db, err := createDBConnection(
+		enforceSSL,
+		sqlDatabaseDNSSuffix,
+		serverName,
+		administratorLoginPassword,
+		fullyQualifiedDomainName,
+		databaseName,
+	)
+	if err != nil {
+		return err
+	}
+	defer db.Close() // nolint: errcheck
+
+	// Open doesn't open a connection. Validate DSN data:
+	err = db.Ping()
+	if err != nil {
+		return err
+	}
+
+	_, err = db.Exec(
+		fmt.Sprintf("DROP USER '%s'@'%%'", bindingDetails.LoginName),
+	)
+	if err != nil {
+		return fmt.Errorf(
+			`error dropping user "%s": %s`,
+			bindingDetails.LoginName,
+			err,
+		)
+	}
+	return nil
+}

--- a/pkg/services/mysqldb/unbind_db_only.go
+++ b/pkg/services/mysqldb/unbind_db_only.go
@@ -36,28 +36,13 @@ func (d *dbOnlyManager) Unbind(
 		)
 	}
 
-	db, err := d.getDBConnection(pdt, spdt, dt)
-	if err != nil {
-		return err
-	}
-	defer db.Close() // nolint: errcheck
-
-	// Open doesn't open a connection. Validate DSN data:
-	err = db.Ping()
-	if err != nil {
-		return err
-	}
-
-	_, err = db.Exec(
-		fmt.Sprintf("DROP USER '%s'@'%%'", bc.LoginName),
+	return unbind(
+		pdt.EnforceSSL,
+		d.sqlDatabaseDNSSuffix,
+		pdt.ServerName,
+		spdt.AdministratorLoginPassword,
+		pdt.FullyQualifiedDomainName,
+		dt.DatabaseName,
+		bc,
 	)
-	if err != nil {
-		return fmt.Errorf(
-			`error dropping user "%s": %s`,
-			bc.LoginName,
-			err,
-		)
-	}
-
-	return nil
 }

--- a/pkg/services/postgresqldb/bind_all_in_one.go
+++ b/pkg/services/postgresqldb/bind_all_in_one.go
@@ -65,11 +65,13 @@ func (a *allInOneManager) GetCredentials(
 			"error casting binding.SecureDetails as *postgresqlSecureBindingDetails",
 		)
 	}
-	return &Credentials{
-		Host:     dt.FullyQualifiedDomainName,
-		Port:     5432,
-		Database: dt.DatabaseName,
-		Username: fmt.Sprintf("%s@%s", bd.LoginName, dt.ServerName),
-		Password: sbd.Password,
-	}, nil
+	cred := createCredential(
+		dt.FullyQualifiedDomainName,
+		dt.EnforceSSL,
+		dt.ServerName,
+		dt.DatabaseName,
+		bd,
+		sbd,
+	)
+	return cred, nil
 }

--- a/pkg/services/postgresqldb/bind_common.go
+++ b/pkg/services/postgresqldb/bind_common.go
@@ -83,3 +83,42 @@ func createBinding(
 		},
 		nil
 }
+
+// Create a credential to be returned for binding purposes. This includes a CF
+// compatible uri string and a flag to indicate if this connection should
+// use ssl
+func createCredential(
+	fqdn string,
+	sslRequired bool,
+	serverName string,
+	databaseName string,
+	bindDetails *postgresqlBindingDetails,
+	secureBindingDetails *postgresqlSecureBindingDetails,
+) *Credentials {
+	username := fmt.Sprintf("%s@%s", bindDetails.LoginName, serverName)
+	port := 5432
+	var connectionTemplate string
+	if sslRequired {
+		connectionTemplate = "postgresql://%s:%s@%s:%d/%s?&sslmode=require"
+
+	} else {
+		connectionTemplate = "postgresql://%s:%s@%s:%d/%s"
+	}
+	connectionString := fmt.Sprintf(
+		connectionTemplate,
+		username,
+		secureBindingDetails.Password,
+		fqdn,
+		port,
+		databaseName,
+	)
+	return &Credentials{
+		Host:        fqdn,
+		Port:        port,
+		Database:    databaseName,
+		Username:    username,
+		Password:    secureBindingDetails.Password,
+		SSLRequired: sslRequired,
+		URI:         connectionString,
+	}
+}

--- a/pkg/services/postgresqldb/bind_common.go
+++ b/pkg/services/postgresqldb/bind_common.go
@@ -2,6 +2,7 @@ package postgresqldb
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/Azure/open-service-broker-azure/pkg/generate"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
@@ -86,7 +87,8 @@ func createBinding(
 
 // Create a credential to be returned for binding purposes. This includes a CF
 // compatible uri string and a flag to indicate if this connection should
-// use ssl
+// use ssl. URI is built with the username passed to url.QueryEscape to escape
+// the @ in the username
 func createCredential(
 	fqdn string,
 	sslRequired bool,
@@ -106,7 +108,7 @@ func createCredential(
 	}
 	connectionString := fmt.Sprintf(
 		connectionTemplate,
-		username,
+		url.QueryEscape(username),
 		secureBindingDetails.Password,
 		fqdn,
 		port,
@@ -120,5 +122,6 @@ func createCredential(
 		Password:    secureBindingDetails.Password,
 		SSLRequired: sslRequired,
 		URI:         connectionString,
+		Tags:        []string{"postgresql"},
 	}
 }

--- a/pkg/services/postgresqldb/bind_db_only.go
+++ b/pkg/services/postgresqldb/bind_db_only.go
@@ -83,11 +83,13 @@ func (d *dbOnlyManager) GetCredentials(
 			"error casting binding.SecureDetails as *postgresqlSecureBindingDetails",
 		)
 	}
-	return &Credentials{
-		Host:     pdt.FullyQualifiedDomainName,
-		Port:     5432,
-		Database: dt.DatabaseName,
-		Username: fmt.Sprintf("%s@%s", bd.LoginName, pdt.ServerName),
-		Password: sbd.Password,
-	}, nil
+	cred := createCredential(
+		pdt.FullyQualifiedDomainName,
+		pdt.EnforceSSL,
+		pdt.ServerName,
+		dt.DatabaseName,
+		bd,
+		sbd,
+	)
+	return cred, nil
 }

--- a/pkg/services/postgresqldb/types_common.go
+++ b/pkg/services/postgresqldb/types_common.go
@@ -19,11 +19,12 @@ type postgresqlSecureBindingDetails struct {
 // Credentials encapsulates PostgreSQL-specific coonection details and
 // credentials.
 type Credentials struct {
-	Host        string `json:"host"`
-	Port        int    `json:"port"`
-	Database    string `json:"database"`
-	Username    string `json:"username"`
-	Password    string `json:"password"`
-	URI         string `json:"uri"`
-	SSLRequired bool   `json:"sslRequired"`
+	Host        string   `json:"host"`
+	Port        int      `json:"port"`
+	Database    string   `json:"database"`
+	Username    string   `json:"username"`
+	Password    string   `json:"password"`
+	URI         string   `json:"uri"`
+	SSLRequired bool     `json:"sslRequired"`
+	Tags        []string `json:"tags"`
 }

--- a/pkg/services/postgresqldb/types_common.go
+++ b/pkg/services/postgresqldb/types_common.go
@@ -19,9 +19,11 @@ type postgresqlSecureBindingDetails struct {
 // Credentials encapsulates PostgreSQL-specific coonection details and
 // credentials.
 type Credentials struct {
-	Host     string `json:"host"`
-	Port     int    `json:"port"`
-	Database string `json:"database"`
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Host        string `json:"host"`
+	Port        int    `json:"port"`
+	Database    string `json:"database"`
+	Username    string `json:"username"`
+	Password    string `json:"password"`
+	URI         string `json:"uri"`
+	SSLRequired bool   `json:"sslRequired"`
 }

--- a/tests/lifecycle/postgresql_cases_test.go
+++ b/tests/lifecycle/postgresql_cases_test.go
@@ -78,7 +78,6 @@ func getPostgresqlCases(
 			provisioningParameters: &postgresqldb.ServerProvisioningParameters{
 				FirewallIPStart: "0.0.0.0",
 				FirewallIPEnd:   "255.255.255.255",
-				SSLEnforcement:  "disabled",
 			},
 			childTestCases: []*serviceLifecycleTestCase{
 				{ // db only scenario
@@ -109,16 +108,7 @@ func testPostgreSQLCreds() func(credentials service.Credentials) error {
 				"error casting credentials as *postgresqldb.Credentials",
 			)
 		}
-		connectionStrTemplate := "postgres://%s:%s@%s:%d/%s"
-		connectionString := fmt.Sprintf(
-			connectionStrTemplate,
-			cdts.Username,
-			cdts.Password,
-			cdts.Host,
-			cdts.Port,
-			cdts.Database,
-		)
-		db, err := sql.Open("postgres", connectionString)
+		db, err := sql.Open("postgres", cdts.URI)
 
 		if err != nil {
 			return fmt.Errorf("error validating the database arguments: %s", err)

--- a/tests/lifecycle/postgresql_cases_test.go
+++ b/tests/lifecycle/postgresql_cases_test.go
@@ -108,7 +108,20 @@ func testPostgreSQLCreds() func(credentials service.Credentials) error {
 				"error casting credentials as *postgresqldb.Credentials",
 			)
 		}
-		db, err := sql.Open("postgres", cdts.URI)
+		var connectionStrTemplate string
+		if cdts.SSLRequired {
+			connectionStrTemplate =
+				"postgres://%s:%s@%s/%s?sslmode=require"
+		} else {
+			connectionStrTemplate = "postgres://%s:%s@%s/%s"
+		}
+		db, err := sql.Open("postgres", fmt.Sprintf(
+			connectionStrTemplate,
+			cdts.Username,
+			cdts.Password,
+			cdts.Host,
+			cdts.Database,
+		))
 
 		if err != nil {
 			return fmt.Errorf("error validating the database arguments: %s", err)


### PR DESCRIPTION
1.) Added more info to the MySQL and PostgreSQL bind credentials.
    - uri for compliance with CF recommendations
    - SSLRequired to indicate if the connection should be done
      over SLS
2.) Enhanced lifecycle tests to verify
3.) small DRY refactor to support this

Closes #275 