### PR TITLE
Replacing MySQL Firewall Rules with Go Templates

### DIFF
--- a/contrib/k8s/examples/mysqldb-instance.yaml
+++ b/contrib/k8s/examples/mysqldb-instance.yaml
@@ -10,6 +10,6 @@ spec:
     location: eastus
     resourceGroup: demo
     firewallRules:
-      - firewallStartIPAddress: "0.0.0.0"
-        firewallEndIPAddress: "255.255.255.255"
-        firewallRuleName: "AllowAll"
+    - firewallStartIPAddress: "0.0.0.0"
+      firewallEndIPAddress: "255.255.255.255"
+      firewallRuleName: "AllowAll"

--- a/contrib/k8s/examples/mysqldb-instance.yaml
+++ b/contrib/k8s/examples/mysqldb-instance.yaml
@@ -9,5 +9,7 @@ spec:
   parameters:
     location: eastus
     resourceGroup: demo
-    firewallStartIPAddress: "0.0.0.0"
-    firewallEndIPAddress: "255.255.255.255"
+    firewallRules:
+      - firewallStartIPAddress: "0.0.0.0"
+        firewallEndIPAddress: "255.255.255.255"
+        firewallRuleName: "AllowAll"

--- a/contrib/k8s/examples/mysqldb-instance.yaml
+++ b/contrib/k8s/examples/mysqldb-instance.yaml
@@ -10,6 +10,6 @@ spec:
     location: eastus
     resourceGroup: demo
     firewallRules:
-    - firewallStartIPAddress: "0.0.0.0"
-      firewallEndIPAddress: "255.255.255.255"
-      firewallRuleName: "AllowAll"
+    - startIPAddress: "0.0.0.0"
+      endIPAddress: "255.255.255.255"
+      name: "AllowAll"

--- a/docs/modules/mysqldb.md
+++ b/docs/modules/mysqldb.md
@@ -15,7 +15,7 @@
 #### Behaviors
 
 ##### Provision
-  
+
 Provisions a new MySQL server and a new database upon that server. The new
 database will be named randomly.
 
@@ -26,10 +26,14 @@ database will be named randomly.
 | `location` | `string` | The Azure region in which to provision applicable resources. | Required _unless_ an administrator has configured the broker itself with a default location. | The broker's default location, if configured. |
 | `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and nonde is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
 | `sslEnforcement` | `string` | Specifies whether the server requires the use of TLS when connecting. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | `""`. Left unspecified, SSL _will_ be enforced. |
+| `firewallRules`  | `array` | Specifies the firewall rules to apply to the server. Definition follows. | N | `[]` Left unspecified, Firewall will default to only Azure IPs. If rules are provided, they must have valid values. |
+| `firewallRules[0].firewallRuleName` | Specifies the name of the generated firewall rule | Y | |
+| `firewallRules[0].firewallStartIPAddress` | Specifies the start of the IP range allowed by this firewall rule | Y | |
+| `firewallRules[0].firewallEndIPAddress` | Specifies the end of the IP range allowed by this firewall rule | Y | |
 | `tags` | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
-  
+
 ##### Bind
-  
+
 Creates a new user on the MySQL server. The new user will be named randomly and
 will be granted a wide array of permissions on the database.
 
@@ -52,7 +56,7 @@ Binding returns the following connection details and credentials:
 ##### Unbind
 
 Drops the applicable user from the MySQL server.
-  
+
 ##### Deprovision
 
 Deletes the MySQL server.

--- a/docs/modules/mysqldb.md
+++ b/docs/modules/mysqldb.md
@@ -27,9 +27,9 @@ database will be named randomly.
 | `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and nonde is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
 | `sslEnforcement` | `string` | Specifies whether the server requires the use of TLS when connecting. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | `""`. Left unspecified, SSL _will_ be enforced. |
 | `firewallRules`  | `array` | Specifies the firewall rules to apply to the server. Definition follows. | N | `[]` Left unspecified, Firewall will default to only Azure IPs. If rules are provided, they must have valid values. |
-| `firewallRules[0].firewallRuleName` | Specifies the name of the generated firewall rule | Y | |
-| `firewallRules[0].firewallStartIPAddress` | Specifies the start of the IP range allowed by this firewall rule | Y | |
-| `firewallRules[0].firewallEndIPAddress` | Specifies the end of the IP range allowed by this firewall rule | Y | |
+| `firewallRules[0].firewallRuleName` | `string` | Specifies the name of the generated firewall rule |Y | |
+| `firewallRules[0].firewallStartIPAddress` | `string` | Specifies the start of the IP range allowed by this firewall rule | Y | |
+| `firewallRules[0].firewallEndIPAddress` | `string` | Specifies the end of the IP range allowed by this firewall rule | Y | |
 | `tags` | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
 
 ##### Bind

--- a/docs/modules/mysqldb.md
+++ b/docs/modules/mysqldb.md
@@ -27,9 +27,9 @@ database will be named randomly.
 | `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and nonde is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
 | `sslEnforcement` | `string` | Specifies whether the server requires the use of TLS when connecting. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | `""`. Left unspecified, SSL _will_ be enforced. |
 | `firewallRules`  | `array` | Specifies the firewall rules to apply to the server. Definition follows. | N | `[]` Left unspecified, Firewall will default to only Azure IPs. If rules are provided, they must have valid values. |
-| `firewallRules[n].firewallRuleName` | `string` | Specifies the name of the generated firewall rule |Y | |
-| `firewallRules[n].firewallStartIPAddress` | `string` | Specifies the start of the IP range allowed by this firewall rule | Y | |
-| `firewallRules[n].firewallEndIPAddress` | `string` | Specifies the end of the IP range allowed by this firewall rule | Y | |
+| `firewallRules[n].name` | `string` | Specifies the name of the generated firewall rule |Y | |
+| `firewallRules[n].startIPAddress` | `string` | Specifies the start of the IP range allowed by this firewall rule | Y | |
+| `firewallRules[n].endIPAddress` | `string` | Specifies the end of the IP range allowed by this firewall rule | Y | |
 | `tags` | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
 
 ##### Bind

--- a/docs/modules/mysqldb.md
+++ b/docs/modules/mysqldb.md
@@ -27,9 +27,9 @@ database will be named randomly.
 | `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and nonde is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
 | `sslEnforcement` | `string` | Specifies whether the server requires the use of TLS when connecting. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | `""`. Left unspecified, SSL _will_ be enforced. |
 | `firewallRules`  | `array` | Specifies the firewall rules to apply to the server. Definition follows. | N | `[]` Left unspecified, Firewall will default to only Azure IPs. If rules are provided, they must have valid values. |
