### PR TITLE
refactor how async engine gets its redis client

### DIFF
--- a/pkg/async/redis/common_test.go
+++ b/pkg/async/redis/common_test.go
@@ -3,17 +3,10 @@ package redis
 import (
 	"errors"
 
-	goredis "github.com/go-redis/redis"
 	uuid "github.com/satori/go.uuid"
 )
 
-var (
-	redisClient = goredis.NewClient(&goredis.Options{
-		Addr:     "redis:6379",
-		PoolSize: 20,
-	})
-	errSome = errors.New("an error")
-)
+var errSome = errors.New("an error")
 
 func getDisposableQueueName() string {
 	return uuid.NewV4().String()

--- a/pkg/async/redis/config.go
+++ b/pkg/async/redis/config.go
@@ -2,47 +2,27 @@ package redis
 
 import "github.com/kelseyhightower/envconfig"
 
-// Config represents details for connecting to the Redis instance that
-// the broker relies on for orchestrating asynchronous processes
-type Config interface {
-	GetHost() string
-	GetPort() int
-	GetPassword() string
-	GetDB() int
-	IsTLSEnabled() bool
+// Config encapsulates all configuration options for the Redis-based
+// implementation of the async.Engine interface
+type Config struct {
+	RedisHost      string `envconfig:"ASYNC_REDIS_HOST" required:"true"`
+	RedisPort      int    `envconfig:"ASYNC_REDIS_PORT"`
+	RedisPassword  string `envconfig:"ASYNC_REDIS_PASSWORD"`
+	RedisDB        int    `envconfig:"ASYNC_REDIS_DB"`
+	RedisEnableTLS bool   `envconfig:"ASYNC_REDIS_ENABLE_TLS"`
 }
 
-type config struct {
-	Host      string `envconfig:"ASYNC_REDIS_HOST" required:"true"`
-	Port      int    `envconfig:"ASYNC_REDIS_PORT" default:"6379"`
-	Password  string `envconfig:"ASYNC_REDIS_PASSWORD" default:""`
-	DB        int    `envconfig:"ASYNC_REDIS_DB" default:"0"`
-	EnableTLS bool   `envconfig:"ASYNC_REDIS_ENABLE_TLS" default:"false"`
+// NewConfigWithDefaults returns a Config object with default values already
+// applied. Callers are then free to set custom values for the remaining fields
+// and/or override default values.
+func NewConfigWithDefaults() Config {
+	return Config{RedisPort: 6379}
 }
 
-// GetConfig returns Redis configuration
-func GetConfig() (Config, error) {
-	c := config{}
+// GetConfigFromEnvironment returns configuration derived from environment
+// variables
+func GetConfigFromEnvironment() (Config, error) {
+	c := NewConfigWithDefaults()
 	err := envconfig.Process("", &c)
 	return c, err
-}
-
-func (c config) GetHost() string {
-	return c.Host
-}
-
-func (c config) GetPort() int {
-	return c.Port
-}
-
-func (c config) GetPassword() string {
-	return c.Password
-}
-
-func (c config) GetDB() int {
-	return c.DB
-}
-
-func (c config) IsTLSEnabled() bool {
-	return c.EnableTLS
 }

--- a/pkg/async/redis/engine_test.go
+++ b/pkg/async/redis/engine_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestNewEnginesHaveUniqueWorkerIDs(t *testing.T) {
 	// Create two engines
-	e1 := NewEngine(redisClient).(*engine)
-	e2 := NewEngine(redisClient).(*engine)
+	e1 := getTestEngine()
+	e2 := getTestEngine()
 
 	// Assert that their workerIDs are at least different from one another
 	assert.NotEqual(t, e1.workerID, e2.workerID)
@@ -440,7 +440,10 @@ func TestRunRespondsToCanceledContext(t *testing.T) {
 // are passed is canceled. Individual test cases can selectively revert or
 // amend these overrides to test specific scenarios.
 func getTestEngine() *engine {
-	e := NewEngine(redisClient).(*engine)
+	config := NewConfigWithDefaults()
+	config.RedisHost = "redis"
+	config.RedisDB = 1
+	e := NewEngine(config).(*engine)
 	// Cleaner loop
 	e.clean = func(
 		ctx context.Context,

--- a/pkg/async/redis/heart_test.go
+++ b/pkg/async/redis/heart_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDefaultRunHeartBlocksUntilBeatErrors(t *testing.T) {
-	e := NewEngine(redisClient).(*engine)
+	e := getTestEngine()
 
 	// Override default heartbeat function so it just returns an error
 	e.heartbeat = func(time.Duration) error {
@@ -37,7 +37,7 @@ func TestDefaultRunHeartBlocksUntilBeatErrors(t *testing.T) {
 }
 
 func TestDefaultRunHeartRespondsToCanceledContext(t *testing.T) {
-	e := NewEngine(redisClient).(*engine)
+	e := getTestEngine()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -65,16 +65,16 @@ func TestDefaultRunHeartRespondsToCanceledContext(t *testing.T) {
 }
 
 func TestDefaultHeartbeat(t *testing.T) {
-	e := NewEngine(redisClient).(*engine)
+	e := getTestEngine()
 
 	err := e.defaultHeartbeat(time.Second)
 	assert.Nil(t, err)
 
 	// Assert that the heartbeat is visible, with a TTL, in Redis.
-	str, err := redisClient.Get(getHeartbeatKey(e.workerID)).Result()
+	str, err := e.redisClient.Get(getHeartbeatKey(e.workerID)).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, aliveIndicator, str)
-	ttl, err := redisClient.TTL(getHeartbeatKey(e.workerID)).Result()
+	ttl, err := e.redisClient.TTL(getHeartbeatKey(e.workerID)).Result()
 	assert.Nil(t, err)
 	assert.True(t, ttl > 0)
 }

--- a/pkg/async/redis/task_watcher_test.go
+++ b/pkg/async/redis/task_watcher_test.go
@@ -16,17 +16,17 @@ func TestDefaultWatchDeferredTaskWithInvalidTask(t *testing.T) {
 	watchedTaskQueueName := getWatchedTaskQueueName(e.workerID)
 
 	// Assert that the pending task queue is empty
-	pendingTaskQueueDepth, err := redisClient.LLen(pendingTaskQueueName).Result()
+	pendingTaskQueueDepth, err := e.redisClient.LLen(pendingTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, pendingTaskQueueDepth)
 
 	// Put an invalid task (it isn't even JSON) on the worker's watched task queue
 	invalidTaskJSON := []byte("bogus")
-	err = redisClient.LPush(watchedTaskQueueName, invalidTaskJSON).Err()
+	err = e.redisClient.LPush(watchedTaskQueueName, invalidTaskJSON).Err()
 	assert.Nil(t, err)
 
 	// Assert that queue now has precisely 1 task
-	watchedTaskQueueDepth, err := redisClient.LLen(watchedTaskQueueName).Result()
+	watchedTaskQueueDepth, err := e.redisClient.LLen(watchedTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), watchedTaskQueueDepth)
 
@@ -55,12 +55,12 @@ func TestDefaultWatchDeferredTaskWithInvalidTask(t *testing.T) {
 	}
 
 	// Assert that the pending task queue is STILL empty
-	pendingTaskQueueDepth, err = redisClient.LLen(pendingTaskQueueName).Result()
+	pendingTaskQueueDepth, err = e.redisClient.LLen(pendingTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, pendingTaskQueueDepth)
 
 	// And so is the worker's watched task queue
-	watchedTaskQueueDepth, err = redisClient.LLen(watchedTaskQueueName).Result()
+	watchedTaskQueueDepth, err = e.redisClient.LLen(watchedTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, watchedTaskQueueDepth)
 }
@@ -72,7 +72,7 @@ func TestDefaultWatchDeferredTaskWithTaskWithoutExecuteTime(t *testing.T) {
 	watchedTaskQueueName := getWatchedTaskQueueName(e.workerID)
 
 	// Assert that the pending task queue is empty
-	pendingTaskQueueDepth, err := redisClient.LLen(pendingTaskQueueName).Result()
+	pendingTaskQueueDepth, err := e.redisClient.LLen(pendingTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, pendingTaskQueueDepth)
 
@@ -80,11 +80,11 @@ func TestDefaultWatchDeferredTaskWithTaskWithoutExecuteTime(t *testing.T) {
 	task := async.NewTask("foo", nil)
 	taskJSON, err := task.ToJSON()
 	assert.Nil(t, err)
-	err = redisClient.LPush(watchedTaskQueueName, taskJSON).Err()
+	err = e.redisClient.LPush(watchedTaskQueueName, taskJSON).Err()
 	assert.Nil(t, err)
 
 	// Assert that queue now has precisely 1 task
-	watchedTaskQueueDepth, err := redisClient.LLen(watchedTaskQueueName).Result()
+	watchedTaskQueueDepth, err := e.redisClient.LLen(watchedTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), watchedTaskQueueDepth)
 
@@ -113,12 +113,12 @@ func TestDefaultWatchDeferredTaskWithTaskWithoutExecuteTime(t *testing.T) {
 	}
 
 	// Assert that the pending task queue is STILL empty
-	pendingTaskQueueDepth, err = redisClient.LLen(pendingTaskQueueName).Result()
+	pendingTaskQueueDepth, err = e.redisClient.LLen(pendingTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, pendingTaskQueueDepth)
 
 	// And so is the worker's watched task queue
-	watchedTaskQueueDepth, err = redisClient.LLen(watchedTaskQueueName).Result()
+	watchedTaskQueueDepth, err = e.redisClient.LLen(watchedTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, watchedTaskQueueDepth)
 }
@@ -130,7 +130,7 @@ func TestDefaultWatchDeferredTaskWithLapsedTask(t *testing.T) {
 	watchedTaskQueueName := getWatchedTaskQueueName(e.workerID)
 
 	// Assert that the pending task queue is empty
-	pendingTaskQueueDepth, err := redisClient.LLen(pendingTaskQueueName).Result()
+	pendingTaskQueueDepth, err := e.redisClient.LLen(pendingTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, pendingTaskQueueDepth)
 
@@ -138,11 +138,11 @@ func TestDefaultWatchDeferredTaskWithLapsedTask(t *testing.T) {
 	task := async.NewDelayedTask("foo", nil, time.Second*-1)
 	taskJSON, err := task.ToJSON()
 	assert.Nil(t, err)
-	err = redisClient.LPush(watchedTaskQueueName, taskJSON).Err()
+	err = e.redisClient.LPush(watchedTaskQueueName, taskJSON).Err()
 	assert.Nil(t, err)
 
 	// Assert that queue now has precisely 1 task
-	watchedTaskQueueDepth, err := redisClient.LLen(watchedTaskQueueName).Result()
+	watchedTaskQueueDepth, err := e.redisClient.LLen(watchedTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), watchedTaskQueueDepth)
 
@@ -168,12 +168,12 @@ func TestDefaultWatchDeferredTaskWithLapsedTask(t *testing.T) {
 	}
 
 	// Assert that the pending task queue now has precisely 1 task
-	pendingTaskQueueDepth, err = redisClient.LLen(pendingTaskQueueName).Result()
+	pendingTaskQueueDepth, err = e.redisClient.LLen(pendingTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), pendingTaskQueueDepth)
 
 	// And the worker's watched task queue is now empty
-	watchedTaskQueueDepth, err = redisClient.LLen(watchedTaskQueueName).Result()
+	watchedTaskQueueDepth, err = e.redisClient.LLen(watchedTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, watchedTaskQueueDepth)
 }
@@ -185,7 +185,7 @@ func TestDefaultWatchDeferredTaskRespondsToCanceledContext(t *testing.T) {
 	watchedTaskQueueName := getWatchedTaskQueueName(e.workerID)
 
 	// Assert that the pending task queue is empty
-	pendingTaskQueueDepth, err := redisClient.LLen(pendingTaskQueueName).Result()
+	pendingTaskQueueDepth, err := e.redisClient.LLen(pendingTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, pendingTaskQueueDepth)
 
@@ -193,11 +193,11 @@ func TestDefaultWatchDeferredTaskRespondsToCanceledContext(t *testing.T) {
 	task := async.NewDelayedTask("foo", nil, time.Second*5)
 	taskJSON, err := task.ToJSON()
 	assert.Nil(t, err)
-	err = redisClient.LPush(watchedTaskQueueName, taskJSON).Err()
+	err = e.redisClient.LPush(watchedTaskQueueName, taskJSON).Err()
 	assert.Nil(t, err)
 
 	// Assert that queue now has precisely 1 task
-	watchedTaskQueueDepth, err := redisClient.LLen(watchedTaskQueueName).Result()
+	watchedTaskQueueDepth, err := e.redisClient.LLen(watchedTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), watchedTaskQueueDepth)
 
@@ -227,12 +227,12 @@ func TestDefaultWatchDeferredTaskRespondsToCanceledContext(t *testing.T) {
 	// should have changed in the queues....
 
 	// Assert that the pending task queue is STILL empty
-	pendingTaskQueueDepth, err = redisClient.LLen(pendingTaskQueueName).Result()
+	pendingTaskQueueDepth, err = e.redisClient.LLen(pendingTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, pendingTaskQueueDepth)
 
 	// And the worker's watched task STILL has precisely 1 task
-	watchedTaskQueueDepth, err = redisClient.LLen(watchedTaskQueueName).Result()
+	watchedTaskQueueDepth, err = e.redisClient.LLen(watchedTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), watchedTaskQueueDepth)
 }

--- a/pkg/async/redis/tasks_executor_test.go
+++ b/pkg/async/redis/tasks_executor_test.go
@@ -61,22 +61,23 @@ func TestDefaultExecuteTasks(t *testing.T) {
 
 	// Put all the tasks on the worker's active task queue
 	for _, task := range tasks {
-		err := redisClient.LPush(activeTaskQueueName, task).Err()
+		err := e.redisClient.LPush(activeTaskQueueName, task).Err()
 		assert.Nil(t, err)
 	}
 
 	// Assert that the pending task queue is empty
-	pendingTaskQueueDepth, err := redisClient.LLen(pendingTaskQueueName).Result()
+	pendingTaskQueueDepth, err := e.redisClient.LLen(pendingTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, pendingTaskQueueDepth)
 
 	// Assert that the deferred task queue is empty
-	deferredTaskQueueDepth, err := redisClient.LLen(deferredTaskQueueName).Result()
+	deferredTaskQueueDepth, err :=
+		e.redisClient.LLen(deferredTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, deferredTaskQueueDepth)
 
 	// Assert that worker's active task queue has precisely len(tasks) tasks
-	activeTaskQueueDepth, err := redisClient.LLen(activeTaskQueueName).Result()
+	activeTaskQueueDepth, err := e.redisClient.LLen(activeTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(len(tasks)), activeTaskQueueDepth)
 
@@ -116,19 +117,20 @@ func TestDefaultExecuteTasks(t *testing.T) {
 	// Assert that the pending task queue has precisely two tasks-- the
 	// unprocessable task, which should have been returned to it, and a follow-up
 	// task
-	pendingTaskQueueDepth, err = redisClient.LLen(pendingTaskQueueName).Result()
+	pendingTaskQueueDepth, err = e.redisClient.LLen(pendingTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(2), pendingTaskQueueDepth)
 
 	// Assert that the deferred task queue has precisely one task-- a follow-up
 	// task
-	deferredTaskQueueDepth, err = redisClient.LLen(deferredTaskQueueName).Result()
+	deferredTaskQueueDepth, err =
+		e.redisClient.LLen(deferredTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), deferredTaskQueueDepth)
 
 	// Assert that the worker's active task queue is empty-- in all cases, the
 	// tasks should have been removed from this queue
-	activeTaskQueueDepth, err = redisClient.LLen(activeTaskQueueName).Result()
+	activeTaskQueueDepth, err = e.redisClient.LLen(activeTaskQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, activeTaskQueueDepth)
 

--- a/pkg/async/redis/tasks_receiver_test.go
+++ b/pkg/async/redis/tasks_receiver_test.go
@@ -18,17 +18,17 @@ func TestDefaultReceiveTasks(t *testing.T) {
 	const taskCount int64 = 5
 	for range [taskCount]struct{}{} {
 		// Dummy tasks are fine. This test won't ever parse them.
-		err := redisClient.LPush(sourceQueueName, "foo").Err()
+		err := e.redisClient.LPush(sourceQueueName, "foo").Err()
 		assert.Nil(t, err)
 	}
 
 	// Assert that the source queue has precisely taskCount tasks
-	sourceQueueDepth, err := redisClient.LLen(sourceQueueName).Result()
+	sourceQueueDepth, err := e.redisClient.LLen(sourceQueueName).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, taskCount, sourceQueueDepth)
 
 	// Assert that the destination queue is empty
-	destinationQueueDepth, err := redisClient.LLen(destinationQueueName).Result()
+	destinationQueueDepth, err := e.redisClient.LLen(destinationQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, destinationQueueDepth)
 
@@ -71,12 +71,12 @@ func TestDefaultReceiveTasks(t *testing.T) {
 	assert.Equal(t, taskCount, resCount)
 
 	// Assert that the source task queue has been drained
-	sourceQueueDepth, err = redisClient.LLen(sourceQueueName).Result()
+	sourceQueueDepth, err = e.redisClient.LLen(sourceQueueName).Result()
 	assert.Nil(t, err)
 	assert.Empty(t, sourceQueueDepth)
 
 	// Assert that the destination queue now has precisely taskCount tasks
-	destinationQueueDepth, err = redisClient.LLen(destinationQueueName).Result()
+	destinationQueueDepth, err = e.redisClient.LLen(destinationQueueName).Result()
 	assert.Nil(t, err)
 	assert.Equal(t, taskCount, destinationQueueDepth)
 }

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Azure/open-service-broker-azure/pkg/api"
 	"github.com/Azure/open-service-broker-azure/pkg/async"
-	redisAsync "github.com/Azure/open-service-broker-azure/pkg/async/redis"
 	"github.com/Azure/open-service-broker-azure/pkg/crypto"
 	"github.com/Azure/open-service-broker-azure/pkg/http/filter"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
@@ -50,7 +49,7 @@ type broker struct {
 // NewBroker returns a new Broker
 func NewBroker(
 	storageRedisClient *redis.Client,
-	asyncRedisClient *redis.Client,
+	asyncEngine async.Engine,
 	codec crypto.Codec,
 	filterChain filter.Filter,
 	modules []service.Module,
@@ -92,7 +91,7 @@ func NewBroker(
 	catalog := service.NewCatalog(services)
 	b := &broker{
 		store:       storage.NewStore(storageRedisClient, catalog, codec),
-		asyncEngine: redisAsync.NewEngine(asyncRedisClient),
+		asyncEngine: asyncEngine,
 		catalog:     catalog,
 	}
 

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -143,7 +143,7 @@ func TestBrokerStartBlocksUntilContextCanceled(t *testing.T) {
 func getTestBroker() (*broker, error) {
 	b, err := NewBroker(
 		nil,
-		nil,
+		fakeAsync.NewEngine(),
 		nil,
 		filter.NewChain(),
 		nil,


### PR DESCRIPTION
This is a pre-req for a future PR that will solve #237 

My goal is for the async engine to be configurable in the same way that a Redis client is. This is how you make a Redis client:

```
redisClient := redis.NewClient(
  &redis.Options{
    // Set options ...
  },
)
```

As the number of configurable options for the async engine grows, I want it to work the same way-- you pass config/options to the constructor-like function like so:

```
asyncConfig, err := async.GetConfigFromEnvironment()
if err != nil {
  log.Fatal(err)
}
asyncEngine := async.NewEngine(asyncConfig)
```

While this gets config from environment variables, you can just as easily do this:

```
asyncEngine := async.NewEngine(
  async.Config{
    // Set options ...
  },
)
```

The above makes it convenient to set config options during tests without messing around with environment variables. It will also make this nice and clean to use if/when we separate the async engine into its own project.

Note that in this refactor, when you pass this configuration to the consructor-like function, you _no longer_ pass a pre-built Redis client. Essentially, we're doing away with the dependency-injection aspect of this. Is that advisable? I think in this case, yes. For two reasons:

1. First and foremost, we don't want to burden users of the async engine with details of its underlying Redis library. i.e., The async engine should be able to swap Redis libraries without its users ever knowing.
2. A main benefit of injecting dependencies is the ease with which alternative implementations can be injected-- e.g. injecting a fake to support testing. But the Redis client (and the _Redis_ that it is an interface to) aren't so easily mocked that we would ever _not_ simply use the real thing and just fire up a containerized Redis to test against.

Bottom line-- this PR cleans "bootstrap" code up significantly and advances us toward addressing #237 much more cleanly.

Note that a few other PRs will follow this one to give similar treatment to storage configuration, API configuration, and catalog-building.

@jeremyrickard, let me know if you have questions.