### PR TITLE
Update MS SQL module to allow TDE to be disabled

### DIFF
--- a/docs/modules/mssql.md
+++ b/docs/modules/mssql.md
@@ -49,7 +49,7 @@ Provisions a new SQL Server and a new database upon that server. The new dbms an
 | `firewallRules[n].name` | `string` | Specifies the name of the generated firewall rule |Y | |
 | `firewallRules[n].startIPAddress` | `string` | Specifies the start of the IP range allowed by this firewall rule | Y | |
 | `firewallRules[n].endIPAddress` | `string` | Specifies the end of the IP range allowed by this firewall rule | Y | |
-| `disableTransparentDataEncryption` | `boolean` | Specifies if [Transparent Data Encryption](https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/transparent-data-encryption-azure-sql) should be disabled | F | |
+| `disableTransparentDataEncryption` | `boolean` | Specifies if [Transparent Data Encryption](https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/transparent-data-encryption-azure-sql) should be disabled | N | False. Left unspecified, Transparent Data Encryption remains enabled. |
 
 ##### Bind
 
@@ -273,7 +273,7 @@ Provisions a new database upon an existing server. The new database will be name
 | Parameter Name | Type | Description | Required | Default Value |
 |----------------|------|-------------|----------|---------------|
 | `parentAlias` | `string` | Specifies the alias of the DBMS upon which the database should be provisioned. | Y | |
-| `disableTransparentDataEncryption` | `boolean` | Specifies if [Transparent Data Encryption](https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/transparent-data-encryption-azure-sql) should be disabled | F | |
+| `disableTransparentDataEncryption` | `boolean` | Specifies if [Transparent Data Encryption](https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/transparent-data-encryption-azure-sql) should be disabled | N | False. Left unspecified, Transparent Data Encryption remains enabled. |
 
 ##### Bind
 

--- a/docs/modules/mssql.md
+++ b/docs/modules/mssql.md
@@ -49,6 +49,7 @@ Provisions a new SQL Server and a new database upon that server. The new dbms an
 | `firewallRules[n].name` | `string` | Specifies the name of the generated firewall rule |Y | |
 | `firewallRules[n].startIPAddress` | `string` | Specifies the start of the IP range allowed by this firewall rule | Y | |
 | `firewallRules[n].endIPAddress` | `string` | Specifies the end of the IP range allowed by this firewall rule | Y | |
+| `disableTransparentDataEncryption` | `boolean` | Specifies if [Transparent Data Encryption](https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/transparent-data-encryption-azure-sql) should be disabled | F | |
 
 ##### Bind
 
@@ -272,6 +273,7 @@ Provisions a new database upon an existing server. The new database will be name
 | Parameter Name | Type | Description | Required | Default Value |
 |----------------|------|-------------|----------|---------------|
 | `parentAlias` | `string` | Specifies the alias of the DBMS upon which the database should be provisioned. | Y | |
+| `disableTransparentDataEncryption` | `boolean` | Specifies if [Transparent Data Encryption](https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/transparent-data-encryption-azure-sql) should be disabled | F | |
 
 ##### Bind
 

--- a/pkg/services/mssql/all_in_one_arm_template.go
+++ b/pkg/services/mssql/all_in_one_arm_template.go
@@ -88,6 +88,24 @@ var allInOneARMTemplateBytes = []byte(`
 						"[concat('Microsoft.Sql/servers/', parameters('serverName'))]"
 						
 					],
+					"resources": [
+						{
+							"comments": "Transparent Data Encryption",
+							"name": "current",
+							"type": "transparentDataEncryption",
+							"apiVersion": "2014-04-01-preview",
+							"properties": {
+								{{if .transparentDataEncryption}}
+								"status": "Enabled"
+								{{else}}
+								"status": "Disabled"
+								{{end}}
+							},
+							"dependsOn": [
+								"[parameters('databaseName')]"
+							]
+						}
+					],
 					"tags": "[parameters('tags')]"
 				}
 			]

--- a/pkg/services/mssql/all_in_one_types.go
+++ b/pkg/services/mssql/all_in_one_types.go
@@ -5,12 +5,14 @@ import "github.com/Azure/open-service-broker-azure/pkg/service"
 // AllInOneProvisioningParameters encapsulates non-sensitive dbms AND database
 // MS SQL-specific provisioning options
 type AllInOneProvisioningParameters struct {
-	DBMSProvisioningParams `json:",squash"`
+	DBMSProvisioningParams     `json:",squash"`
+	DatabaseProvisioningParams `json:",squash"`
 }
 
 type allInOneInstanceDetails struct {
 	dbmsInstanceDetails
-	DatabaseName string `json:"database"`
+	DatabaseName              string `json:"database"`
+	TransparentDataEncryption bool   `json:"transparentDataEncryption"`
 }
 
 type secureAllInOneInstanceDetails struct {

--- a/pkg/services/mssql/database_arm_template.go
+++ b/pkg/services/mssql/database_arm_template.go
@@ -43,6 +43,24 @@ var databaseARMTemplateBytes = []byte(`
 				"requestedServiceObjectiveName": "[parameters('requestedServiceObjectiveName')]",
 				"maxSizeBytes": "[parameters('maxSizeBytes')]"
 			},
