### PR TITLE
move configs around

### DIFF
--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/crypto/noop"
 	"github.com/Azure/open-service-broker-azure/pkg/http/filter"
 	"github.com/Azure/open-service-broker-azure/pkg/http/filters"
+	brokerLog "github.com/Azure/open-service-broker-azure/pkg/log"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/Azure/open-service-broker-azure/pkg/version"
 	log "github.com/Sirupsen/logrus"
@@ -40,7 +41,7 @@ func main() {
 		FullTimestamp: true,
 	}
 	log.SetFormatter(formatter)
-	logConfig, err := config.GetLogConfig()
+	logConfig, err := brokerLog.GetConfig()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/crypto/noop"
 	"github.com/Azure/open-service-broker-azure/pkg/http/filter"
 	"github.com/Azure/open-service-broker-azure/pkg/http/filters"
+	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/Azure/open-service-broker-azure/pkg/version"
 	log "github.com/Sirupsen/logrus"
 	"github.com/go-redis/redis"
@@ -141,7 +142,7 @@ func main() {
 		apiFilters.NewAPIVersionFilter(),
 	)
 
-	modulesConfig, err := config.GetModulesConfig()
+	modulesConfig, err := service.GetModulesConfig()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	apiFilters "github.com/Azure/open-service-broker-azure/pkg/api/filters"
+	"github.com/Azure/open-service-broker-azure/pkg/azure"
 	"github.com/Azure/open-service-broker-azure/pkg/broker"
 	"github.com/Azure/open-service-broker-azure/pkg/config"
 	"github.com/Azure/open-service-broker-azure/pkg/crypto"
@@ -49,7 +50,7 @@ func main() {
 	).Info("Setting log level")
 	log.SetLevel(logLevel)
 
-	azureConfig, err := config.GetAzureConfig()
+	azureConfig, err := azure.GetConfig()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Azure/open-service-broker-azure/pkg/api"
 	apiFilters "github.com/Azure/open-service-broker-azure/pkg/api/filters"
 	"github.com/Azure/open-service-broker-azure/pkg/azure"
 	"github.com/Azure/open-service-broker-azure/pkg/broker"
@@ -128,7 +129,7 @@ func main() {
 	}
 
 	// Assemble the filter chain
-	basicAuthConfig, err := config.GetBasicAuthConfig()
+	basicAuthConfig, err := api.GetBasicAuthConfig()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -88,6 +88,12 @@ func main() {
 		DB:         storageRedisConfig.GetDB(),
 		MaxRetries: 5,
 	}
+	if storageRedisConfig.IsTLSEnabled() {
+		storageRedisOpts.TLSConfig = &tls.Config{
+			ServerName: storageRedisConfig.GetHost(),
+		}
+	}
+	storageRedisClient := redis.NewClient(storageRedisOpts)
 
 	// Async
 	asyncRedisConfig, err := redisAsync.GetConfig()
@@ -105,14 +111,10 @@ func main() {
 		MaxRetries: 5,
 	}
 	if asyncRedisConfig.IsTLSEnabled() {
-		storageRedisOpts.TLSConfig = &tls.Config{
-			ServerName: asyncRedisConfig.GetHost(),
-		}
 		asyncRedisOpts.TLSConfig = &tls.Config{
 			ServerName: asyncRedisConfig.GetHost(),
 		}
 	}