-| `firewallRules[0].firewallRuleName` | `string` | Specifies the name of the generated firewall rule |Y | |
-| `firewallRules[0].firewallStartIPAddress` | `string` | Specifies the start of the IP range allowed by this firewall rule | Y | |
-| `firewallRules[0].firewallEndIPAddress` | `string` | Specifies the end of the IP range allowed by this firewall rule | Y | |
+| `firewallRules[n].firewallRuleName` | `string` | Specifies the name of the generated firewall rule |Y | |
+| `firewallRules[n].firewallStartIPAddress` | `string` | Specifies the start of the IP range allowed by this firewall rule | Y | |
+| `firewallRules[n].firewallEndIPAddress` | `string` | Specifies the end of the IP range allowed by this firewall rule | Y | |
 | `tags` | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
 
 ##### Bind

--- a/pkg/services/mysqldb/arm_template_all_in_one.go
+++ b/pkg/services/mysqldb/arm_template_all_in_one.go
@@ -45,24 +45,6 @@ var allInOneArmTemplateBytes = []byte(`
 			"minLength": 2,
 			"maxLength": 63
 		},
-		"firewallRuleName": {
-			"type": "string",
-			"minLength": 1,
-			"maxLength": 128,
-			"defaultValue": "AllowAll"
-		},
-		"firewallStartIpAddress": {
-			"type": "string",
-			"minLength": 1,
-			"maxLength": 15,
-			"defaultValue": "0.0.0.0"
-		},
-		"firewallEndIpAddress": {
-			"type": "string",
-			"minLength": 1,
-			"maxLength": 15,
-			"defaultValue": "0.0.0.0"
-		},
 		"sslEnforcement": {
 			"type": "string",
 			"allowedValues": [ "Enabled", "Disabled" ],
@@ -97,6 +79,7 @@ var allInOneArmTemplateBytes = []byte(`
 			"type": "Microsoft.DBforMySQL/servers",
 			"tags": "[parameters('tags')]",
 			"resources": [
+				{{range .firewallRules}}
 				{
 					"type": "firewallrules",
 					"apiVersion": "[variables('DBforMySQLapiVersion')]",
@@ -104,20 +87,23 @@ var allInOneArmTemplateBytes = []byte(`
 						"[concat('Microsoft.DBforMySQL/servers/', parameters('serverName'))]"
 					],
 					"location": "[parameters('location')]",
-					"name": "[parameters('firewallRuleName')]",
+					"name": "{{.FirewallRuleName}}",
 					"properties": {
-						"startIpAddress": "[parameters('firewallStartIpAddress')]",
-						"endIpAddress": "[parameters('firewallEndIpAddress')]"
+						"startIpAddress": "{{.FirewallIPStart}}",
+						"endIpAddress": "{{.FirewallIPEnd}}"
 					}
 				},
+				{{end}}
 				{
 					"apiVersion": "2017-04-30-preview",
 					"name": "[parameters('databaseName')]",
 					"type": "databases",
 					"location": "[parameters('location')]",
 					"dependsOn": [
-							"[concat('Microsoft.DBforMySQL/servers/', parameters('serverName'))]",
-							"[concat('Microsoft.DBforMySQL/servers/', parameters('serverName'), '/firewallrules/', parameters('firewallRuleName'))]"
+						{{range .firewallRules}}
+						"[concat('Microsoft.DBforMySQL/servers/', parameters('serverName'), '/firewallrules/', '{{.FirewallRuleName}}')]",
+						{{end}}
+							"[concat('Microsoft.DBforMySQL/servers/', parameters('serverName'))]"
 					],
 					"properties": {}
 				}

--- a/pkg/services/mysqldb/arm_template_all_in_one.go
+++ b/pkg/services/mysqldb/arm_template_all_in_one.go
@@ -87,10 +87,10 @@ var allInOneArmTemplateBytes = []byte(`
 						"[concat('Microsoft.DBforMySQL/servers/', parameters('serverName'))]"
 					],
 					"location": "[parameters('location')]",
-					"name": "{{.FirewallRuleName}}",
+					"name": "{{.Name}}",
 					"properties": {
-						"startIpAddress": "{{.FirewallIPStart}}",
-						"endIpAddress": "{{.FirewallIPEnd}}"
+						"startIpAddress": "{{.StartIP}}",
+						"endIpAddress": "{{.EndIP}}"
 					}
 				},
 				{{end}}
@@ -101,7 +101,7 @@ var allInOneArmTemplateBytes = []byte(`
 					"location": "[parameters('location')]",
 					"dependsOn": [
 						{{range .firewallRules}}
-						"[concat('Microsoft.DBforMySQL/servers/', parameters('serverName'), '/firewallrules/', '{{.FirewallRuleName}}')]",
+						"[concat('Microsoft.DBforMySQL/servers/', parameters('serverName'), '/firewallrules/', '{{.Name}}')]",
 						{{end}}
 							"[concat('Microsoft.DBforMySQL/servers/', parameters('serverName'))]"
 					],

--- a/pkg/services/mysqldb/arm_template_dbms_only.go
+++ b/pkg/services/mysqldb/arm_template_dbms_only.go
@@ -40,24 +40,6 @@ var dbmsOnlyARMTemplate = []byte(`
 				"allowedValues": [ "5.7", "5.6" ],
 				"defaultValue": "5.7"
 			},
-			"firewallRuleName": {
-				"type": "string",
-				"minLength": 1,
-				"maxLength": 128,
-				"defaultValue": "AllowAll"
-			},
-			"firewallStartIpAddress": {
-				"type": "string",
-				"minLength": 1,
-				"maxLength": 15,
-				"defaultValue": "0.0.0.0"
-			},
-			"firewallEndIpAddress": {
-				"type": "string",
-				"minLength": 1,
-				"maxLength": 15,
-				"defaultValue": "0.0.0.0"
-			},
 			"sslEnforcement": {
 				"type": "string",
 				"allowedValues": [ "Enabled", "Disabled" ],
@@ -92,6 +74,8 @@ var dbmsOnlyARMTemplate = []byte(`
 				"type": "Microsoft.DBforMySQL/servers",
 				"tags": "[parameters('tags')]",
 				"resources": [
+					{{$count:= sub (len .firewallRules)  1}}
+					{{range $i, $rule := .firewallRules}}
 					{
 						"type": "firewallrules",
 						"apiVersion": "[variables('DBforMySQLapiVersion')]",
@@ -99,12 +83,13 @@ var dbmsOnlyARMTemplate = []byte(`
 							"[concat('Microsoft.DBforMySQL/servers/', parameters('serverName'))]"
 						],
 						"location": "[parameters('location')]",
-						"name": "[parameters('firewallRuleName')]",
+						"name": "{{$rule.FirewallRuleName}}",
 						"properties": {
-							"startIpAddress": "[parameters('firewallStartIpAddress')]",
-							"endIpAddress": "[parameters('firewallEndIpAddress')]"
+							"startIpAddress": "{{$rule.FirewallIPStart}}",
+							"endIpAddress": "{{$rule.FirewallIPEnd}}"
 						}
-					}
+					}{{if lt $i $count}},{{end}}
+					{{end}}
 				]
 			}
 		],