+			"resources": [
+				{
+					"comments": "Transparent Data Encryption",
+					"name": "current",
+					"type": "transparentDataEncryption",
+					"apiVersion": "2014-04-01-preview",
+					"properties": {
+						{{if .transparentDataEncryption}}
+						"status": "Enabled"
+						{{else}}
+						"status": "Disabled"
+						{{end}}
+					},
+					"dependsOn": [
+						"[concat('Microsoft.Sql/servers/', parameters('serverName'), '/databases/', parameters('databaseName'))]"
+					]
+				}
+			],
 			"tags": "[parameters('tags')]"
 		}
 	],

--- a/pkg/services/mssql/database_types.go
+++ b/pkg/services/mssql/database_types.go
@@ -2,15 +2,22 @@ package mssql
 
 import "github.com/Azure/open-service-broker-azure/pkg/service"
 
+// DatabaseProvisioningParams encapsulates non-sensitive database
+// MS SQL-specific provisioning options
+type DatabaseProvisioningParams struct {
+	DisableTDE bool `json:"disableTransparentDataEncryption"`
+}
+
 type databaseInstanceDetails struct {
-	ARMDeploymentName string `json:"armDeployment"`
-	DatabaseName      string `json:"database"`
+	ARMDeploymentName         string `json:"armDeployment"`
+	DatabaseName              string `json:"database"`
+	TransparentDataEncryption bool   `json:"transparentDataEncryption"`
 }
 
 func (
 	d *databaseManager,
 ) GetEmptyProvisioningParameters() service.ProvisioningParameters {
-	return nil
+	return &DatabaseProvisioningParams{}
 }
 
 func (

--- a/tests/lifecycle/mssql_cases_test.go
+++ b/tests/lifecycle/mssql_cases_test.go
@@ -81,16 +81,14 @@ func getMssqlCases(
 			},
 			childTestCases: []*serviceLifecycleTestCase{
 				{ // db only scenario
-					module:            module,
-					description:       "database on new server",
-					serviceID:         "2bbc160c-e279-4757-a6b6-4c0a4822d0aa",
-					planID:            "8fa8d759-c142-45dd-ae38-b93482ddc04a",
-					location:          "", // This is actually irrelevant for this test
-					bindingParameters: nil,
-					testCredentials:   testMsSQLCreds(),
-					provisioningParameters: &mssql.DatabaseProvisioningParams{
-						DisableTDE: true,
-					},
+					module:                 module,
+					description:            "database on new server",
+					serviceID:              "2bbc160c-e279-4757-a6b6-4c0a4822d0aa",
+					planID:                 "8fa8d759-c142-45dd-ae38-b93482ddc04a",
+					location:               "", // This is actually irrelevant for this test
+					bindingParameters:      nil,
+					testCredentials:        testMsSQLCreds(),
+					provisioningParameters: &mssql.DatabaseProvisioningParams{},
 				},
 			},
 		},

--- a/tests/lifecycle/mssql_cases_test.go
+++ b/tests/lifecycle/mssql_cases_test.go
@@ -88,6 +88,9 @@ func getMssqlCases(
 					location:          "", // This is actually irrelevant for this test
 					bindingParameters: nil,
 					testCredentials:   testMsSQLCreds(),
+					provisioningParameters: &mssql.DatabaseProvisioningParams{
+						DisableTDE: true,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Adds a new parameter called "disableTransparentDataEncryption" to the all-in-one
and database only MS SQL services. TDE is enabled by default, so this was added in a
backward compatible way. TDE is enabled by default, this allows it to be disabled.

Closes: #325