-	storageRedisClient := redis.NewClient(storageRedisOpts)
 	asyncRedisClient := redis.NewClient(asyncRedisOpts)
 
 	// Crypto

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -105,7 +105,7 @@ func main() {
 	asyncRedisClient := redis.NewClient(asyncRedisOpts)
 
 	// Crypto
-	cryptoConfig, err := config.GetCryptoConfig()
+	cryptoConfig, err := crypto.GetConfig()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/broker/modules.go
+++ b/cmd/broker/modules.go
@@ -17,9 +17,8 @@ import (
 	sqlSDK "github.com/Azure/azure-sdk-for-go/services/sql/mgmt/2017-03-01-preview/sql"                             // nolint: lll
 	storageSDK "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-10-01/storage"                         // nolint: lll
 	"github.com/Azure/go-autorest/autorest"
-	az "github.com/Azure/open-service-broker-azure/pkg/azure"
+	"github.com/Azure/open-service-broker-azure/pkg/azure"
 	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
-	"github.com/Azure/open-service-broker-azure/pkg/config"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/Azure/open-service-broker-azure/pkg/services/aci"
 	"github.com/Azure/open-service-broker-azure/pkg/services/cosmosdb"
@@ -37,11 +36,11 @@ import (
 
 var modules []service.Module
 
-func initModules(azureConfig config.AzureConfig) error {
+func initModules(azureConfig azure.Config) error {
 	azureEnvironment := azureConfig.GetEnvironment()
 	azureSubscriptionID := azureConfig.GetSubscriptionID()
 
-	authorizer, err := az.GetBearerTokenAuthorizer(
+	authorizer, err := azure.GetBearerTokenAuthorizer(
 		azureEnvironment,
 		azureConfig.GetTenantID(),
 		azureConfig.GetClientID(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,10 @@ services:
     build: .
     environment:
       LOG_LEVEL: DEBUG
-      REDIS_HOST: redis
+      STORAGE_REDIS_HOST: redis
+      STORAGE_REDIS_DB: 0
+      ASYNC_REDIS_HOST: redis
+      ASYNC_REDIS_DB: 1
       ENCRYPTION_SCHEME: NOOP
       # AES256_KEY: AES256Key-32Characters1234567890
       BASIC_AUTH_USERNAME: username

--- a/pkg/api/basic_auth_config.go
+++ b/pkg/api/basic_auth_config.go
@@ -1,4 +1,4 @@
-package config
+package api
 
 import (
 	"github.com/kelseyhightower/envconfig"

--- a/pkg/api/basic_auth_config_errors.go
+++ b/pkg/api/basic_auth_config_errors.go
@@ -1,4 +1,4 @@
-package config
+package api
 
 type errBasicAuthUsernameNotSpecified struct{}
 

--- a/pkg/api/basic_auth_config_test.go
+++ b/pkg/api/basic_auth_config_test.go
@@ -1,4 +1,4 @@
-package config
+package api
 
 import (
 	"os"

--- a/pkg/async/redis/config.go
+++ b/pkg/async/redis/config.go
@@ -1,0 +1,48 @@
+package redis
+
+import "github.com/kelseyhightower/envconfig"
+
+// Config represents details for connecting to the Redis instance that
+// the broker relies on for orchestrating asynchronous processes
+type Config interface {
+	GetHost() string
+	GetPort() int
+	GetPassword() string
+	GetDB() int
+	IsTLSEnabled() bool
+}
+
+type config struct {
+	Host      string `envconfig:"ASYNC_REDIS_HOST" required:"true"`
+	Port      int    `envconfig:"ASYNC_REDIS_PORT" default:"6379"`
+	Password  string `envconfig:"ASYNC_REDIS_PASSWORD" default:""`
+	DB        int    `envconfig:"ASYNC_REDIS_DB" default:"0"`
+	EnableTLS bool   `envconfig:"ASYNC_REDIS_ENABLE_TLS" default:"false"`
+}
+
+// GetConfig returns Redis configuration
+func GetConfig() (Config, error) {
+	c := config{}
+	err := envconfig.Process("", &c)
+	return c, err
+}
+
+func (c config) GetHost() string {
+	return c.Host
+}
+
+func (c config) GetPort() int {
+	return c.Port
+}
+
+func (c config) GetPassword() string {
+	return c.Password
+}
+
+func (c config) GetDB() int {
+	return c.DB
+}
+
+func (c config) IsTLSEnabled() bool {
+	return c.EnableTLS
+}

--- a/pkg/azure/config.go
+++ b/pkg/azure/config.go
@@ -1,13 +1,13 @@
-package config
+package azure
 
 import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/kelseyhightower/envconfig"
 )
 
-// AzureConfig represents details necessary for the broker to interact with
+// Config represents details necessary for the broker to interact with
 // an Azure subscription
-type AzureConfig interface {
+type Config interface {
 	GetEnvironment() azure.Environment
 	GetSubscriptionID() string
 	GetTenantID() string
@@ -17,7 +17,7 @@ type AzureConfig interface {
 	GetDefaultResourceGroup() string
 }
 
-type azureConfig struct {
+type config struct {
 	EnvironmentStr       string `envconfig:"AZURE_ENVIRONMENT" default:"AzurePublicCloud"` // nolint: lll
 	Environment          azure.Environment
 	SubscriptionID       string `envconfig:"AZURE_SUBSCRIPTION_ID" required:"true"` // nolint: lll
@@ -28,41 +28,41 @@ type azureConfig struct {
 	DefaultResourceGroup string `envconfig:"AZURE_DEFAULT_RESOURCE_GROUP"`
 }
 
-// GetAzureConfig returns Azure subscription configuration
-func GetAzureConfig() (AzureConfig, error) {
-	ac := azureConfig{}
-	err := envconfig.Process("", &ac)
+// GetConfig returns Azure-related configuration
+func GetConfig() (Config, error) {
+	c := config{}
+	err := envconfig.Process("", &c)
 	if err != nil {
-		return ac, err
+		return c, err
 	}
-	ac.Environment, err = azure.EnvironmentFromName(ac.EnvironmentStr)
-	return ac, err
+	c.Environment, err = azure.EnvironmentFromName(c.EnvironmentStr)
+	return c, err
 }
 
-func (a azureConfig) GetEnvironment() azure.Environment {
-	return a.Environment
+func (c config) GetEnvironment() azure.Environment {
+	return c.Environment
 }
 
-func (a azureConfig) GetSubscriptionID() string {
-	return a.SubscriptionID
+func (c config) GetSubscriptionID() string {
+	return c.SubscriptionID
 }
 
-func (a azureConfig) GetTenantID() string {
-	return a.TenantID
+func (c config) GetTenantID() string {
+	return c.TenantID
 }
 
-func (a azureConfig) GetClientID() string {
-	return a.ClientID
+func (c config) GetClientID() string {
+	return c.ClientID
 }
 
-func (a azureConfig) GetClientSecret() string {
-	return a.ClientSecret
+func (c config) GetClientSecret() string {
+	return c.ClientSecret
 }
 
-func (a azureConfig) GetDefaultLocation() string {
-	return a.DefaultLocation
+func (c config) GetDefaultLocation() string {
+	return c.DefaultLocation
 }
 
-func (a azureConfig) GetDefaultResourceGroup() string {
-	return a.DefaultResourceGroup
+func (c config) GetDefaultResourceGroup() string {
+	return c.DefaultResourceGroup
 }

--- a/pkg/crypto/config.go
+++ b/pkg/crypto/config.go
@@ -1,40 +1,39 @@
-package config
+package crypto
 
 import (
 	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/Azure/open-service-broker-azure/pkg/crypto"
 	"github.com/kelseyhightower/envconfig"
 )
 
-// CryptoConfig represents details (e.g. key) for encrypting and decrypting any
+// Config represents details (e.g. key) for encrypting and decrypting any
 // (potentially) sensitive information
-type CryptoConfig interface {
+type Config interface {
 	GetEncryptionScheme() string
 	GetAES256Key() string
 }
 
-type cryptoConfig struct {
+type config struct {
 	EncryptionScheme string `envconfig:"ENCRYPTION_SCHEME" default:"AES256"`
 	AES256Key        string `envconfig:"AES256_KEY"`
 }
 
-// GetCryptoConfig returns crypto configuration
-func GetCryptoConfig() (CryptoConfig, error) {
-	cc := cryptoConfig{}
+// GetConfig returns crypto configuration
+func GetConfig() (Config, error) {
+	cc := config{}
 	err := envconfig.Process("", &cc)
 	cc.EncryptionScheme = strings.ToUpper(cc.EncryptionScheme)
 	switch cc.EncryptionScheme {
-	case crypto.AES256:
+	case AES256:
 		if cc.AES256Key == "" {
 			return cc, errors.New("AES256_KEY was not specified")
 		}
 		if len(cc.AES256Key) != 32 {
 			return cc, errors.New("AES256_KEY is an invalid length")
 		}
-	case crypto.NOOP:
+	case NOOP:
 	default:
 		return cc, fmt.Errorf(
 			`unrecognized ENCRYPTION_SCHEME "%s"`,
@@ -44,10 +43,10 @@ func GetCryptoConfig() (CryptoConfig, error) {
 	return cc, err
 }
 
-func (c cryptoConfig) GetEncryptionScheme() string {
+func (c config) GetEncryptionScheme() string {
 	return c.EncryptionScheme
 }
 
-func (c cryptoConfig) GetAES256Key() string {
+func (c config) GetAES256Key() string {
 	return c.AES256Key
 }

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -1,23 +1,23 @@
-package config
+package log
 
 import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/kelseyhightower/envconfig"
 )
 
-// LogConfig represents configuration options for the broker's leveled logging
-type LogConfig interface {
+// Config represents configuration options for the broker's leveled logging
+type Config interface {
 	GetLevel() log.Level
 }
 
-type logConfig struct {
+type config struct {
 	LevelStr string `envconfig:"LOG_LEVEL" default:"INFO"`
 	Level    log.Level
 }
 
-// GetLogConfig returns log configuration
-func GetLogConfig() (LogConfig, error) {
-	lc := logConfig{}
+// GetConfig returns log configuration
+func GetConfig() (Config, error) {
+	lc := config{}
 	err := envconfig.Process("", &lc)
 	if err != nil {
 		return lc, err
@@ -26,6 +26,6 @@ func GetLogConfig() (LogConfig, error) {
 	return lc, err
 }
 
-func (l logConfig) GetLevel() log.Level {
-	return l.Level
+func (c config) GetLevel() log.Level {
+	return c.Level
 }

--- a/pkg/service/modules_config.go
+++ b/pkg/service/modules_config.go
@@ -1,22 +1,21 @@
-package config
+package service
 
 import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/kelseyhightower/envconfig"
 )
 
-// ModulesConfig represents details re: which modules should be included or
-// excluded when the broker is started
+// ModulesConfig represents details re: which modules' services should be
+// included or excluded from the catalog
 type ModulesConfig interface {
-	GetMinStability() service.Stability
+	GetMinStability() Stability
 }
 
 type modulesConfig struct {
 	MinStabilityStr string `envconfig:"MIN_STABILITY" default:"EXPERIMENTAL"`
-	MinStability    service.Stability
+	MinStability    Stability
 }
 
 // GetModulesConfig returns modules configuration
@@ -29,11 +28,11 @@ func GetModulesConfig() (ModulesConfig, error) {
 	minStabilityStr := strings.ToUpper(mc.MinStabilityStr)
 	switch minStabilityStr {
 	case "EXPERIMENTAL":
-		mc.MinStability = service.StabilityExperimental
+		mc.MinStability = StabilityExperimental
 	case "PREVIEW":
-		mc.MinStability = service.StabilityPreview
+		mc.MinStability = StabilityPreview
 	case "STABLE":
-		mc.MinStability = service.StabilityStable
+		mc.MinStability = StabilityStable
 	default:
 		return mc, fmt.Errorf(
 			`unrecognized stability level "%s"`,
@@ -43,6 +42,6 @@ func GetModulesConfig() (ModulesConfig, error) {
 	return mc, nil
 }
 
-func (m modulesConfig) GetMinStability() service.Stability {
+func (m modulesConfig) GetMinStability() Stability {
 	return m.MinStability
 }

--- a/pkg/storage/redis_config.go
+++ b/pkg/storage/redis_config.go
@@ -1,26 +1,23 @@
-package config
+package storage
 
 import "github.com/kelseyhightower/envconfig"
 
 // RedisConfig represents details for connecting to the Redis instance that
-// the broker itself relies on for storing state and orchestrating asynchronous
-// processes
+// the broker relies on for storage
 type RedisConfig interface {
 	GetHost() string
 	GetPort() int
 	GetPassword() string
-	GetStorageDB() int
-	GetAsyncDB() int
+	GetDB() int
 	IsTLSEnabled() bool
 }
 
 type redisConfig struct {
-	Host      string `envconfig:"REDIS_HOST" required:"true"`
-	Port      int    `envconfig:"REDIS_PORT" default:"6379"`
-	Password  string `envconfig:"REDIS_PASSWORD" default:""`
-	StorageDB int    `envconfig:"REDIS_STORAGE_DB" default:"0"`
-	AsyncDB   int    `envconfig:"REDIS_ASYNC_DB" default:"1"`
-	EnableTLS bool   `envconfig:"REDIS_ENABLE_TLS" default:"false"`
+	Host      string `envconfig:"STORAGE_REDIS_HOST" required:"true"`
+	Port      int    `envconfig:"STORAGE_REDIS_PORT" default:"6379"`
+	Password  string `envconfig:"STORAGE_REDIS_PASSWORD" default:""`
+	DB        int    `envconfig:"STORAGE_REDIS_DB" default:"0"`
+	EnableTLS bool   `envconfig:"STORAGE_REDIS_ENABLE_TLS" default:"false"`
 }
 
 // GetRedisConfig returns Redis configuration
@@ -42,12 +39,8 @@ func (r redisConfig) GetPassword() string {
 	return r.Password
 }
 
-func (r redisConfig) GetStorageDB() int {
-	return r.StorageDB
-}
-
-func (r redisConfig) GetAsyncDB() int {
-	return r.AsyncDB
+func (r redisConfig) GetDB() int {
+	return r.DB
 }
 
 func (r redisConfig) IsTLSEnabled() bool {

--- a/tests/lifecycle/groups_client_test.go
+++ b/tests/lifecycle/groups_client_test.go
@@ -7,7 +7,6 @@ import (
 
 	resourcesSDK "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources" // nolint: lll
 	az "github.com/Azure/open-service-broker-azure/pkg/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/config"
 )
 
 func ensureResourceGroup(resourceGroup string) error {
@@ -39,7 +38,7 @@ func deleteResourceGroup(
 }
 
 func getGroupsClient() (*resourcesSDK.GroupsClient, error) {
-	azureConfig, err := config.GetAzureConfig()
+	azureConfig, err := az.GetConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/tests/lifecycle/keyvault_cases_test.go
+++ b/tests/lifecycle/keyvault_cases_test.go
@@ -6,8 +6,8 @@ import (
 	keyVaultSDK "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault" // nolint: lll
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
+	az "github.com/Azure/open-service-broker-azure/pkg/azure"
 	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
-	"github.com/Azure/open-service-broker-azure/pkg/config"
 	"github.com/Azure/open-service-broker-azure/pkg/services/keyvault"
 )
 
@@ -17,7 +17,7 @@ func getKeyvaultCases(
 	authorizer autorest.Authorizer,
 	armDeployer arm.Deployer,
 ) ([]serviceLifecycleTestCase, error) {
-	azureConfig, err := config.GetAzureConfig()
+	azureConfig, err := az.GetConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/tests/lifecycle/test_cases_test.go
+++ b/tests/lifecycle/test_cases_test.go
@@ -13,11 +13,10 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	az "github.com/Azure/open-service-broker-azure/pkg/azure"
 	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
-	"github.com/Azure/open-service-broker-azure/pkg/config"
 )
 
 func getTestCases() ([]serviceLifecycleTestCase, error) {
-	azureConfig, err := config.GetAzureConfig()
+	azureConfig, err := az.GetConfig()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Related to #237 

When I address #237, there will be additional configuration options for the async engine. Keeping in mind that we will very likely extract that package into its own project at some point in the future, I want to make sure those options are defined _within_ the async package- which means the existing async options should probably move to that package as well...

Well... to be consistent, that means options for a lot of other packages should move closer to the components they affect. This make a lot of sense, actually, because as with async, this reduces the effort required to extract broker packages into their own projects (if warranted) in the future.

This is _not_ the last of the refactoring that's going to happen on configs/options, but I want to keep PRs tightly scoped and easier-to-review.

This is ready for review, but let's hold off on merging it for now. I want to let this marinate for a while. I'm building on this work in another PR, and I want to feel more certain that this all works out as I hope before we merge.