### PR TITLE
refactor how (where) the catalog is built

### DIFF
--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -59,8 +59,17 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Initialize modules
-	if err = initModules(azureConfig); err != nil {
+	// Initialize catalog
+	modulesConfig, err := service.GetModulesConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+	modules, err := getModules(modulesConfig, azureConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+	catalog, err := getCatalog(modules)
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -137,19 +146,13 @@ func main() {
 		apiFilters.NewAPIVersionFilter(),
 	)
 
-	modulesConfig, err := service.GetModulesConfig()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	// Create broker
 	broker, err := broker.NewBroker(
 		storageRedisClient,
 		asyncEngine,
 		codec,
 		filterChain,
-		modules,
-		modulesConfig.GetMinStability(),
+		catalog,
 		azureConfig.GetDefaultLocation(),
 		azureConfig.GetDefaultResourceGroup(),
 	)

--- a/cmd/broker/catalog.go
+++ b/cmd/broker/catalog.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+)
+
+func getCatalog(modules []service.Module) (service.Catalog, error) {
+	// Consolidate the catalogs from all the individual modules into a single
+	// catalog. Check as we go along to make sure that no two modules provide
+	// services having the same ID.
+	services := []service.Service{}
+	usedServiceIDs := map[string]string{}
+	for _, module := range modules {
+		moduleName := module.GetName()
+		catalog, err := module.GetCatalog()
+		if err != nil {
+			return nil, fmt.Errorf(
+				`error retrieving catalog from module "%s": %s`,
+				moduleName,
+				err,
+			)
+		}
+		for _, svc := range catalog.GetServices() {
+			serviceID := svc.GetID()
+			if moduleNameForUsedServiceID, ok := usedServiceIDs[serviceID]; ok {
+				return nil, fmt.Errorf(
+					`modules "%s" and "%s" both provide a service with the id "%s"`,
+					moduleNameForUsedServiceID,
+					moduleName,
+					serviceID,
+				)
+			}
+			services = append(services, svc)
+			usedServiceIDs[serviceID] = moduleName
+		}
+	}
+	catalog := service.NewCatalog(services)
+
+	return catalog, nil
+}

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -52,43 +52,10 @@ func NewBroker(
 	asyncEngine async.Engine,
 	codec crypto.Codec,
 	filterChain filter.Filter,
-	modules []service.Module,
-	minStability service.Stability,
+	catalog service.Catalog,
 	defaultAzureLocation string,
 	defaultAzureResourceGroup string,
 ) (Broker, error) {
-	// Consolidate the catalogs from all the individual modules into a single
-	// catalog. Check as we go along to make sure that no two modules provide
-	// services having the same ID.
-	services := []service.Service{}
-	usedServiceIDs := map[string]string{}
-	for _, module := range modules {
-		if module.GetStability() >= minStability {
-			moduleName := module.GetName()
-			catalog, err := module.GetCatalog()
-			if err != nil {
-				return nil, fmt.Errorf(
-					`error retrieving catalog from module "%s": %s`,
-					moduleName,
-					err,
-				)
-			}
-			for _, svc := range catalog.GetServices() {
-				serviceID := svc.GetID()
-				if moduleNameForUsedServiceID, ok := usedServiceIDs[serviceID]; ok {
-					return nil, fmt.Errorf(
-						`modules "%s" and "%s" both provide a service with the id "%s"`,
-						moduleNameForUsedServiceID,
-						moduleName,
-						serviceID,
-					)
-				}
-				services = append(services, svc)
-				usedServiceIDs[serviceID] = moduleName
-			}
-		}
-	}
-	catalog := service.NewCatalog(services)
 	b := &broker{
 		store:       storage.NewStore(storageRedisClient, catalog, codec),
 		asyncEngine: asyncEngine,

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/Azure/open-service-broker-azure/pkg/http/filter"
+	"github.com/Azure/open-service-broker-azure/pkg/service"
 
 	fakeAPI "github.com/Azure/open-service-broker-azure/pkg/api/fake"
 	fakeAsync "github.com/Azure/open-service-broker-azure/pkg/async/fake"
-	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -146,8 +146,7 @@ func getTestBroker() (*broker, error) {
 		fakeAsync.NewEngine(),
 		nil,
 		filter.NewChain(),
-		nil,
-		service.StabilityExperimental,
+		service.NewCatalog(nil),
 		"",
 		"",
 	)


### PR DESCRIPTION
This builds on #333 and improves how/where we build the catalog.

Previously, we were handing a slice of modules to the broker along with module config that allowed the broker to know which modules to filter out. The broker would then build the catalog itself from the "mini catalogs" provided by each non-filtered-out module. The broker (the component that is) shouldn't be responsible for this.

Now, more of this is done by the bootstrap code in the `cmd`. This means that the resulting catalog can now be treated like a first-class component (it is, really) and passed in an already usable state to other components that need it.

This also makes it easier to programmatically provide a customized / abbreviated catalog during testing.