### PR TITLE
separate sensitive and non-sensitive updating parameters

### DIFF
--- a/pkg/api/update_test.go
+++ b/pkg/api/update_test.go
@@ -166,7 +166,7 @@ func TestKickOffNewAsyncUpdating(t *testing.T) {
 	assert.Nil(t, err)
 	validationCalled := false
 	m.ServiceManager.UpdatingValidationBehavior =
-		func(service.UpdatingParameters) error {
+		func(service.Instance) error {
 			validationCalled = true
 			return nil
 		}

--- a/pkg/service/instance_test.go
+++ b/pkg/service/instance_test.go
@@ -36,7 +36,11 @@ func init() {
 	updatingParameters := &ArbitraryType{
 		Foo: "bat",
 	}
-	encryptedUpdatingParameters := []byte(`{"foo":"bat"}`)
+	updatingParametersJSONStr := []byte(`{"foo":"bat"}`)
+	secureUpdatingParameters := &ArbitraryType{
+		Foo: "bat",
+	}
+	encryptedSecureUpdatingParameters := []byte(`{"foo":"bat"}`)
 	statusReason := "in-progress"
 	details := &ArbitraryType{
 		Foo: "baz",
@@ -59,25 +63,26 @@ func init() {
 		ProvisioningParameters:                provisioningParameters,
 		EncryptedSecureProvisioningParameters: encryptedSecureProvisiongingParameters, // nolint: lll
 		SecureProvisioningParameters:          secureProvisioningParameters,
-		EncryptedUpdatingParameters:           encryptedUpdatingParameters,
 		UpdatingParameters:                    updatingParameters,
-		Status:                                InstanceStateProvisioning,
-		StatusReason:                          statusReason,
-		Location:                              location,
-		ResourceGroup:                         resourceGroup,
-		ParentAlias:                           parentAlias,
-		Tags:                                  map[string]string{tagKey: tagVal},
-		Details:                               details,
-		EncryptedSecureDetails:                encryptedSecureDetails,
-		SecureDetails:                         secureDetails,
-		Created:                               created,
+		EncryptedSecureUpdatingParameters:     encryptedSecureUpdatingParameters,
+		SecureUpdatingParameters:              secureUpdatingParameters,
+		Status:                 InstanceStateProvisioning,
+		StatusReason:           statusReason,
+		Location:               location,
+		ResourceGroup:          resourceGroup,
+		ParentAlias:            parentAlias,
+		Tags:                   map[string]string{tagKey: tagVal},
+		Details:                details,
+		EncryptedSecureDetails: encryptedSecureDetails,
+		SecureDetails:          secureDetails,
+		Created:                created,
 	}
 
 	b64EncryptedSecureProvisioningParameters := base64.StdEncoding.EncodeToString(
 		encryptedSecureProvisiongingParameters,
 	)
-	b64EncryptedUpdatingParameters := base64.StdEncoding.EncodeToString(
-		encryptedUpdatingParameters,
+	b64EncryptedSecureUpdatingParameters := base64.StdEncoding.EncodeToString(
+		encryptedSecureUpdatingParameters,
 	)
 	b64EncryptedSecureDetails := base64.StdEncoding.EncodeToString(
 		encryptedSecureDetails,
@@ -91,7 +96,8 @@ func init() {
 			"planId":"%s",
 			"provisioningParameters":%s,
 			"secureProvisioningParameters":"%s",
-			"updatingParameters":"%s",
+			"updatingParameters":%s,
+			"secureUpdatingParameters":"%s",
 			"status":"%s",
 			"statusReason":"%s",
 			"location":"%s",
@@ -108,7 +114,8 @@ func init() {
 		planID,
 		provisioningParametersJSONStr,
 		b64EncryptedSecureProvisioningParameters,
-		b64EncryptedUpdatingParameters,
+		updatingParametersJSONStr,
+		b64EncryptedSecureUpdatingParameters,
 		InstanceStateProvisioning,
 		statusReason,
 		location,
@@ -129,6 +136,7 @@ func init() {
 func TestNewInstanceFromJSON(t *testing.T) {
 	instance, err := NewInstanceFromJSON(
 		testInstanceJSON,
+		&ArbitraryType{},
 		&ArbitraryType{},
 		&ArbitraryType{},
 		&ArbitraryType{},
@@ -160,17 +168,17 @@ func TestEncryptSecureProvisioningParameters(t *testing.T) {
 	)
 }
 
-func TestEncryptUpdatingParameters(t *testing.T) {
+func TestEncryptSecureUpdatingParameters(t *testing.T) {
 	instance := Instance{
-		UpdatingParameters: testArbitraryObject,
+		SecureUpdatingParameters: testArbitraryObject,
 	}
 	var err error
-	instance, err = instance.encryptUpdatingParameters(noopCodec)
+	instance, err = instance.encryptSecureUpdatingParameters(noopCodec)
 	assert.Nil(t, err)
 	assert.Equal(
 		t,
 		testArbitraryObjectJSON,
-		instance.EncryptedUpdatingParameters,
+		instance.EncryptedSecureUpdatingParameters,
 	)
 }
 
@@ -201,13 +209,13 @@ func TestDecryptSecureProvisioningParameters(t *testing.T) {
 
 func TestDecryptUpdatingParameters(t *testing.T) {
 	instance := Instance{
-		EncryptedUpdatingParameters: testArbitraryObjectJSON,
-		UpdatingParameters:          &ArbitraryType{},
+		EncryptedSecureUpdatingParameters: testArbitraryObjectJSON,
+		SecureUpdatingParameters:          &ArbitraryType{},
 	}
 	var err error
-	instance, err = instance.decryptUpdatingParameters(noopCodec)
+	instance, err = instance.decryptSecureUpdatingParameters(noopCodec)
 	assert.Nil(t, err)
-	assert.Equal(t, testArbitraryObject, instance.UpdatingParameters)
+	assert.Equal(t, testArbitraryObject, instance.SecureUpdatingParameters)
 }
 
 func TestDecryptSecureDetails(t *testing.T) {

--- a/pkg/service/service_manager.go
+++ b/pkg/service/service_manager.go
@@ -24,12 +24,10 @@ type ServiceManager interface { // nolint: golint
 	// GetEmptySecureInstanceDetails returns an empty instance of sensitive
 	// service-specific instance details
 	GetEmptySecureInstanceDetails() SecureInstanceDetails
-	// GetEmptyUpdatingParameters returns an empty instance of module-specific
-	// updatingParameters
-	GetEmptyUpdatingParameters() UpdatingParameters
 	// ValidateUpdatingParameters validates the provided
-	// updatingParameters and returns an error if there is any problem
-	ValidateUpdatingParameters(UpdatingParameters) error
+	// updating parameters against allowed values and current instance state
+	// and returns an error if there is any problem
+	ValidateUpdatingParameters(Instance) error
 	// GetUpdater returns a updater that defines the steps a module must
 	// execute asynchronously to update a service.
 	GetUpdater(Plan) (Updater, error)

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -37,12 +37,6 @@ type InstanceDetails interface{}
 // types that represent the secure (sensitive) details of a service instance.
 type SecureInstanceDetails interface{}
 
-// UpdatingParameters is an interface to be implemented by module-specific
-// types that represent updating parameters. This interface doesn't require
-// any functions to be implemented. It exists to improve the clarity of function
-// signatures and documentation.
-type UpdatingParameters interface{}
-
 // BindingParameters is an interface to be implemented by service-specific types
 // that represent non-sensitive binding parameters. This interface doesn't
 // require any functions to be implemented. It exists to improve the clarity of

--- a/pkg/services/aci/types.go
+++ b/pkg/services/aci/types.go
@@ -23,10 +23,6 @@ type aciInstanceDetails struct {
 
 type aciSecureInstanceDetails struct{}
 
-// UpdatingParameters encapsulates aci-specific updating options
-type UpdatingParameters struct {
-}
-
 // BindingParameters encapsulates non-sensitive aci-specific binding options
 type BindingParameters struct {
 }
@@ -59,12 +55,6 @@ func (
 	s *serviceManager,
 ) GetEmptySecureProvisioningParameters() service.SecureProvisioningParameters {
 	return &SecureProvisioningParameters{}
-}
-
-func (
-	s *serviceManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
 }
 
 func (s *serviceManager) GetEmptyInstanceDetails() service.InstanceDetails {

--- a/pkg/services/aci/update.go
+++ b/pkg/services/aci/update.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (s *serviceManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (s *serviceManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/cosmosdb/types.go
+++ b/pkg/services/cosmosdb/types.go
@@ -29,10 +29,6 @@ type cosmosdbSecureInstanceDetails struct {
 	PrimaryKey       string `json:"primaryKey"`
 }
 
-// UpdatingParameters encapsulates CosmosDB-specific updating options
-type UpdatingParameters struct {
-}
-
 // BindingParameters encapsulates non-sensitive CosmosDB-specific binding
 // options
 type BindingParameters struct {
@@ -85,12 +81,6 @@ func (
 	s *serviceManager,
 ) GetEmptySecureInstanceDetails() service.SecureInstanceDetails {
 	return &cosmosdbSecureInstanceDetails{}
-}
-
-func (
-	s *serviceManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
 }
 
 func (s *serviceManager) GetEmptyBindingParameters() service.BindingParameters {

--- a/pkg/services/cosmosdb/update.go
+++ b/pkg/services/cosmosdb/update.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (s *serviceManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (s *serviceManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/eventhubs/types.go
+++ b/pkg/services/eventhubs/types.go
@@ -21,10 +21,6 @@ type eventHubSecureInstanceDetails struct {
 	PrimaryKey       string `json:"primaryKey"`
 }
 
-// UpdatingParameters encapsulates search-specific updating options
-type UpdatingParameters struct {
-}
-
 // BindingParameters encapsulates non-sensitive Azure Event Hub specific binding
 // options
 type BindingParameters struct {
@@ -58,12 +54,6 @@ func (
 	s *serviceManager,
 ) GetEmptySecureProvisioningParameters() service.SecureProvisioningParameters {
 	return &SecureProvisioningParameters{}
-}
-
-func (
-	s *serviceManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
 }
 
 func (

--- a/pkg/services/eventhubs/update.go
+++ b/pkg/services/eventhubs/update.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (s *serviceManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (s *serviceManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/fake/fake.go
+++ b/pkg/services/fake/fake.go
@@ -17,7 +17,7 @@ type ProvisioningValidationFunction func(
 // UpdatingValidationFunction describes a function used to provide pluggable
 // updating validation behavior to the fake implementation of the
 // service.Module interface
-type UpdatingValidationFunction func(service.UpdatingParameters) error
+type UpdatingValidationFunction func(service.Instance) error
 
 // BindingValidationFunction describes a function used to provide pluggable
 // binding validation behavior to the fake implementation of the service.Module
@@ -107,12 +107,12 @@ func (s *ServiceManager) provision(
 	return instance.Details, instance.SecureDetails, nil
 }
 
-// ValidateUpdatingParameters validates the provided updatingParameters
+// ValidateUpdatingParameters validates the provided updating parameters
 // and returns an error if there is any problem
 func (s *ServiceManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
+	instance service.Instance,
 ) error {
-	return s.UpdatingValidationBehavior(updatingParameters)
+	return s.UpdatingValidationBehavior(instance)
 }
 
 // GetUpdater returns a updater that defines the steps a module must
@@ -188,9 +188,7 @@ func defaultProvisioningValidationBehavior(
 	return nil
 }
 
-func defaultUpdatingValidationBehavior(
-	service.UpdatingParameters,
-) error {
+func defaultUpdatingValidationBehavior(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/fake/types.go
+++ b/pkg/services/fake/types.go
@@ -34,15 +34,6 @@ type InstanceDetails struct {
 // module is used to facilitate testing of the broker framework itself.
 type SecureInstanceDetails struct{}
 
-// UpdatingParameters represents parameters specific to binding to a service
-// instance using the fake service module. Note that, ordinarily, service
-// module-specific types such as this do not need to be exported. An exception
-// is made here because the fake service module is used to facilitate testing of
-// the broker framework itself.
-type UpdatingParameters struct {
-	SomeParameter string `json:"someParameter"`
-}
-
 // BindingParameters represents non-sensitive parameters specific to binding to
 // a service instance using the fake service module. Note that, ordinarily,
 // service-specific types such as this do not need to be exported. An exception
@@ -119,14 +110,6 @@ func (
 	s *ServiceManager,
 ) GetEmptySecureInstanceDetails() service.SecureInstanceDetails {
 	return &SecureInstanceDetails{}
-}
-
-// GetEmptyUpdatingParameters returns an empty instance of module-specific
-// updatingParameters
-func (
-	s *ServiceManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
 }
 
 // GetEmptyBindingParameters returns an empty instance of non-sensitive

--- a/pkg/services/keyvault/types.go
+++ b/pkg/services/keyvault/types.go
@@ -26,10 +26,6 @@ type keyvaultSecureInstanceDetails struct {
 	ClientSecret string `json:"clientSecret"`
 }
 
-// UpdatingParameters encapsulates keyvault-specific updating options
-type UpdatingParameters struct {
-}
-
 // BindingParameters encapsulates non-sensitive keyvault-specific binding
 // options
 type BindingParameters struct {
@@ -64,12 +60,6 @@ func (
 	s *serviceManager,
 ) GetEmptySecureProvisioningParameters() service.SecureProvisioningParameters {
 	return &SecureProvisioningParameters{}
-}
-
-func (
-	s *serviceManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
 }
 
 func (

--- a/pkg/services/keyvault/update.go
+++ b/pkg/services/keyvault/update.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (s *serviceManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (s *serviceManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/mysqldb/types_all_in_one.go
+++ b/pkg/services/mysqldb/types_all_in_one.go
@@ -28,12 +28,6 @@ func (
 
 func (
 	a *allInOneManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
-}
-
-func (
-	a *allInOneManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
 	return &allInOneMysqlInstanceDetails{}
 }

--- a/pkg/services/mysqldb/types_common.go
+++ b/pkg/services/mysqldb/types_common.go
@@ -12,10 +12,6 @@ type ServerProvisioningParameters struct {
 // server provisioning options
 type SecureServerProvisioningParameters struct{}
 
-// UpdatingParameters encapsulates MySQL-specific updating options
-type UpdatingParameters struct {
-}
-
 // BindingParameters encapsulates non-sensitive MySQL-specific binding options
 type BindingParameters struct {
 }

--- a/pkg/services/mysqldb/types_db_only.go
+++ b/pkg/services/mysqldb/types_db_only.go
@@ -31,12 +31,6 @@ func (
 
 func (
 	d *dbOnlyManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
-}
-
-func (
-	d *dbOnlyManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
 	return &dbOnlyMysqlInstanceDetails{}
 }

--- a/pkg/services/mysqldb/types_dbms_only.go
+++ b/pkg/services/mysqldb/types_dbms_only.go
@@ -27,12 +27,6 @@ func (
 
 func (
 	d *dbmsOnlyManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
-}
-
-func (
-	d *dbmsOnlyManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
 	return &dbmsOnlyMysqlInstanceDetails{}
 }

--- a/pkg/services/mysqldb/update_all_in_one.go
+++ b/pkg/services/mysqldb/update_all_in_one.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (a *allInOneManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (a *allInOneManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/mysqldb/update_db_only.go
+++ b/pkg/services/mysqldb/update_db_only.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (d *dbOnlyManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (d *dbOnlyManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/mysqldb/update_dbms_only.go
+++ b/pkg/services/mysqldb/update_dbms_only.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (v *dbmsOnlyManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (v *dbmsOnlyManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/postgresqldb/types_all_in_one.go
+++ b/pkg/services/postgresqldb/types_all_in_one.go
@@ -36,12 +36,6 @@ func (
 
 func (
 	a *allInOneManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
-}
-
-func (
-	a *allInOneManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
 	return &allInOnePostgresqlInstanceDetails{}
 }

--- a/pkg/services/postgresqldb/types_common.go
+++ b/pkg/services/postgresqldb/types_common.go
@@ -1,9 +1,5 @@
 package postgresqldb
 
-// UpdatingParameters encapsulates PostgreSQL-specific updating options
-type UpdatingParameters struct {
-}
-
 // BindingParameters encapsulates non-sensitive PostgreSQL-specific binding
 // options
 type BindingParameters struct {

--- a/pkg/services/postgresqldb/types_db_only.go
+++ b/pkg/services/postgresqldb/types_db_only.go
@@ -33,12 +33,6 @@ func (
 
 func (
 	d *dbOnlyManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
-}
-
-func (
-	d *dbOnlyManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
 	return &dbOnlyPostgresqlInstanceDetails{}
 }

--- a/pkg/services/postgresqldb/types_dbms_only.go
+++ b/pkg/services/postgresqldb/types_dbms_only.go
@@ -43,12 +43,6 @@ func (
 
 func (
 	d *dbmsOnlyManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
-}
-
-func (
-	d *dbmsOnlyManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
 	return &dbmsOnlyPostgresqlInstanceDetails{}
 }

--- a/pkg/services/postgresqldb/update_all_in_one.go
+++ b/pkg/services/postgresqldb/update_all_in_one.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (a *allInOneManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (a *allInOneManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/postgresqldb/update_db_only.go
+++ b/pkg/services/postgresqldb/update_db_only.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (d *dbOnlyManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (d *dbOnlyManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/postgresqldb/update_dbms_only.go
+++ b/pkg/services/postgresqldb/update_dbms_only.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (d *dbmsOnlyManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (d *dbmsOnlyManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/rediscache/types.go
+++ b/pkg/services/rediscache/types.go
@@ -20,10 +20,6 @@ type redisSecureInstanceDetails struct {
 	PrimaryKey string `json:"primaryKey"`
 }
 
-// UpdatingParameters encapsulates Redis-specific updating options
-type UpdatingParameters struct {
-}
-
 // BindingParameters encapsulates non-sensitive Redis-specific binding options
 type BindingParameters struct {
 }
@@ -55,12 +51,6 @@ func (
 	s *serviceManager,
 ) GetEmptySecureProvisioningParameters() service.SecureProvisioningParameters {
 	return &SecureProvisioningParameters{}
-}
-
-func (
-	s *serviceManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
 }
 
 func (

--- a/pkg/services/rediscache/update.go
+++ b/pkg/services/rediscache/update.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (s *serviceManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (s *serviceManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/search/types.go
+++ b/pkg/services/search/types.go
@@ -19,10 +19,6 @@ type searchSecureInstanceDetails struct {
 	APIKey string `json:"apiKey"`
 }
 
-// UpdatingParameters encapsulates search-specific updating options
-type UpdatingParameters struct {
-}
-
 // BindingParameters encapsulates non-sensitive Azure Search-specific binding
 // options
 type BindingParameters struct {
@@ -54,12 +50,6 @@ func (
 	s *serviceManager,
 ) GetEmptySecureProvisioningParameters() service.SecureProvisioningParameters {
 	return &SecureProvisioningParameters{}
-}
-
-func (
-	s *serviceManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
 }
 
 func (

--- a/pkg/services/search/update.go
+++ b/pkg/services/search/update.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (s *serviceManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (s *serviceManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/servicebus/types.go
+++ b/pkg/services/servicebus/types.go
@@ -20,10 +20,6 @@ type serviceBusSecureInstanceDetails struct {
 	PrimaryKey       string `json:"primaryKey"`
 }
 
-// UpdatingParameters encapsulates servicebus-specific updating options
-type UpdatingParameters struct {
-}
-
 // BindingParameters encapsulates non-sensitive Service Bus specific binding
 // options
 type BindingParameters struct {
@@ -57,12 +53,6 @@ func (
 	s *serviceManager,
 ) GetEmptySecureProvisioningParameters() service.SecureProvisioningParameters {
 	return &SecureProvisioningParameters{}
-}
-
-func (
-	s *serviceManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
 }
 
 func (

--- a/pkg/services/servicebus/update.go
+++ b/pkg/services/servicebus/update.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (s *serviceManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (s *serviceManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/sqldb/types_all_in_one.go
+++ b/pkg/services/sqldb/types_all_in_one.go
@@ -26,12 +26,6 @@ func (
 
 func (
 	a *allInOneManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
-}
-
-func (
-	a *allInOneManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
 	return &mssqlAllInOneInstanceDetails{}
 }

--- a/pkg/services/sqldb/types_db_only.go
+++ b/pkg/services/sqldb/types_db_only.go
@@ -33,12 +33,6 @@ func (
 
 func (
 	d *dbOnlyManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
-}
-
-func (
-	d *dbOnlyManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
 	return &mssqlDBOnlyInstanceDetails{}
 }

--- a/pkg/services/sqldb/types_dbms_only.go
+++ b/pkg/services/sqldb/types_dbms_only.go
@@ -25,12 +25,6 @@ func (
 
 func (
 	d *dbmsOnlyManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
-}
-
-func (
-	d *dbmsOnlyManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
 	return &mssqlVMOnlyInstanceDetails{}
 }

--- a/pkg/services/sqldb/update_all_in_one.go
+++ b/pkg/services/sqldb/update_all_in_one.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (a *allInOneManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (a *allInOneManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/sqldb/update_db_only.go
+++ b/pkg/services/sqldb/update_db_only.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (d *dbOnlyManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (d *dbOnlyManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/sqldb/update_dbms_only.go
+++ b/pkg/services/sqldb/update_dbms_only.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (d *dbmsOnlyManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (d *dbmsOnlyManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/services/storage/types.go
+++ b/pkg/services/storage/types.go
@@ -68,12 +68,6 @@ func (
 
 func (
 	s *serviceManager,
-) GetEmptyUpdatingParameters() service.UpdatingParameters {
-	return &UpdatingParameters{}
-}
-
-func (
-	s *serviceManager,
 ) GetEmptyInstanceDetails() service.InstanceDetails {
 	return &storageInstanceDetails{}
 }

--- a/pkg/services/storage/update.go
+++ b/pkg/services/storage/update.go
@@ -4,9 +4,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (s *serviceManager) ValidateUpdatingParameters(
-	updatingParameters service.UpdatingParameters,
-) error {
+func (s *serviceManager) ValidateUpdatingParameters(service.Instance) error {
 	return nil
 }
 

--- a/pkg/storage/memory/store.go
+++ b/pkg/storage/memory/store.go
@@ -65,6 +65,7 @@ func (s *store) GetInstance(instanceID string) (
 		nil,
 		nil,
 		nil,
+		nil,
 		s.codec,
 	)
 	if err != nil {
@@ -94,7 +95,8 @@ func (s *store) GetInstance(instanceID string) (
 		json,
 		serviceManager.GetEmptyProvisioningParameters(),
 		serviceManager.GetEmptySecureProvisioningParameters(),
-		serviceManager.GetEmptyUpdatingParameters(),
+		serviceManager.GetEmptyProvisioningParameters(),
+		serviceManager.GetEmptySecureProvisioningParameters(),
 		serviceManager.GetEmptyInstanceDetails(),
 		serviceManager.GetEmptySecureInstanceDetails(),
 		s.codec,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -102,6 +102,7 @@ func (s *store) GetInstance(instanceID string) (service.Instance, bool, error) {
 		nil,
 		nil,
 		nil,
+		nil,
 		s.codec,
 	)
 	if err != nil {
@@ -131,7 +132,8 @@ func (s *store) GetInstance(instanceID string) (service.Instance, bool, error) {
 		bytes,
 		serviceManager.GetEmptyProvisioningParameters(),
 		serviceManager.GetEmptySecureProvisioningParameters(),
-		serviceManager.GetEmptyUpdatingParameters(),
+		serviceManager.GetEmptyProvisioningParameters(),
+		serviceManager.GetEmptySecureProvisioningParameters(),
 		serviceManager.GetEmptyInstanceDetails(),
 		serviceManager.GetEmptySecureInstanceDetails(),
 		s.codec,

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -137,7 +137,7 @@ func TestGetExistingInstance(t *testing.T) {
 	retrievedInstance.Service = nil
 	retrievedInstance.Plan = nil
 	retrievedInstance.EncryptedSecureProvisioningParameters = nil
-	retrievedInstance.EncryptedUpdatingParameters = nil
+	retrievedInstance.EncryptedSecureUpdatingParameters = nil
 	retrievedInstance.EncryptedSecureDetails = nil
 	assert.Equal(t, instance, retrievedInstance)
 }
@@ -178,8 +178,8 @@ func TestGetExistingInstanceWithParent(t *testing.T) {
 	retrievedInstance.Parent.Plan = nil
 	retrievedInstance.EncryptedSecureProvisioningParameters = nil
 	retrievedInstance.Parent.EncryptedSecureProvisioningParameters = nil
-	retrievedInstance.EncryptedUpdatingParameters = nil
-	retrievedInstance.Parent.EncryptedUpdatingParameters = nil
+	retrievedInstance.EncryptedSecureUpdatingParameters = nil
+	retrievedInstance.Parent.EncryptedSecureUpdatingParameters = nil
 	retrievedInstance.EncryptedSecureDetails = nil
 	retrievedInstance.Parent.EncryptedSecureDetails = nil
 	assert.Equal(t, instance, retrievedInstance)
@@ -219,7 +219,7 @@ func TestGetExistingInstanceByAlias(t *testing.T) {
 	retrievedInstance.Service = nil
 	retrievedInstance.Plan = nil
 	retrievedInstance.EncryptedSecureProvisioningParameters = nil
-	retrievedInstance.EncryptedUpdatingParameters = nil
+	retrievedInstance.EncryptedSecureUpdatingParameters = nil
 	retrievedInstance.EncryptedSecureDetails = nil
 	assert.Equal(t, instance, retrievedInstance)
 }
@@ -429,14 +429,15 @@ func getTestInstance() service.Instance {
 		PlanID:                       fake.StandardPlanID,
 		ProvisioningParameters:       fakeServiceManager.GetEmptyProvisioningParameters(),       // nolint: lll
 		SecureProvisioningParameters: fakeServiceManager.GetEmptySecureProvisioningParameters(), // nolint: lll
-		UpdatingParameters:           fakeServiceManager.GetEmptyUpdatingParameters(),           // nolint: lll
-		Status:                       service.InstanceStateProvisioned,
-		StatusReason:                 "",
-		Location:                     "eastus",
-		ResourceGroup:                "test",
-		Tags:                         map[string]string{"foo": "bar"},
-		Details:                      fakeServiceManager.GetEmptyInstanceDetails(),
-		SecureDetails:                fakeServiceManager.GetEmptySecureInstanceDetails(), // nolint: lll
+		UpdatingParameters:           fakeServiceManager.GetEmptyProvisioningParameters(),       // nolint: lll
+		SecureUpdatingParameters:     fakeServiceManager.GetEmptySecureProvisioningParameters(), // nolint: lll
+		Status:        service.InstanceStateProvisioned,
+		StatusReason:  "",
+		Location:      "eastus",
+		ResourceGroup: "test",
+		Tags:          map[string]string{"foo": "bar"},
+		Details:       fakeServiceManager.GetEmptyInstanceDetails(),
+		SecureDetails: fakeServiceManager.GetEmptySecureInstanceDetails(), // nolint: lll
 	}
 }
 


### PR DESCRIPTION
Though smaller, this PR isn't quite as simple as other recent PRs that were _similar_, but larger.

As with similar PRs, this is a continuation of an effort to me more selective about what is encrypted at rest and what isn't (see #272). What is different in this case is that existing types `ProvisioningParameters` and `SecureProvisioningParameters` are being re-used for and `Instance`'s `UpdatingParameters` and `SecureUpdatingParameters` fields, respectively.

The reasoning is this...

First, we need to acknowledge that updating isn't fully implemented or tested yet _and_ that no modules are currently offering `plan_updateable` services. There's a lot of work that remains to be sorted out on this front.

According to the OSB spec, updating

> can enable users to modify two attributes of an existing Service Instance: the Service Plan and parameters.

It is my belief that at the _end_ of a successful update, a service instance should appear the same as if it were _originally_ provisioned in its new state. To this end, _to whatever extent individual modules / services will allow it_, the updating parameters should be viewed as a _replacement_ for the provisioning parameters. They must be maintained separately from one another for the duration of the update, but when complete, I expect the original provisioning parameters will be overwritten with the updating parameters and the updating parameters will be nilled out.

Conclusion: Provisioning parameters and updating parameters _should be the same type_.

Given the above, two change to the `ServiceManager` are advisable:

1. Validation of updating parameters must weigh an instance's existing state to determine if the requested modifications are valid. Therefore, service `Instance`s should be passed to the `ValidateUpdatingParameters(...)` function.

1. There is no longer a need for a `GetEmptyUpdatingParameters()` function (nor is there now a need for a GetEmptySecureUpdatingParameters()`. `GetEmptyProvisioningParameters()` and `GetEmptySecureProvisioningParameters()` can simply be reused in any case where the broker core needs to obtain empty updating parameters.

Note that this PR in no way fixes the half-implemented / untested update process. It's only taking small, sensible steps in that direction.

#292 should be merged first.