--- a/pkg/services/mysqldb/arm_template_dbms_only.go
+++ b/pkg/services/mysqldb/arm_template_dbms_only.go
@@ -83,10 +83,10 @@ var dbmsOnlyARMTemplate = []byte(`
 							"[concat('Microsoft.DBforMySQL/servers/', parameters('serverName'))]"
 						],
 						"location": "[parameters('location')]",
-						"name": "{{$rule.FirewallRuleName}}",
+						"name": "{{$rule.Name}}",
 						"properties": {
-							"startIpAddress": "{{$rule.FirewallIPStart}}",
-							"endIpAddress": "{{$rule.FirewallIPEnd}}"
+							"startIpAddress": "{{$rule.StartIP}}",
+							"endIpAddress": "{{$rule.EndIP}}"
 						}
 					}{{if lt $i $count}},{{end}}
 					{{end}}

--- a/pkg/services/mysqldb/provision_all_in_one.go
+++ b/pkg/services/mysqldb/provision_all_in_one.go
@@ -104,15 +104,6 @@ func (a *allInOneManager) buildARMTemplateParameters(
 		"skuSizeMB":      plan.GetProperties().Extended["skuSizeMB"],
 		"sslEnforcement": sslEnforcement,
 	}
-	//Only include these if they are not empty.
-	//ARM Deployer will fail if the values included are not
-	//valid IPV4 addresses (i.e. empty string will fail)
-	if provisioningParameters.FirewallIPStart != "" {
-		p["firewallStartIpAddress"] = provisioningParameters.FirewallIPStart
-	}
-	if provisioningParameters.FirewallIPEnd != "" {
-		p["firewallEndIpAddress"] = provisioningParameters.FirewallIPEnd
-	}
 	return p
 }
 
@@ -146,12 +137,13 @@ func (a *allInOneManager) deployARMTemplate(
 		sdt,
 		pp,
 	)
+	goTemplateParameters := buildGoTemplateParameters(pp)
 	outputs, err := a.armDeployer.Deploy(
 		dt.ARMDeploymentName,
 		instance.ResourceGroup,
 		instance.Location,
 		allInOneArmTemplateBytes,
-		nil, // Go template params
+		goTemplateParameters, // Go template params
 		armTemplateParameters,
 		instance.Tags,
 	)

--- a/pkg/services/mysqldb/provision_all_in_one.go
+++ b/pkg/services/mysqldb/provision_all_in_one.go
@@ -85,7 +85,6 @@ func (a *allInOneManager) buildARMTemplateParameters(
 	plan service.Plan,
 	details *allInOneMysqlInstanceDetails,
 	secureDetails *allInOneMysqlSecureInstanceDetails,
-	provisioningParameters *ServerProvisioningParameters,
 ) map[string]interface{} {
 	var sslEnforcement string
 	if details.EnforceSSL {
@@ -135,7 +134,6 @@ func (a *allInOneManager) deployARMTemplate(
 		instance.Plan,
 		dt,
 		sdt,
-		pp,
 	)
 	goTemplateParameters := buildGoTemplateParameters(pp)
 	outputs, err := a.armDeployer.Deploy(
@@ -143,7 +141,7 @@ func (a *allInOneManager) deployARMTemplate(
 		instance.ResourceGroup,
 		instance.Location,
 		allInOneArmTemplateBytes,
-		goTemplateParameters, // Go template params
+		goTemplateParameters,
 		armTemplateParameters,
 		instance.Tags,
 	)

--- a/pkg/services/mysqldb/provision_all_in_one_test.go
+++ b/pkg/services/mysqldb/provision_all_in_one_test.go
@@ -19,9 +19,9 @@ func TestValidateGoodFirewallConfig(t *testing.T) {
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
 			{
-				FirewallRuleName: "good rule",
-				FirewallIPStart:  "192.168.86.1",
-				FirewallIPEnd:    "192.168.86.100",
+				Name:    "good rule",
+				StartIP: "192.168.86.1",
+				EndIP:   "192.168.86.100",
 			},
 		},
 	}
@@ -34,14 +34,14 @@ func TestValidateMultipleGoodFirewallConfig(t *testing.T) {
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
 			{
-				FirewallRuleName: "good rule",
-				FirewallIPStart:  "192.168.86.1",
-				FirewallIPEnd:    "192.168.86.100",
+				Name:    "good rule",
+				StartIP: "192.168.86.1",
+				EndIP:   "192.168.86.100",
 			},
 			{
-				FirewallRuleName: "good rule 2",
-				FirewallIPStart:  "192.168.86.101",
-				FirewallIPEnd:    "192.168.86.150",
+				Name:    "good rule 2",
+				StartIP: "192.168.86.101",
+				EndIP:   "192.168.86.150",
 			},
 		},
 	}
@@ -54,15 +54,15 @@ func TestValidateMissingFirewallRuleName(t *testing.T) {
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
 			{
-				FirewallIPStart: "192.168.86.1",
-				FirewallIPEnd:   "192.168.86.100",
+				StartIP: "192.168.86.1",
+				EndIP:   "192.168.86.100",
 			},
 		},
 	}
 	error := sm.ValidateProvisioningParameters(pp, nil)
 	v, ok := error.(*service.ValidationError)
 	assert.True(t, ok)
-	assert.Equal(t, v.Field, "firewallRuleName")
+	assert.Equal(t, v.Field, "name")
 }
 
 func TestValidateMissingEndFirewallConfig(t *testing.T) {
@@ -70,8 +70,8 @@ func TestValidateMissingEndFirewallConfig(t *testing.T) {
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
 			{
-				FirewallRuleName: "Test",
-				FirewallIPStart:  "192.168.86.1",
+				Name:    "Test",
+				StartIP: "192.168.86.1",
 			},
 		},
 	}
@@ -79,7 +79,7 @@ func TestValidateMissingEndFirewallConfig(t *testing.T) {
 	assert.NotNil(t, error)
 	v, ok := error.(*service.ValidationError)
 	assert.True(t, ok)
-	assert.Equal(t, v.Field, "firewallEndIPAddress")
+	assert.Equal(t, v.Field, "endIPAddress")
 }
 
 func TestValidateMissingStartFirewallConfig(t *testing.T) {
@@ -87,8 +87,8 @@ func TestValidateMissingStartFirewallConfig(t *testing.T) {
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
 			{
-				FirewallRuleName: "Test",
-				FirewallIPEnd:    "192.168.86.200",
+				Name:  "Test",
+				EndIP: "192.168.86.200",
 			},
 		},
 	}
@@ -96,7 +96,7 @@ func TestValidateMissingStartFirewallConfig(t *testing.T) {
 	assert.NotNil(t, error)
 	v, ok := error.(*service.ValidationError)
 	assert.True(t, ok)
-	assert.Equal(t, v.Field, "firewallStartIPAddress")
+	assert.Equal(t, v.Field, "startIPAddress")
 }
 
 func TestValidateInvalidIP(t *testing.T) {
@@ -104,9 +104,9 @@ func TestValidateInvalidIP(t *testing.T) {
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
 			{
-				FirewallRuleName: "Test",
-				FirewallIPStart:  "decafbad",
-				FirewallIPEnd:    "192.168.86.200",
+				Name:    "Test",
+				StartIP: "decafbad",
+				EndIP:   "192.168.86.200",
 			},
 		},
 	}
@@ -114,7 +114,7 @@ func TestValidateInvalidIP(t *testing.T) {
 	assert.NotNil(t, error)
 	v, ok := error.(*service.ValidationError)
 	assert.True(t, ok)
-	assert.Equal(t, v.Field, "firewallStartIPAddress")
+	assert.Equal(t, v.Field, "startIPAddress")
 }
 
 func TestValidateIncompleteIP(t *testing.T) {
@@ -122,9 +122,9 @@ func TestValidateIncompleteIP(t *testing.T) {
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
 			{
-				FirewallRuleName: "Test",
-				FirewallIPStart:  "192.168.",
-				FirewallIPEnd:    "192.168.86.200",
+				Name:    "Test",
+				StartIP: "192.168.",
+				EndIP:   "192.168.86.200",
 			},
 		},
 	}
@@ -132,5 +132,5 @@ func TestValidateIncompleteIP(t *testing.T) {
 	assert.NotNil(t, error)
 	v, ok := error.(*service.ValidationError)
 	assert.True(t, ok)
-	assert.Equal(t, v.Field, "firewallStartIPAddress")
+	assert.Equal(t, v.Field, "startIPAddress")
 }

--- a/pkg/services/mysqldb/provision_all_in_one_test.go
+++ b/pkg/services/mysqldb/provision_all_in_one_test.go
@@ -18,7 +18,7 @@ func TestValidateGoodFirewallConfig(t *testing.T) {
 	sm := &allInOneManager{}
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
-			FirewallRule{
+			{
 				FirewallRuleName: "good rule",
 				FirewallIPStart:  "192.168.86.1",
 				FirewallIPEnd:    "192.168.86.100",
@@ -33,12 +33,12 @@ func TestValidateMultipleGoodFirewallConfig(t *testing.T) {
 	sm := &allInOneManager{}
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
-			FirewallRule{
+			{
 				FirewallRuleName: "good rule",
 				FirewallIPStart:  "192.168.86.1",
 				FirewallIPEnd:    "192.168.86.100",
 			},
-			FirewallRule{
+			{
 				FirewallRuleName: "good rule 2",
 				FirewallIPStart:  "192.168.86.101",
 				FirewallIPEnd:    "192.168.86.150",
@@ -53,7 +53,7 @@ func TestValidateMissingFirewallRuleName(t *testing.T) {
 	sm := &allInOneManager{}
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
-			FirewallRule{
+			{
 				FirewallIPStart: "192.168.86.1",
 				FirewallIPEnd:   "192.168.86.100",
 			},
@@ -69,7 +69,7 @@ func TestValidateMissingEndFirewallConfig(t *testing.T) {
 	sm := &allInOneManager{}
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
-			FirewallRule{
+			{
 				FirewallRuleName: "Test",
 				FirewallIPStart:  "192.168.86.1",
 			},
@@ -86,7 +86,7 @@ func TestValidateMissingStartFirewallConfig(t *testing.T) {
 	sm := &allInOneManager{}
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
-			FirewallRule{
+			{
 				FirewallRuleName: "Test",
 				FirewallIPEnd:    "192.168.86.200",
 			},
@@ -103,7 +103,7 @@ func TestValidateInvalidIP(t *testing.T) {
 	sm := &allInOneManager{}
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
-			FirewallRule{
+			{
 				FirewallRuleName: "Test",
 				FirewallIPStart:  "decafbad",
 				FirewallIPEnd:    "192.168.86.200",
@@ -121,7 +121,7 @@ func TestValidateIncompleteIP(t *testing.T) {
 	sm := &allInOneManager{}
 	pp := &ServerProvisioningParameters{
 		FirewallRules: []FirewallRule{
-			FirewallRule{
+			{
 				FirewallRuleName: "Test",
 				FirewallIPStart:  "192.168.",
 				FirewallIPEnd:    "192.168.86.200",

--- a/pkg/services/mysqldb/provision_all_in_one_test.go
+++ b/pkg/services/mysqldb/provision_all_in_one_test.go
@@ -17,17 +17,63 @@ func TestValidateNoFirewallConfig(t *testing.T) {
 func TestValidateGoodFirewallConfig(t *testing.T) {
 	sm := &allInOneManager{}
 	pp := &ServerProvisioningParameters{
-		FirewallIPStart: "192.168.86.1",
-		FirewallIPEnd:   "192.168.86.100",
+		FirewallRules: []FirewallRule{
+			FirewallRule{
+				FirewallRuleName: "good rule",
+				FirewallIPStart:  "192.168.86.1",
+				FirewallIPEnd:    "192.168.86.100",
+			},
+		},
 	}
 	error := sm.ValidateProvisioningParameters(pp, nil)
 	assert.Nil(t, error)
 }
 
+func TestValidateMultipleGoodFirewallConfig(t *testing.T) {
+	sm := &allInOneManager{}
+	pp := &ServerProvisioningParameters{
+		FirewallRules: []FirewallRule{
+			FirewallRule{
+				FirewallRuleName: "good rule",
+				FirewallIPStart:  "192.168.86.1",
+				FirewallIPEnd:    "192.168.86.100",
+			},
+			FirewallRule{
+				FirewallRuleName: "good rule 2",
+				FirewallIPStart:  "192.168.86.101",
+				FirewallIPEnd:    "192.168.86.150",
+			},
+		},
+	}
+	error := sm.ValidateProvisioningParameters(pp, nil)
+	assert.Nil(t, error)
+}
+
+func TestValidateMissingFirewallRuleName(t *testing.T) {
+	sm := &allInOneManager{}
+	pp := &ServerProvisioningParameters{
+		FirewallRules: []FirewallRule{
+			FirewallRule{
+				FirewallIPStart: "192.168.86.1",
+				FirewallIPEnd:   "192.168.86.100",
+			},
+		},
+	}
+	error := sm.ValidateProvisioningParameters(pp, nil)
+	v, ok := error.(*service.ValidationError)
+	assert.True(t, ok)
+	assert.Equal(t, v.Field, "firewallRuleName")
+}
+
 func TestValidateMissingEndFirewallConfig(t *testing.T) {
 	sm := &allInOneManager{}
 	pp := &ServerProvisioningParameters{
-		FirewallIPStart: "192.168.86.1",
+		FirewallRules: []FirewallRule{
+			FirewallRule{
+				FirewallRuleName: "Test",
+				FirewallIPStart:  "192.168.86.1",
+			},
+		},
 	}
 	error := sm.ValidateProvisioningParameters(pp, nil)
 	assert.NotNil(t, error)
@@ -39,7 +85,12 @@ func TestValidateMissingEndFirewallConfig(t *testing.T) {
 func TestValidateMissingStartFirewallConfig(t *testing.T) {
 	sm := &allInOneManager{}
 	pp := &ServerProvisioningParameters{
-		FirewallIPEnd: "192.168.86.200",
+		FirewallRules: []FirewallRule{
+			FirewallRule{
+				FirewallRuleName: "Test",
+				FirewallIPEnd:    "192.168.86.200",
+			},
+		},
 	}
 	error := sm.ValidateProvisioningParameters(pp, nil)
 	assert.NotNil(t, error)
@@ -51,8 +102,13 @@ func TestValidateMissingStartFirewallConfig(t *testing.T) {
 func TestValidateInvalidIP(t *testing.T) {
 	sm := &allInOneManager{}
 	pp := &ServerProvisioningParameters{
-		FirewallIPStart: "decafbad",
-		FirewallIPEnd:   "192.168.86.200",
+		FirewallRules: []FirewallRule{
+			FirewallRule{
+				FirewallRuleName: "Test",
+				FirewallIPStart:  "decafbad",
+				FirewallIPEnd:    "192.168.86.200",
+			},
+		},
 	}
 	error := sm.ValidateProvisioningParameters(pp, nil)
 	assert.NotNil(t, error)
@@ -64,8 +120,13 @@ func TestValidateInvalidIP(t *testing.T) {
 func TestValidateIncompleteIP(t *testing.T) {
 	sm := &allInOneManager{}
 	pp := &ServerProvisioningParameters{
-		FirewallIPStart: "192.168.",
-		FirewallIPEnd:   "192.168.86.200",
+		FirewallRules: []FirewallRule{
+			FirewallRule{
+				FirewallRuleName: "Test",
+				FirewallIPStart:  "192.168.",
+				FirewallIPEnd:    "192.168.86.200",
+			},
+		},
 	}
 	error := sm.ValidateProvisioningParameters(pp, nil)
 	assert.NotNil(t, error)

--- a/pkg/services/mysqldb/provision_common.go
+++ b/pkg/services/mysqldb/provision_common.go
@@ -33,38 +33,38 @@ func validateServerProvisionParameters(
 		)
 	}
 	for _, firewallRule := range pp.FirewallRules {
-		if firewallRule.FirewallRuleName == "" {
+		if firewallRule.Name == "" {
 			return service.NewValidationError(
-				"firewallRuleName",
+				"name",
 				"must be set",
 			)
 		}
-		if firewallRule.FirewallIPStart != "" || firewallRule.FirewallIPEnd != "" {
-			if firewallRule.FirewallIPStart == "" {
+		if firewallRule.StartIP != "" || firewallRule.EndIP != "" {
+			if firewallRule.StartIP == "" {
 				return service.NewValidationError(
-					"firewallStartIPAddress",
-					"must be set when firewallEndIPAddress is set",
+					"startIPAddress",
+					"must be set when endIPAddress is set",
 				)
 			}
-			if firewallRule.FirewallIPEnd == "" {
+			if firewallRule.EndIP == "" {
 				return service.NewValidationError(
-					"firewallEndIPAddress",
-					"must be set when firewallStartIPAddress is set",
+					"endIPAddress",
+					"must be set when startIPAddress is set",
 				)
 			}
 		}
-		startIP := net.ParseIP(firewallRule.FirewallIPStart)
-		if firewallRule.FirewallIPStart != "" && startIP == nil {
+		startIP := net.ParseIP(firewallRule.StartIP)
+		if firewallRule.StartIP != "" && startIP == nil {
 			return service.NewValidationError(
-				"firewallStartIPAddress",
-				fmt.Sprintf(`invalid value: "%s"`, firewallRule.FirewallIPStart),
+				"startIPAddress",
+				fmt.Sprintf(`invalid value: "%s"`, firewallRule.StartIP),
 			)
 		}
-		endIP := net.ParseIP(firewallRule.FirewallIPEnd)
-		if firewallRule.FirewallIPEnd != "" && endIP == nil {
+		endIP := net.ParseIP(firewallRule.EndIP)
+		if firewallRule.EndIP != "" && endIP == nil {
 			return service.NewValidationError(
-				"firewallEndIPAddress",
-				fmt.Sprintf(`invalid value: "%s"`, firewallRule.FirewallIPEnd),
+				"endIPAddress",
+				fmt.Sprintf(`invalid value: "%s"`, firewallRule.EndIP),
 			)
 		}
 		//The net.IP.To4 method returns a 4 byte representation of an IPv4 address.
@@ -75,10 +75,10 @@ func validateServerProvisionParameters(
 		endBytes := endIP.To4()
 		if bytes.Compare(startBytes, endBytes) > 0 {
 			return service.NewValidationError(
-				"firewallEndIPAddress",
+				"endIPAddress",
 				fmt.Sprintf(`invalid value: "%s". must be 
-				greater than or equal to firewallStartIPAddress`,
-					firewallRule.FirewallIPEnd),
+				greater than or equal tostartIPAddress`,
+					firewallRule.EndIP),
 			)
 		}
 	}
@@ -98,9 +98,9 @@ func buildGoTemplateParameters(
 		//Build the azure default
 		p["firewallRules"] = []FirewallRule{
 			{
-				FirewallRuleName: "AllowAzure",
-				FirewallIPStart:  "0.0.0.0",
-				FirewallIPEnd:    "0.0.0.0",
+				Name:    "AllowAzure",
+				StartIP: "0.0.0.0",
+				EndIP:   "0.0.0.0",
 			},
 		}
 	}

--- a/pkg/services/mysqldb/provision_common.go
+++ b/pkg/services/mysqldb/provision_common.go
@@ -77,7 +77,8 @@ func validateServerProvisionParameters(
 			return service.NewValidationError(
 				"firewallEndIPAddress",
 				fmt.Sprintf(`invalid value: "%s". must be 
-				greater than or equal to firewallStartIPAddress`, firewallRule.FirewallIPEnd),
+				greater than or equal to firewallStartIPAddress`,
+					firewallRule.FirewallIPEnd),
 			)
 		}
 	}
@@ -96,7 +97,7 @@ func buildGoTemplateParameters(
 	} else {
 		//Build the azure default
 		p["firewallRules"] = []FirewallRule{
-			FirewallRule{
+			{
 				FirewallRuleName: "AllowAzure",
 				FirewallIPStart:  "0.0.0.0",
 				FirewallIPEnd:    "0.0.0.0",

--- a/pkg/services/mysqldb/provision_common.go
+++ b/pkg/services/mysqldb/provision_common.go
@@ -32,48 +32,78 @@ func validateServerProvisionParameters(
 			fmt.Sprintf(`invalid option: "%s"`, pp.SSLEnforcement),
 		)
 	}
-	if pp.FirewallIPStart != "" || pp.FirewallIPEnd != "" {
-		if pp.FirewallIPStart == "" {
+	for _, firewallRule := range pp.FirewallRules {
+		if firewallRule.FirewallRuleName == "" {
+			return service.NewValidationError(
+				"firewallRuleName",
+				"must be set",
+			)
+		}
+		if firewallRule.FirewallIPStart != "" || firewallRule.FirewallIPEnd != "" {
+			if firewallRule.FirewallIPStart == "" {
+				return service.NewValidationError(
+					"firewallStartIPAddress",
+					"must be set when firewallEndIPAddress is set",
+				)
+			}
+			if firewallRule.FirewallIPEnd == "" {
+				return service.NewValidationError(
+					"firewallEndIPAddress",
+					"must be set when firewallStartIPAddress is set",
+				)
+			}
+		}
+		startIP := net.ParseIP(firewallRule.FirewallIPStart)
+		if firewallRule.FirewallIPStart != "" && startIP == nil {
 			return service.NewValidationError(
 				"firewallStartIPAddress",
-				"must be set when firewallEndIPAddress is set",
+				fmt.Sprintf(`invalid value: "%s"`, firewallRule.FirewallIPStart),
 			)
 		}
-		if pp.FirewallIPEnd == "" {
+		endIP := net.ParseIP(firewallRule.FirewallIPEnd)
+		if firewallRule.FirewallIPEnd != "" && endIP == nil {
 			return service.NewValidationError(
 				"firewallEndIPAddress",
-				"must be set when firewallStartIPAddress is set",
+				fmt.Sprintf(`invalid value: "%s"`, firewallRule.FirewallIPEnd),
+			)
+		}
+		//The net.IP.To4 method returns a 4 byte representation of an IPv4 address.
+		//Once converted,comparing two IP addresses can be done by using the
+		//bytes. Compare function. Per the ARM template documentation,
+		//startIP must be <= endIP.
+		startBytes := startIP.To4()
+		endBytes := endIP.To4()
+		if bytes.Compare(startBytes, endBytes) > 0 {
+			return service.NewValidationError(
+				"firewallEndIPAddress",
+				fmt.Sprintf(`invalid value: "%s". must be 
+				greater than or equal to firewallStartIPAddress`, firewallRule.FirewallIPEnd),
 			)
 		}
 	}
-	startIP := net.ParseIP(pp.FirewallIPStart)
-	if pp.FirewallIPStart != "" && startIP == nil {
-		return service.NewValidationError(
-			"firewallStartIPAddress",
-			fmt.Sprintf(`invalid value: "%s"`, pp.FirewallIPStart),
-		)
-	}
-	endIP := net.ParseIP(pp.FirewallIPEnd)
-	if pp.FirewallIPEnd != "" && endIP == nil {
-		return service.NewValidationError(
-			"firewallEndIPAddress",
-			fmt.Sprintf(`invalid value: "%s"`, pp.FirewallIPEnd),
-		)
-	}
-	//The net.IP.To4 method returns a 4 byte representation of an IPv4 address.
-	//Once converted,comparing two IP addresses can be done by using the
-	//bytes. Compare function. Per the ARM template documentation,
-	//startIP must be <= endIP.
-	startBytes := startIP.To4()
-	endBytes := endIP.To4()
-	if bytes.Compare(startBytes, endBytes) > 0 {
-		return service.NewValidationError(
-			"firewallEndIPAddress",
-			fmt.Sprintf(`invalid value: "%s". must be 
-				greater than or equal to firewallStartIPAddress`, pp.FirewallIPEnd),
-		)
-	}
 	return nil
+}
+
+func buildGoTemplateParameters(
+	provisioningParameters *ServerProvisioningParameters,
+) map[string]interface{} {
+	p := map[string]interface{}{}
+	//Only include these if they are not empty.
+	//ARM Deployer will fail if the values included are not
+	//valid IPV4 addresses (i.e. empty string wil fail)
+	if len(provisioningParameters.FirewallRules) > 0 {
+		p["firewallRules"] = provisioningParameters.FirewallRules
+	} else {
+		//Build the azure default
+		p["firewallRules"] = []FirewallRule{
+			FirewallRule{
+				FirewallRuleName: "AllowAzure",
+				FirewallIPStart:  "0.0.0.0",
+				FirewallIPEnd:    "0.0.0.0",
+			},
+		}
+	}
+	return p
 }
 
 func getAvailableServerName(

--- a/pkg/services/mysqldb/provision_dbms_only.go
+++ b/pkg/services/mysqldb/provision_dbms_only.go
@@ -79,7 +79,6 @@ func (d *dbmsOnlyManager) buildARMTemplateParameters(
 	plan service.Plan,
 	details *dbmsOnlyMysqlInstanceDetails,
 	secureDetails *dbmsOnlyMysqlSecureInstanceDetails,
-	provisioningParameters *ServerProvisioningParameters,
 ) map[string]interface{} {
 	var sslEnforcement string
 	if details.EnforceSSL {
@@ -129,7 +128,6 @@ func (d *dbmsOnlyManager) deployARMTemplate(
 		instance.Plan,
 		dt,
 		sdt,
-		pp,
 	)
 	goTemplateParameters := buildGoTemplateParameters(pp)
 	outputs, err := d.armDeployer.Deploy(
@@ -137,7 +135,7 @@ func (d *dbmsOnlyManager) deployARMTemplate(
 		instance.ResourceGroup,
 		instance.Location,
 		dbmsOnlyARMTemplate,
-		goTemplateParameters, // Go template params
+		goTemplateParameters,
 		armTemplateParameters,
 		instance.Tags,
 	)

--- a/pkg/services/mysqldb/provision_dbms_only.go
+++ b/pkg/services/mysqldb/provision_dbms_only.go
@@ -97,15 +97,7 @@ func (d *dbmsOnlyManager) buildARMTemplateParameters(
 		"skuSizeMB":      plan.GetProperties().Extended["skuSizeMB"],
 		"sslEnforcement": sslEnforcement,
 	}
-	//Only include these if they are not empty.
-	//ARM Deployer will fail if the values included are not
-	//valid IPV4 addresses (i.e. empty string wil fail)
-	if provisioningParameters.FirewallIPStart != "" {
-		p["firewallStartIpAddress"] = provisioningParameters.FirewallIPStart
-	}
-	if provisioningParameters.FirewallIPEnd != "" {
-		p["firewallEndIpAddress"] = provisioningParameters.FirewallIPEnd
-	}
+
 	return p
 }
 
@@ -139,12 +131,13 @@ func (d *dbmsOnlyManager) deployARMTemplate(
 		sdt,
 		pp,
 	)
+	goTemplateParameters := buildGoTemplateParameters(pp)
 	outputs, err := d.armDeployer.Deploy(
 		dt.ARMDeploymentName,
 		instance.ResourceGroup,
 		instance.Location,
 		dbmsOnlyARMTemplate,
-		nil, // Go template params
+		goTemplateParameters, // Go template params
 		armTemplateParameters,
 		instance.Tags,
 	)

--- a/pkg/services/mysqldb/types_common.go
+++ b/pkg/services/mysqldb/types_common.go
@@ -9,9 +9,9 @@ type ServerProvisioningParameters struct {
 
 // FirewallRule represents a firewall rule to be applied to the DBMS
 type FirewallRule struct {
-	FirewallRuleName string `json:"firewallRuleName"`
-	FirewallIPStart  string `json:"firewallStartIPAddress"`
-	FirewallIPEnd    string `json:"firewallEndIPAddress"`
+	Name    string `json:"name"`
+	StartIP string `json:"startIPAddress"`
+	EndIP   string `json:"endIPAddress"`
 }
 
 // SecureServerProvisioningParameters encapsulates sensitive MySQL-specific

--- a/pkg/services/mysqldb/types_common.go
+++ b/pkg/services/mysqldb/types_common.go
@@ -7,6 +7,7 @@ type ServerProvisioningParameters struct {
 	FirewallRules  []FirewallRule `json:"firewallRules"`
 }
 
+// FirewallRule represents a firewall rule to be applied to the DBMS
 type FirewallRule struct {
 	FirewallRuleName string `json:"firewallRuleName"`
 	FirewallIPStart  string `json:"firewallStartIPAddress"`

--- a/pkg/services/mysqldb/types_common.go
+++ b/pkg/services/mysqldb/types_common.go
@@ -3,9 +3,14 @@ package mysqldb
 // ServerProvisioningParameters encapsulates non-sensitive MySQL-specific
 // server provisioning options
 type ServerProvisioningParameters struct {
-	SSLEnforcement  string `json:"sslEnforcement"`
-	FirewallIPStart string `json:"firewallStartIPAddress"`
-	FirewallIPEnd   string `json:"firewallEndIPAddress"`
+	SSLEnforcement string         `json:"sslEnforcement"`
+	FirewallRules  []FirewallRule `json:"firewallRules"`
+}
+
+type FirewallRule struct {
+	FirewallRuleName string `json:"firewallRuleName"`
+	FirewallIPStart  string `json:"firewallStartIPAddress"`
+	FirewallIPEnd    string `json:"firewallEndIPAddress"`
 }
 
 // SecureServerProvisioningParameters encapsulates sensitive MySQL-specific

--- a/tests/lifecycle/mysql_cases_test.go
+++ b/tests/lifecycle/mysql_cases_test.go
@@ -56,8 +56,13 @@ func getMysqlCases(
 				SSLEnforcement: "disabled",
 				FirewallRules: []mysqldb.FirewallRule{
 					{
-						FirewallRuleName: "AllowAll",
+						FirewallRuleName: "AllowSome",
 						FirewallIPStart:  "0.0.0.0",
+						FirewallIPEnd:    "35.0.0.0",
+					},
+					{
+						FirewallRuleName: "AllowMore",
+						FirewallIPStart:  "35.0.0.1",
 						FirewallIPEnd:    "255.255.255.255",
 					},
 				},

--- a/tests/lifecycle/mysql_cases_test.go
+++ b/tests/lifecycle/mysql_cases_test.go
@@ -56,14 +56,14 @@ func getMysqlCases(
 				SSLEnforcement: "disabled",
 				FirewallRules: []mysqldb.FirewallRule{
 					{
-						FirewallRuleName: "AllowSome",
-						FirewallIPStart:  "0.0.0.0",
-						FirewallIPEnd:    "35.0.0.0",
+						Name:    "AllowSome",
+						StartIP: "0.0.0.0",
+						EndIP:   "35.0.0.0",
 					},
 					{
-						FirewallRuleName: "AllowMore",
-						FirewallIPStart:  "35.0.0.1",
-						FirewallIPEnd:    "255.255.255.255",
+						Name:    "AllowMore",
+						StartIP: "35.0.0.1",
+						EndIP:   "255.255.255.255",
 					},
 				},
 			},
@@ -79,9 +79,9 @@ func getMysqlCases(
 			provisioningParameters: &mysqldb.ServerProvisioningParameters{
 				FirewallRules: []mysqldb.FirewallRule{
 					{
-						FirewallRuleName: "AllowAll",
-						FirewallIPStart:  "0.0.0.0",
-						FirewallIPEnd:    "255.255.255.255",
+						Name:    "AllowAll",
+						StartIP: "0.0.0.0",
+						EndIP:   "255.255.255.255",
 					},
 				},
 			},

--- a/tests/lifecycle/mysql_cases_test.go
+++ b/tests/lifecycle/mysql_cases_test.go
@@ -55,7 +55,7 @@ func getMysqlCases(
 			provisioningParameters: &mysqldb.ServerProvisioningParameters{
 				SSLEnforcement: "disabled",
 				FirewallRules: []mysqldb.FirewallRule{
-					mysqldb.FirewallRule{
+					{
 						FirewallRuleName: "AllowAll",
 						FirewallIPStart:  "0.0.0.0",
 						FirewallIPEnd:    "255.255.255.255",
@@ -73,7 +73,7 @@ func getMysqlCases(
 			location:    "eastus",
 			provisioningParameters: &mysqldb.ServerProvisioningParameters{
 				FirewallRules: []mysqldb.FirewallRule{
-					mysqldb.FirewallRule{
+					{
 						FirewallRuleName: "AllowAll",
 						FirewallIPStart:  "0.0.0.0",
 						FirewallIPEnd:    "255.255.255.255",

--- a/tests/lifecycle/mysql_cases_test.go
+++ b/tests/lifecycle/mysql_cases_test.go
@@ -53,9 +53,14 @@ func getMysqlCases(
 			planID:      "427559f1-bf2a-45d3-8844-32374a3e58aa",
 			location:    "southcentralus",
 			provisioningParameters: &mysqldb.ServerProvisioningParameters{
-				SSLEnforcement:  "disabled",
-				FirewallIPStart: "0.0.0.0",
-				FirewallIPEnd:   "255.255.255.255",
+				SSLEnforcement: "disabled",
+				FirewallRules: []mysqldb.FirewallRule{
+					mysqldb.FirewallRule{
+						FirewallRuleName: "AllowAll",
+						FirewallIPStart:  "0.0.0.0",
+						FirewallIPEnd:    "255.255.255.255",
+					},
+				},
 			},
 			bindingParameters: &mysqldb.BindingParameters{},
 			testCredentials:   testMySQLCreds(),
@@ -67,8 +72,13 @@ func getMysqlCases(
 			planID:      "3f65ebf9-ac1d-4e77-b9bf-918889a4482b",
 			location:    "eastus",
 			provisioningParameters: &mysqldb.ServerProvisioningParameters{
-				FirewallIPStart: "0.0.0.0",
-				FirewallIPEnd:   "255.255.255.255",
+				FirewallRules: []mysqldb.FirewallRule{
+					mysqldb.FirewallRule{
+						FirewallRuleName: "AllowAll",
+						FirewallIPStart:  "0.0.0.0",
+						FirewallIPEnd:    "255.255.255.255",
+					},
+				},
 			},
 			childTestCases: []*serviceLifecycleTestCase{
 				{ // db only scenario


### PR DESCRIPTION
Support multiple firewall rules via the use of Go Templates.

- Refactor parameters to use array of firewall rules
- added name to parameters
- changed arm template to use a go template for firewall rules
- doc updates

Closes #246 