### PR TITLE
refactor lifecycle tests

### DIFF
--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -12,6 +12,7 @@ import (
 	apiFilters "github.com/Azure/open-service-broker-azure/pkg/api/filters"
 	async "github.com/Azure/open-service-broker-azure/pkg/async/redis"
 	"github.com/Azure/open-service-broker-azure/pkg/azure"
+	"github.com/Azure/open-service-broker-azure/pkg/boot"
 	"github.com/Azure/open-service-broker-azure/pkg/broker"
 	"github.com/Azure/open-service-broker-azure/pkg/http/filter"
 	"github.com/Azure/open-service-broker-azure/pkg/http/filters"
@@ -48,21 +49,16 @@ func main() {
 	).Info("Setting log level")
 	log.SetLevel(logLevel)
 
+	// Initialize catalog
+	catalogConfig, err := service.GetCatalogConfigFromEnvironment()
+	if err != nil {
+		log.Fatal(err)
+	}
 	azureConfig, err := azure.GetConfigFromEnvironment()
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// Initialize catalog
-	modulesConfig, err := service.GetModulesConfig()
-	if err != nil {
-		log.Fatal(err)
-	}
-	modules, err := getModules(modulesConfig, azureConfig)
-	if err != nil {
-		log.Fatal(err)
-	}
-	catalog, err := getCatalog(modules)
+	catalog, err := boot.GetCatalog(catalogConfig, azureConfig)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/boot/catalog.go
+++ b/pkg/boot/catalog.go
@@ -1,12 +1,22 @@
-package main
+package boot
 
 import (
 	"fmt"
 
+	"github.com/Azure/open-service-broker-azure/pkg/azure"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func getCatalog(modules []service.Module) (service.Catalog, error) {
+// GetCatalog returns a fully initialized catalog
+func GetCatalog(
+	catalogConfig service.CatalogConfig,
+	azureConfig azure.Config,
+) (service.Catalog, error) {
+	modules, err := getModules(catalogConfig, azureConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error getting modules: %s", err)
+	}
+
 	// Consolidate the catalogs from all the individual modules into a single
 	// catalog. Check as we go along to make sure that no two modules provide
 	// services having the same ID.

--- a/pkg/boot/modules.go
+++ b/pkg/boot/modules.go
@@ -1,4 +1,4 @@
-package main
+package boot
 
 import (
 	"fmt"
@@ -35,7 +35,7 @@ import (
 )
 
 func getModules(
-	modulesConfig service.ModulesConfig,
+	catalogConfig service.CatalogConfig,
 	azureConfig azure.Config,
 ) ([]service.Module, error) {
 	azureSubscriptionID := azureConfig.SubscriptionID
@@ -215,7 +215,7 @@ func getModules(
 	// Filter modules based on stability
 	filteredModules := []service.Module{}
 	for _, module := range modules {
-		if module.GetStability() >= modulesConfig.GetMinStability() {
+		if module.GetStability() >= catalogConfig.GetMinStability() {
 			filteredModules = append(filteredModules, module)
 		}
 	}

--- a/pkg/service/catalog_config.go
+++ b/pkg/service/catalog_config.go
@@ -7,20 +7,20 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-// ModulesConfig represents details re: which modules' services should be
+// CatalogConfig represents details re: which modules' services should be
 // included or excluded from the catalog
-type ModulesConfig interface {
+type CatalogConfig interface {
 	GetMinStability() Stability
 }
 
-type modulesConfig struct {
+type catalogConfig struct {
 	MinStabilityStr string `envconfig:"MIN_STABILITY" default:"EXPERIMENTAL"`
 	MinStability    Stability
 }
 
-// GetModulesConfig returns modules configuration
-func GetModulesConfig() (ModulesConfig, error) {
-	mc := modulesConfig{}
+// GetCatalogConfigFromEnvironment returns catalog configuration
+func GetCatalogConfigFromEnvironment() (CatalogConfig, error) {
+	mc := catalogConfig{}
 	err := envconfig.Process("", &mc)
 	if err != nil {
 		return mc, err
@@ -42,6 +42,6 @@ func GetModulesConfig() (ModulesConfig, error) {
 	return mc, nil
 }
 
-func (m modulesConfig) GetMinStability() Stability {
-	return m.MinStability
+func (c catalogConfig) GetMinStability() Stability {
+	return c.MinStability
 }

--- a/pkg/services/eventhubs/eventhub.go
+++ b/pkg/services/eventhubs/eventhub.go
@@ -30,7 +30,7 @@ func New(
 }
 
 func (m *module) GetName() string {
-	return "eventhub"
+	return "eventhubs"
 }
 
 func (m *module) GetStability() service.Stability {

--- a/pkg/services/search/search.go
+++ b/pkg/services/search/search.go
@@ -30,7 +30,7 @@ func New(
 }
 
 func (m *module) GetName() string {
-	return "azuresearch"
+	return "search"
 }
 
 func (m *module) GetStability() service.Stability {

--- a/tests/lifecycle/aci_cases_test.go
+++ b/tests/lifecycle/aci_cases_test.go
@@ -2,38 +2,20 @@
 
 package lifecycle
 
-import (
-	aciSDK "github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2017-08-01-preview/containerinstance" // nolint: lll
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
-	"github.com/Azure/open-service-broker-azure/pkg/service"
-	"github.com/Azure/open-service-broker-azure/pkg/services/aci"
-)
+import "github.com/Azure/open-service-broker-azure/pkg/service"
 
-func getACICases(
-	azureEnvironment azure.Environment,
-	subscriptionID string,
-	authorizer autorest.Authorizer,
-	armDeployer arm.Deployer,
-) ([]serviceLifecycleTestCase, error) {
-	containerGroupsClient := aciSDK.NewContainerGroupsClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	containerGroupsClient.Authorizer = authorizer
-	return []serviceLifecycleTestCase{
-		{
-			module:    aci.New(armDeployer, containerGroupsClient),
-			serviceID: "451d5d19-4575-4d4a-9474-116f705ecc95",
-			planID:    "d48798e2-21db-405b-abc7-aa6f0ff08f6c",
-			location:  "eastus",
-			provisioningParameters: service.CombinedProvisioningParameters{
-				"image":      "nginx",
-				"memoryInGb": 1.5,
-				"cpuCores":   1,
-				"ports":      []int{80, 443},
-			},
+var aciTestCases = []serviceLifecycleTestCase{
+	{
+		group:     "aci",
+		name:      "aci",
+		serviceID: "451d5d19-4575-4d4a-9474-116f705ecc95",
+		planID:    "d48798e2-21db-405b-abc7-aa6f0ff08f6c",
+		location:  "eastus",
+		provisioningParameters: service.CombinedProvisioningParameters{
+			"image":      "nginx",
+			"memoryInGb": 1.5,
+			"cpuCores":   1,
+			"ports":      []int{80, 443},
 		},
-	}, nil
+	},
 }

--- a/tests/lifecycle/cosmosdb_cases_test.go
+++ b/tests/lifecycle/cosmosdb_cases_test.go
@@ -8,115 +8,96 @@ import (
 	"net"
 	"time"
 
-	cosmosSDK "github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2015-04-08/documentdb" // nolint: lll
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
-	"github.com/Azure/open-service-broker-azure/pkg/services/cosmosdb"
 	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
-func getCosmosdbCases(
-	azureEnvironment azure.Environment,
-	subscriptionID string,
-	authorizer autorest.Authorizer,
-	armDeployer arm.Deployer,
-) ([]serviceLifecycleTestCase, error) {
-	dbAccountsClient := cosmosSDK.NewDatabaseAccountsClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	dbAccountsClient.Authorizer = authorizer
-	return []serviceLifecycleTestCase{
-		{ // sql api
-			module:      cosmosdb.New(armDeployer, dbAccountsClient),
-			description: "CosmosDB SQL API",
-			serviceID:   "6330de6f-a561-43ea-a15e-b99f44d183e6",
-			planID:      "71168d1a-c704-49ff-8c79-214dd3d6f8eb",
-			location:    "eastus",
-		},
-		{ // MongoDB
-			module:          cosmosdb.New(armDeployer, dbAccountsClient),
-			description:     "MongoDB API on CosmosDB",
-			serviceID:       "8797a079-5346-4e84-8018-b7d5ea5c0e3a",
-			planID:          "86fdda05-78d7-4026-a443-1325928e7b02",
-			location:        "southcentralus",
-			testCredentials: testMongoDBCreds(),
-		},
-		{ // Graph API
-			module:      cosmosdb.New(armDeployer, dbAccountsClient),
-			description: "CosmosDB Graph API",
-			serviceID:   "5f5252a0-6922-4a0c-a755-f9be70d7c79b",
-			planID:      "126a2c47-11a3-49b1-833a-21b563de6c04",
-			location:    "southcentralus",
-		},
-		{ // Table API
-			module:      cosmosdb.New(armDeployer, dbAccountsClient),
-			description: "CosmosDB Table API",
-			serviceID:   "37915cad-5259-470d-a7aa-207ba89ada8c",
-			planID:      "c970b1e8-794f-4d7c-9458-d28423c08856",
-			location:    "southcentralus",
-		},
-	}, nil
+var cosmosdbTestCases = []serviceLifecycleTestCase{
+	{ // SQL API
+		group:     "cosmosdb",
+		name:      "sql-api",
+		serviceID: "6330de6f-a561-43ea-a15e-b99f44d183e6",
+		planID:    "71168d1a-c704-49ff-8c79-214dd3d6f8eb",
+		location:  "eastus",
+	},
+	{ // Graph API
+		group:     "cosmosdb",
+		name:      "graph-api",
+		serviceID: "5f5252a0-6922-4a0c-a755-f9be70d7c79b",
+		planID:    "126a2c47-11a3-49b1-833a-21b563de6c04",
+		location:  "southcentralus",
+	},
+	{ // Table API
+		group:     "cosmosdb",
+		name:      "table-api",
+		serviceID: "37915cad-5259-470d-a7aa-207ba89ada8c",
+		planID:    "c970b1e8-794f-4d7c-9458-d28423c08856",
+		location:  "southcentralus",
+	},
+	{ // MongoDB
+		group:           "cosmosdb",
+		name:            "mongo-api",
+		serviceID:       "8797a079-5346-4e84-8018-b7d5ea5c0e3a",
+		planID:          "86fdda05-78d7-4026-a443-1325928e7b02",
+		location:        "southcentralus",
+		testCredentials: testMongoDBCreds,
+	},
 }
 
-func testMongoDBCreds() func(credentials map[string]interface{}) error {
-	return func(credentials map[string]interface{}) error {
-		// The following process is based on
-		// https://docs.microsoft.com/en-us/azure/cosmos-db/create-mongodb-golang
+func testMongoDBCreds(credentials map[string]interface{}) error {
+	// The following process is based on
+	// https://docs.microsoft.com/en-us/azure/cosmos-db/create-mongodb-golang
 
-		// DialInfo holds options for establishing a session with a MongoDB cluster.
-		dialInfo := &mgo.DialInfo{
-			Addrs: []string{
-				fmt.Sprintf(
-					"%s:%d",
-					credentials["host"].(string),
-					int(credentials["port"].(float64)),
-				),
-			},
-			Timeout:  60 * time.Second,
-			Database: "database",
-			Username: credentials["username"].(string),
-			Password: credentials["password"].(string),
-			DialServer: func(addr *mgo.ServerAddr) (net.Conn, error) {
-				return tls.Dial("tcp", addr.String(), &tls.Config{})
-			},
-		}
+	// DialInfo holds options for establishing a session with a MongoDB cluster.
+	dialInfo := &mgo.DialInfo{
+		Addrs: []string{
+			fmt.Sprintf(
+				"%s:%d",
+				credentials["host"].(string),
+				int(credentials["port"].(float64)),
+			),
+		},
+		Timeout:  60 * time.Second,
+		Database: "database",
+		Username: credentials["username"].(string),
+		Password: credentials["password"].(string),
+		DialServer: func(addr *mgo.ServerAddr) (net.Conn, error) {
+			return tls.Dial("tcp", addr.String(), &tls.Config{})
+		},
+	}
 
-		// Create a session which maintains a pool of socket connections
-		// to our Azure Cosmos DB MongoDB database.
-		session, err := mgo.DialWithInfo(dialInfo)
+	// Create a session which maintains a pool of socket connections
+	// to our Azure Cosmos DB MongoDB database.
+	session, err := mgo.DialWithInfo(dialInfo)
 
-		if err != nil {
-			return err
-		}
-
-		defer session.Close()
-
-		session.SetSafe(&mgo.Safe{})
-
-		collection := session.DB("database").C("package")
-
-		// Model
-		type Package struct {
-			ID            bson.ObjectId `bson:"_id,omitempty"`
-			FullName      string
-			Description   string
-			StarsCount    int
-			ForksCount    int
-			LastUpdatedBy string
-		}
-
-		// insert Document in collection
-		err = collection.Insert(&Package{
-			FullName:      "react",
-			Description:   "A framework for building native apps with React.",
-			ForksCount:    11392,
-			StarsCount:    48794,
-			LastUpdatedBy: "shergin",
-		})
-
+	if err != nil {
 		return err
 	}
+
+	defer session.Close()
+
+	session.SetSafe(&mgo.Safe{})
+
+	collection := session.DB("database").C("package")
+
+	// Model
+	type Package struct {
+		ID            bson.ObjectId `bson:"_id,omitempty"`
+		FullName      string
+		Description   string
+		StarsCount    int
+		ForksCount    int
+		LastUpdatedBy string
+	}
+
+	// insert Document in collection
+	err = collection.Insert(&Package{
+		FullName:      "react",
+		Description:   "A framework for building native apps with React.",
+		ForksCount:    11392,
+		StarsCount:    48794,
+		LastUpdatedBy: "shergin",
+	})
+
+	return err
 }

--- a/tests/lifecycle/driver_test.go
+++ b/tests/lifecycle/driver_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/open-service-broker-azure/pkg/azure"
+	"github.com/Azure/open-service-broker-azure/pkg/boot"
+	"github.com/Azure/open-service-broker-azure/pkg/service"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,6 +19,15 @@ var resourceGroup string
 
 func TestServices(t *testing.T) {
 	log.Printf("----> testing in resource group \"%s\"\n", resourceGroup)
+
+	azureConfig, err := azure.GetConfigFromEnvironment()
+	assert.Nil(t, err)
+
+	catalogConfig, err := service.GetCatalogConfigFromEnvironment()
+	assert.Nil(t, err)
+
+	catalog, err := boot.GetCatalog(catalogConfig, azureConfig)
+	assert.Nil(t, err)
 
 	testCases, err := getTestCases()
 	assert.Nil(t, err)
@@ -30,12 +42,11 @@ func TestServices(t *testing.T) {
 			t.Run(tc.getName(), func(t *testing.T) {
 				// Run subtests in parallel!
 				t.Parallel()
-				err := tc.execute(t, resourceGroup)
+				err := tc.execute(t, catalog, resourceGroup)
 				assert.Nil(t, err)
 			})
 		}
 	})
-
 }
 
 func TestMain(m *testing.M) {

--- a/tests/lifecycle/eventhub_cases_test.go
+++ b/tests/lifecycle/eventhub_cases_test.go
@@ -2,31 +2,12 @@
 
 package lifecycle
 
-import (
-	eventHubSDK "github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub" // nolint: lll
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
-	"github.com/Azure/open-service-broker-azure/pkg/services/eventhubs"
-)
-
-func getEventhubCases(
-	azureEnvironment azure.Environment,
-	subscriptionID string,
-	authorizer autorest.Authorizer,
-	armDeployer arm.Deployer,
-) ([]serviceLifecycleTestCase, error) {
-	namespacesClient := eventHubSDK.NewNamespacesClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	namespacesClient.Authorizer = authorizer
-	return []serviceLifecycleTestCase{
-		{
-			module:    eventhubs.New(armDeployer, namespacesClient),
-			serviceID: "7bade660-32f1-4fd7-b9e6-d416d975170b",
-			planID:    "80756db5-a20c-495d-ae70-62cf7d196a3c",
-			location:  "southcentralus",
-		},
-	}, nil
+var eventhubsTestCases = []serviceLifecycleTestCase{
+	{
+		group:     "eventhubs",
+		name:      "eventhubs",
+		serviceID: "7bade660-32f1-4fd7-b9e6-d416d975170b",
+		planID:    "80756db5-a20c-495d-ae70-62cf7d196a3c",
+		location:  "southcentralus",
+	},
 }

--- a/tests/lifecycle/keyvault_cases_test.go
+++ b/tests/lifecycle/keyvault_cases_test.go
@@ -2,46 +2,19 @@
 
 package lifecycle
 
-import (
-	keyVaultSDK "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault" // nolint: lll
-	"github.com/Azure/go-autorest/autorest"
-	azureSDK "github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
-	"github.com/Azure/open-service-broker-azure/pkg/service"
-	"github.com/Azure/open-service-broker-azure/pkg/services/keyvault"
-)
+import "github.com/Azure/open-service-broker-azure/pkg/service"
 
-func getKeyvaultCases(
-	azureEnvironment azureSDK.Environment,
-	subscriptionID string,
-	authorizer autorest.Authorizer,
-	armDeployer arm.Deployer,
-) ([]serviceLifecycleTestCase, error) {
-	azureConfig, err := azure.GetConfigFromEnvironment()
-	if err != nil {
-		return nil, err
-	}
-	vaultsClient := keyVaultSDK.NewVaultsClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
-	)
-	vaultsClient.Authorizer = authorizer
-	return []serviceLifecycleTestCase{
-		{
-			module: keyvault.New(
-				azureConfig.TenantID,
-				armDeployer,
-				vaultsClient,
-			),
-			serviceID: "d90c881e-c9bb-4e07-a87b-fcfe87e03276",
-			planID:    "3577ee4a-75fc-44b3-b354-9d33d52ef486",
-			location:  "southcentralus",
-			provisioningParameters: service.CombinedProvisioningParameters{
-				"objectId":     "6a74d229-e927-42c5-b6e8-8f5c095cfba8",
-				"clientId":     "test",
-				"clientSecret": "test",
-			},
+var keyvaultTestCases = []serviceLifecycleTestCase{
+	{
+		group:     "keyvault",
+		name:      "keyvault",
+		serviceID: "d90c881e-c9bb-4e07-a87b-fcfe87e03276",
+		planID:    "3577ee4a-75fc-44b3-b354-9d33d52ef486",
+		location:  "southcentralus",
+		provisioningParameters: service.CombinedProvisioningParameters{
+			"objectId":     "6a74d229-e927-42c5-b6e8-8f5c095cfba8",
+			"clientId":     "test",
+			"clientSecret": "test",
 		},
-	}, nil
+	},
 }

--- a/tests/lifecycle/mssql_cases_test.go
+++ b/tests/lifecycle/mssql_cases_test.go
@@ -7,141 +7,110 @@ import (
 	"fmt"
 	"net/url"
 
-	sqlSDK "github.com/Azure/azure-sdk-for-go/services/sql/mgmt/2017-03-01-preview/sql" // nolint: lll
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
-	"github.com/Azure/open-service-broker-azure/pkg/services/mssql"
 	_ "github.com/denisenkom/go-mssqldb" // MS SQL Driver
 )
 
-func getMssqlCases(
-	azureEnvironment azure.Environment,
-	subscriptionID string,
-	authorizer autorest.Authorizer,
-	armDeployer arm.Deployer,
-) ([]serviceLifecycleTestCase, error) {
-	sqlServersClient := sqlSDK.NewServersClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	sqlServersClient.Authorizer = authorizer
-	sqlDatabasesClient := sqlSDK.NewDatabasesClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	sqlDatabasesClient.Authorizer = authorizer
-	module := mssql.New(
-		azureEnvironment,
-		armDeployer,
-		sqlServersClient,
-		sqlDatabasesClient,
-	)
-	return []serviceLifecycleTestCase{
-		{ // all-in-one scenario
-			module:      module,
-			description: "new server and database (all in one)",
-			serviceID:   "fb9bc99e-0aa9-11e6-8a8a-000d3a002ed5",
-			planID:      "3819fdfa-0aaa-11e6-86f4-000d3a002ed5",
-			location:    "southcentralus",
-			provisioningParameters: service.CombinedProvisioningParameters{
-				"firewallRules": []map[string]string{
-					{
-						"name":           "AllowSome",
-						"startIPAddress": "0.0.0.0",
-						"endIPAddress":   "35.0.0.0",
-					},
-					{
-						"name":           "AllowMore",
-						"startIPAddress": "35.0.0.1",
-						"endIPAddress":   "255.255.255.255",
-					},
+var mssqlTestCases = []serviceLifecycleTestCase{
+	{ // all-in-one scenario
+		group:     "mssql",
+		name:      "all-in-one",
+		serviceID: "fb9bc99e-0aa9-11e6-8a8a-000d3a002ed5",
+		planID:    "3819fdfa-0aaa-11e6-86f4-000d3a002ed5",
+		location:  "southcentralus",
+		provisioningParameters: service.CombinedProvisioningParameters{
+			"firewallRules": []map[string]string{
+				{
+					"name":           "AllowSome",
+					"startIPAddress": "0.0.0.0",
+					"endIPAddress":   "35.0.0.0",
 				},
-			},
-			bindingParameters: nil,
-			testCredentials:   testMsSQLCreds(),
-		},
-		{ // server only scenario
-			module:      module,
-			description: "new server with database child test",
-			serviceID:   "a7454e0e-be2c-46ac-b55f-8c4278117525",
-			planID:      "24f0f42e-1ab3-474e-a5ca-b943b2c48eee",
-			location:    "southcentralus",
-			provisioningParameters: service.CombinedProvisioningParameters{
-				"firewallRules": []map[string]string{
-					{
-						"name":           "AllowAll",
-						"startIPAddress": "0.0.0.0",
-						"endIPAddress":   "255.255.255.255",
-					},
-				},
-			},
-			childTestCases: []*serviceLifecycleTestCase{
-				{ // db only scenario
-					module:            module,
-					description:       "database on new server",
-					serviceID:         "2bbc160c-e279-4757-a6b6-4c0a4822d0aa",
-					planID:            "8fa8d759-c142-45dd-ae38-b93482ddc04a",
-					location:          "", // This is actually irrelevant for this test
-					bindingParameters: nil,
-					testCredentials:   testMsSQLCreds(),
+				{
+					"name":           "AllowMore",
+					"startIPAddress": "35.0.0.1",
+					"endIPAddress":   "255.255.255.255",
 				},
 			},
 		},
-	}, nil
+		testCredentials: testMsSQLCreds,
+	},
+	{ // dbms only scenario
+		group:     "mssql",
+		name:      "dbms-only",
+		serviceID: "a7454e0e-be2c-46ac-b55f-8c4278117525",
+		planID:    "24f0f42e-1ab3-474e-a5ca-b943b2c48eee",
+		location:  "southcentralus",
+		provisioningParameters: service.CombinedProvisioningParameters{
+			"firewallRules": []map[string]string{
+				{
+					"name":           "AllowAll",
+					"startIPAddress": "0.0.0.0",
+					"endIPAddress":   "255.255.255.255",
+				},
+			},
+		},
+		childTestCases: []*serviceLifecycleTestCase{
+			{ // db only scenario
+				group: "mssql",
+				name:  "database-only",
+
+				serviceID:       "2bbc160c-e279-4757-a6b6-4c0a4822d0aa",
+				planID:          "8fa8d759-c142-45dd-ae38-b93482ddc04a",
+				location:        "", // This is actually irrelevant for this test
+				testCredentials: testMsSQLCreds,
+			},
+		},
+	},
 }
 
-func testMsSQLCreds() func(credentials map[string]interface{}) error {
-	return func(credentials map[string]interface{}) error {
-		query := url.Values{}
-		query.Add("database", credentials["database"].(string))
-		query.Add("encrypt", "true")
-		query.Add("TrustServerCertificate", "true")
+func testMsSQLCreds(credentials map[string]interface{}) error {
+	query := url.Values{}
+	query.Add("database", credentials["database"].(string))
+	query.Add("encrypt", "true")
+	query.Add("TrustServerCertificate", "true")
 
-		u := &url.URL{
-			Scheme: "sqlserver",
-			User: url.UserPassword(
-				credentials["username"].(string),
-				credentials["password"].(string),
-			),
-			Host: fmt.Sprintf(
-				"%s:%d",
-				credentials["host"].(string),
-				int(credentials["port"].(float64)),
-			),
-			RawQuery: query.Encode(),
-		}
-
-		db, err := sql.Open("mssql", u.String())
-		if err != nil {
-			return fmt.Errorf("error validating the database arguments: %s", err)
-		}
-
-		if err = db.Ping(); err != nil {
-			return fmt.Errorf("error connecting to the database: %s", err)
-		}
-		defer db.Close() // nolint: errcheck
-
-		rows, err := db.Query("SELECT 1 FROM fn_my_permissions (NULL, 'DATABASE') WHERE permission_name='CONTROL'") // nolint: lll
-		if err != nil {
-			return fmt.Errorf(
-				`error querying SELECT from table fn_my_permissions: %s`,
-				err,
-			)
-		}
-		defer rows.Close() // nolint: errcheck
-		if !rows.Next() {
-			return fmt.Errorf(
-				`error user doesn't have permission 'CONTROL'`,
-			)
-		}
-		if err := rows.Err(); err != nil {
-			return fmt.Errorf(
-				`error iterating rows`,
-			)
-		}
-
-		return nil
+	u := &url.URL{
+		Scheme: "sqlserver",
+		User: url.UserPassword(
+			credentials["username"].(string),
+			credentials["password"].(string),
+		),
+		Host: fmt.Sprintf(
+			"%s:%d",
+			credentials["host"].(string),
+			int(credentials["port"].(float64)),
+		),
+		RawQuery: query.Encode(),
 	}
+
+	db, err := sql.Open("mssql", u.String())
+	if err != nil {
+		return fmt.Errorf("error validating the database arguments: %s", err)
+	}
+
+	if err = db.Ping(); err != nil {
+		return fmt.Errorf("error connecting to the database: %s", err)
+	}
+	defer db.Close() // nolint: errcheck
+
+	rows, err := db.Query("SELECT 1 FROM fn_my_permissions (NULL, 'DATABASE') WHERE permission_name='CONTROL'") // nolint: lll
+	if err != nil {
+		return fmt.Errorf(
+			`error querying SELECT from table fn_my_permissions: %s`,
+			err,
+		)
+	}
+	defer rows.Close() // nolint: errcheck
+	if !rows.Next() {
+		return fmt.Errorf(
+			`error user doesn't have permission 'CONTROL'`,
+		)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf(
+			`error iterating rows`,
+		)
+	}
+
+	return nil
 }

--- a/tests/lifecycle/mysql_cases_test.go
+++ b/tests/lifecycle/mysql_cases_test.go
@@ -6,139 +6,98 @@ import (
 	"database/sql"
 	"fmt"
 
-	mysqlSDK "github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-04-30-preview/mysql" // nolint: lll
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
-	mysql "github.com/Azure/open-service-broker-azure/pkg/services/mysql"
-
-	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/go-sql-driver/mysql" // MySQL SQL driver
 )
 
-func getMysqlCases(
-	azureEnvironment azure.Environment,
-	subscriptionID string,
-	authorizer autorest.Authorizer,
-	armDeployer arm.Deployer,
-) ([]serviceLifecycleTestCase, error) {
-	checkNameAvailabilityClient :=
-		mysqlSDK.NewCheckNameAvailabilityClientWithBaseURI(
-			azureEnvironment.ResourceManagerEndpoint,
-			subscriptionID,
-		)
-	checkNameAvailabilityClient.Authorizer = authorizer
-	serversClient := mysqlSDK.NewServersClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	serversClient.Authorizer = authorizer
-	databasesClient := mysqlSDK.NewDatabasesClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	databasesClient.Authorizer = authorizer
-	module := mysql.New(
-		azureEnvironment,
-		armDeployer,
-		checkNameAvailabilityClient,
-		serversClient,
-		databasesClient,
-	)
-	return []serviceLifecycleTestCase{
-		{
-			module:      module,
-			description: "server and database (all-in-one)",
-			serviceID:   "997b8372-8dac-40ac-ae65-758b4a5075a5",
-			planID:      "427559f1-bf2a-45d3-8844-32374a3e58aa",
-			location:    "southcentralus",
-			provisioningParameters: service.CombinedProvisioningParameters{
-				"sslEnforcement": "disabled",
-				"firewallRules": []map[string]string{
-					{
-						"name":           "AllowSome",
-						"startIPAddress": "0.0.0.0",
-						"endIPAddress":   "35.0.0.0",
-					},
-					{
-						"name":           "AllowMore",
-						"startIPAddress": "35.0.0.1",
-						"endIPAddress":   "255.255.255.255",
-					},
+var mysqlTestCases = []serviceLifecycleTestCase{
+	{
+		group:     "mysql",
+		name:      "all-in-one",
+		serviceID: "997b8372-8dac-40ac-ae65-758b4a5075a5",
+		planID:    "427559f1-bf2a-45d3-8844-32374a3e58aa",
+		location:  "southcentralus",
+		provisioningParameters: service.CombinedProvisioningParameters{
+			"sslEnforcement": "disabled",
+			"firewallRules": []map[string]string{
+				{
+					"name":           "AllowSome",
+					"startIPAddress": "0.0.0.0",
+					"endIPAddress":   "35.0.0.0",
 				},
-			},
-			bindingParameters: nil,
-			testCredentials:   testMySQLCreds(),
-		},
-		{
-			module:      module,
-			description: "dbms server only",
-			serviceID:   "30e7b836-199d-4335-b83d-adc7d23a95c2",
-			planID:      "3f65ebf9-ac1d-4e77-b9bf-918889a4482b",
-			location:    "eastus",
-			provisioningParameters: service.CombinedProvisioningParameters{
-				"firewallRules": []map[string]string{
-					{
-						"name":           "AllowAll",
-						"startIPAddress": "0.0.0.0",
-						"endIPAddress":   "255.255.255.255",
-					},
-				},
-			},
-			childTestCases: []*serviceLifecycleTestCase{
-				{ // database only scenario
-					module:                 module,
-					description:            "database on new server",
-					serviceID:              "6704ae59-3eae-49e9-82b4-4cbcc00edf08",
-					planID:                 "ec77bd04-2107-408e-8fde-8100c1ce1f46",
-					location:               "", // This is actually irrelevant for this test
-					bindingParameters:      nil,
-					testCredentials:        testMySQLCreds(),
-					provisioningParameters: nil,
+				{
+					"name":           "AllowMore",
+					"startIPAddress": "35.0.0.1",
+					"endIPAddress":   "255.255.255.255",
 				},
 			},
 		},
-	}, nil
+		testCredentials: testMySQLCreds,
+	},
+	{
+		group:     "mysql",
+		name:      "dbms-only",
+		serviceID: "30e7b836-199d-4335-b83d-adc7d23a95c2",
+		planID:    "3f65ebf9-ac1d-4e77-b9bf-918889a4482b",
+		location:  "eastus",
+		provisioningParameters: service.CombinedProvisioningParameters{
+			"firewallRules": []map[string]string{
+				{
+					"name":           "AllowAll",
+					"startIPAddress": "0.0.0.0",
+					"endIPAddress":   "255.255.255.255",
+				},
+			},
+		},
+		childTestCases: []*serviceLifecycleTestCase{
+			{ // database only scenario
+				group:           "mysql",
+				name:            "database-only",
+				serviceID:       "6704ae59-3eae-49e9-82b4-4cbcc00edf08",
+				planID:          "ec77bd04-2107-408e-8fde-8100c1ce1f46",
+				location:        "", // This is actually irrelevant for this test
+				testCredentials: testMySQLCreds,
+			},
+		},
+	},
 }
 
-func testMySQLCreds() func(credentials map[string]interface{}) error {
-	return func(credentials map[string]interface{}) error {
+func testMySQLCreds(credentials map[string]interface{}) error {
 
-		var connectionStrTemplate string
-		if credentials["sslRequired"].(bool) {
-			connectionStrTemplate =
-				"%s:%s@tcp(%s:3306)/%s?allowNativePasswords=true&tls=true"
-		} else {
-			connectionStrTemplate =
-				"%s:%s@tcp(%s:3306)/%s?allowNativePasswords=true"
-		}
-
-		db, err := sql.Open("mysql", fmt.Sprintf(
-			connectionStrTemplate,
-			credentials["username"].(string),
-			credentials["password"].(string),
-			credentials["host"].(string),
-			credentials["database"].(string),
-		))
-		if err != nil {
-			return fmt.Errorf("error validating the database arguments: %s", err)
-		}
-		defer db.Close() // nolint: errcheck
-		rows, err := db.Query("SELECT * from INFORMATION_SCHEMA.TABLES")
-		if err != nil {
-			return fmt.Errorf("error validating the database arguments: %s", err)
-		}
-		defer rows.Close() // nolint: errcheck
-		if !rows.Next() {
-			return fmt.Errorf(
-				`error could not select from INFORMATION_SCHEMA.TABLES'`,
-			)
-		}
-		if err := rows.Err(); err != nil {
-			return fmt.Errorf(
-				`error iterating rows`,
-			)
-		}
-		return nil
+	var connectionStrTemplate string
+	if credentials["sslRequired"].(bool) {
+		connectionStrTemplate =
+			"%s:%s@tcp(%s:3306)/%s?allowNativePasswords=true&tls=true"
+	} else {
+		connectionStrTemplate =
+			"%s:%s@tcp(%s:3306)/%s?allowNativePasswords=true"
 	}
+
+	db, err := sql.Open("mysql", fmt.Sprintf(
+		connectionStrTemplate,
+		credentials["username"].(string),
+		credentials["password"].(string),
+		credentials["host"].(string),
+		credentials["database"].(string),
+	))
+	if err != nil {
+		return fmt.Errorf("error validating the database arguments: %s", err)
+	}
+	defer db.Close() // nolint: errcheck
+	rows, err := db.Query("SELECT * from INFORMATION_SCHEMA.TABLES")
+	if err != nil {
+		return fmt.Errorf("error validating the database arguments: %s", err)
+	}
+	defer rows.Close() // nolint: errcheck
+	if !rows.Next() {
+		return fmt.Errorf(
+			`error could not select from INFORMATION_SCHEMA.TABLES'`,
+		)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf(
+			`error iterating rows`,
+		)
+	}
+	return nil
 }

--- a/tests/lifecycle/postgresql_cases_test.go
+++ b/tests/lifecycle/postgresql_cases_test.go
@@ -6,152 +6,111 @@ import (
 	"database/sql"
 	"fmt"
 
-	postgresSDK "github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-04-30-preview/postgresql" // nolint: lll
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
-	"github.com/Azure/open-service-broker-azure/pkg/services/postgresql"
 	_ "github.com/lib/pq" // Postgres SQL driver
 )
 
-func getPostgresqlCases(
-	azureEnvironment azure.Environment,
-	subscriptionID string,
-	authorizer autorest.Authorizer,
-	armDeployer arm.Deployer,
-) ([]serviceLifecycleTestCase, error) {
-	checkNameAvailabilityClient :=
-		postgresSDK.NewCheckNameAvailabilityClientWithBaseURI(
-			azureEnvironment.ResourceManagerEndpoint,
-			subscriptionID,
-		)
-	checkNameAvailabilityClient.Authorizer = authorizer
-	serversClient := postgresSDK.NewServersClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	serversClient.Authorizer = authorizer
-
-	databasesClient := postgresSDK.NewDatabasesClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	databasesClient.Authorizer = authorizer
-
-	module := postgresql.New(
-		armDeployer,
-		checkNameAvailabilityClient,
-		serversClient,
-		databasesClient,
-	)
-
-	return []serviceLifecycleTestCase{
-		{
-			module:          module,
-			serviceID:       "b43b4bba-5741-4d98-a10b-17dc5cee0175",
-			planID:          "b2ed210f-6a10-4593-a6c4-964e6b6fad62",
-			description:     "all-in-one",
-			location:        "southcentralus",
-			testCredentials: testPostgreSQLCreds(),
-			provisioningParameters: service.CombinedProvisioningParameters{
-				"firewallRules": []map[string]string{
-					{
-						"name":           "AllowSome",
-						"startIPAddress": "0.0.0.0",
-						"endIPAddress":   "35.0.0.0",
-					},
-					{
-						"name":           "AllowMore",
-						"startIPAddress": "35.0.0.1",
-						"endIPAddress":   "255.255.255.255",
-					},
+var postgresqlTestCases = []serviceLifecycleTestCase{
+	{
+		group:           "postgresql",
+		name:            "all-in-one",
+		serviceID:       "b43b4bba-5741-4d98-a10b-17dc5cee0175",
+		planID:          "b2ed210f-6a10-4593-a6c4-964e6b6fad62",
+		location:        "southcentralus",
+		testCredentials: testPostgreSQLCreds,
+		provisioningParameters: service.CombinedProvisioningParameters{
+			"firewallRules": []map[string]string{
+				{
+					"name":           "AllowSome",
+					"startIPAddress": "0.0.0.0",
+					"endIPAddress":   "35.0.0.0",
 				},
-				"sslEnforcement": "disabled",
-				"extensions": []string{
-					"uuid-ossp",
-					"postgis",
+				{
+					"name":           "AllowMore",
+					"startIPAddress": "35.0.0.1",
+					"endIPAddress":   "255.255.255.255",
 				},
 			},
-			bindingParameters: nil,
+			"sslEnforcement": "disabled",
+			"extensions": []string{
+				"uuid-ossp",
+				"postgis",
+			},
 		},
-		{
-			module:      module,
-			serviceID:   "d3f74b44-79bc-4d1e-bf7d-c247c2b851f9",
-			planID:      "bf389028-8dcc-433a-ab6f-0ee9b8db142f",
-			description: "dbms-only",
-			location:    "eastus",
-			provisioningParameters: service.CombinedProvisioningParameters{
-				"firewallRules": []map[string]string{
-					{
-						"name":           "AllowAll",
-						"startIPAddress": "0.0.0.0",
-						"endIPAddress":   "255.255.255.255",
-					},
+	},
+	{
+		group:     "postgresql",
+		name:      "dbms-only",
+		serviceID: "d3f74b44-79bc-4d1e-bf7d-c247c2b851f9",
+		planID:    "bf389028-8dcc-433a-ab6f-0ee9b8db142f",
+		location:  "eastus",
+		provisioningParameters: service.CombinedProvisioningParameters{
+			"firewallRules": []map[string]string{
+				{
+					"name":           "AllowAll",
+					"startIPAddress": "0.0.0.0",
+					"endIPAddress":   "255.255.255.255",
 				},
 			},
-			childTestCases: []*serviceLifecycleTestCase{
-				{ // database only scenario
-					module:            module,
-					description:       "database-on-existing-server",
-					serviceID:         "25434f16-d762-41c7-bbdd-8045d7f74ca6",
-					planID:            "df6f5ef1-e602-406b-ba73-09c107d1e31b",
-					location:          "", // This is actually irrelevant for this test
-					bindingParameters: nil,
-					testCredentials:   testPostgreSQLCreds(),
-					provisioningParameters: service.CombinedProvisioningParameters{
-						"extensions": []string{
-							"uuid-ossp",
-							"postgis",
-						},
+		},
+		childTestCases: []*serviceLifecycleTestCase{
+			{ // database only scenario
+				group:           "postgresql",
+				name:            "database-only",
+				serviceID:       "25434f16-d762-41c7-bbdd-8045d7f74ca6",
+				planID:          "df6f5ef1-e602-406b-ba73-09c107d1e31b",
+				location:        "", // This is actually irrelevant for this test
+				testCredentials: testPostgreSQLCreds,
+				provisioningParameters: service.CombinedProvisioningParameters{
+					"extensions": []string{
+						"uuid-ossp",
+						"postgis",
 					},
 				},
 			},
 		},
-	}, nil
+	},
 }
 
-func testPostgreSQLCreds() func(credentials map[string]interface{}) error {
-	return func(credentials map[string]interface{}) error {
-		var connectionStrTemplate string
-		if credentials["sslRequired"].(bool) {
-			connectionStrTemplate =
-				"postgres://%s:%s@%s/%s?sslmode=require"
-		} else {
-			connectionStrTemplate = "postgres://%s:%s@%s/%s"
-		}
-		db, err := sql.Open("postgres", fmt.Sprintf(
-			connectionStrTemplate,
-			credentials["username"].(string),
-			credentials["password"].(string),
-			credentials["host"].(string),
-			credentials["database"].(string),
-		))
+func testPostgreSQLCreds(credentials map[string]interface{}) error {
+	var connectionStrTemplate string
+	if credentials["sslRequired"].(bool) {
+		connectionStrTemplate =
+			"postgres://%s:%s@%s/%s?sslmode=require"
+	} else {
+		connectionStrTemplate = "postgres://%s:%s@%s/%s"
+	}
+	db, err := sql.Open("postgres", fmt.Sprintf(
+		connectionStrTemplate,
+		credentials["username"].(string),
+		credentials["password"].(string),
+		credentials["host"].(string),
+		credentials["database"].(string),
+	))
 
-		if err != nil {
-			return fmt.Errorf("error validating the database arguments: %s", err)
-		}
-		defer db.Close() // nolint: errcheck
-		rows, err := db.Query(`
+	if err != nil {
+		return fmt.Errorf("error validating the database arguments: %s", err)
+	}
+	defer db.Close() // nolint: errcheck
+	rows, err := db.Query(`
 			SELECT * from pg_catalog.pg_tables
 			WHERE
 			schemaname != 'pg_catalog'
 			AND schemaname != 'information_schema'
 			`)
-		if err != nil {
-			return fmt.Errorf("error validating the database arguments: %s", err)
-		}
-		defer rows.Close() // nolint: errcheck
-		if !rows.Next() {
-			return fmt.Errorf(
-				`error could not select from pg_catalog'`,
-			)
-		}
-		if err := rows.Err(); err != nil {
-			return fmt.Errorf(
-				`error iterating rows`,
-			)
-		}
-		return nil
+	if err != nil {
+		return fmt.Errorf("error validating the database arguments: %s", err)
 	}
+	defer rows.Close() // nolint: errcheck
+	if !rows.Next() {
+		return fmt.Errorf(
+			`error could not select from pg_catalog'`,
+		)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf(
+			`error iterating rows`,
+		)
+	}
+	return nil
 }

--- a/tests/lifecycle/rediscache_cases_test.go
+++ b/tests/lifecycle/rediscache_cases_test.go
@@ -2,31 +2,12 @@
 
 package lifecycle
 
-import (
-	redisSDK "github.com/Azure/azure-sdk-for-go/services/redis/mgmt/2017-10-01/redis" // nolint: lll
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
-	"github.com/Azure/open-service-broker-azure/pkg/services/rediscache"
-)
-
-func getRediscacheCases(
-	azureEnvironment azure.Environment,
-	subscriptionID string,
-	authorizer autorest.Authorizer,
-	armDeployer arm.Deployer,
-) ([]serviceLifecycleTestCase, error) {
-	client := redisSDK.NewClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	client.Authorizer = authorizer
-	return []serviceLifecycleTestCase{
-		{
-			module:    rediscache.New(armDeployer, client),
-			serviceID: "0346088a-d4b2-4478-aa32-f18e295ec1d9",
-			planID:    "362b3d1b-5b57-4289-80ad-4a15a760c29c",
-			location:  "southcentralus",
-		},
-	}, nil
+var rediscacheTestCases = []serviceLifecycleTestCase{
+	{
+		group:     "rediscache",
+		name:      "rediscache",
+		serviceID: "0346088a-d4b2-4478-aa32-f18e295ec1d9",
+		planID:    "362b3d1b-5b57-4289-80ad-4a15a760c29c",
+		location:  "southcentralus",
+	},
 }

--- a/tests/lifecycle/search_cases_test.go
+++ b/tests/lifecycle/search_cases_test.go
@@ -2,31 +2,12 @@
 
 package lifecycle
 
-import (
-	searchSDK "github.com/Azure/azure-sdk-for-go/services/search/mgmt/2015-08-19/search" // nolint: lll
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
-	"github.com/Azure/open-service-broker-azure/pkg/services/search"
-)
-
-func getSearchCases(
-	azureEnvironment azure.Environment,
-	subscriptionID string,
-	authorizer autorest.Authorizer,
-	armDeployer arm.Deployer,
-) ([]serviceLifecycleTestCase, error) {
-	servicesClient := searchSDK.NewServicesClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	servicesClient.Authorizer = authorizer
-	return []serviceLifecycleTestCase{
-		{
-			module:    search.New(armDeployer, servicesClient),
-			serviceID: "c54902aa-3027-4c5c-8e96-5b3d3b452f7f",
-			planID:    "35bd6e80-5ff5-487e-be0e-338aee9321e4",
-			location:  "southcentralus",
-		},
-	}, nil
+var searchTestCases = []serviceLifecycleTestCase{
+	{
+		group:     "search",
+		name:      "search",
+		serviceID: "c54902aa-3027-4c5c-8e96-5b3d3b452f7f",
+		planID:    "35bd6e80-5ff5-487e-be0e-338aee9321e4",
+		location:  "southcentralus",
+	},
 }

--- a/tests/lifecycle/servicebus_cases_test.go
+++ b/tests/lifecycle/servicebus_cases_test.go
@@ -2,31 +2,12 @@
 
 package lifecycle
 
-import (
-	servicebusSDK "github.com/Azure/azure-sdk-for-go/services/servicebus/mgmt/2017-04-01/servicebus" // nolint: lll
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
-	"github.com/Azure/open-service-broker-azure/pkg/services/servicebus"
-)
-
-func getServicebusCases(
-	azureEnvironment azure.Environment,
-	subscriptionID string,
-	authorizer autorest.Authorizer,
-	armDeployer arm.Deployer,
-) ([]serviceLifecycleTestCase, error) {
-	namespacesClient := servicebusSDK.NewNamespacesClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	namespacesClient.Authorizer = authorizer
-	return []serviceLifecycleTestCase{
-		{
-			module:    servicebus.New(armDeployer, namespacesClient),
-			serviceID: "6dc44338-2f13-4bc5-9247-5b1b3c5462d3",
-			planID:    "d06817b1-87ea-4320-8942-14b1d060206a",
-			location:  "southcentralus",
-		},
-	}, nil
+var servicebusTestCases = []serviceLifecycleTestCase{
+	{
+		group:     "servicebus",
+		name:      "servicebus",
+		serviceID: "6dc44338-2f13-4bc5-9247-5b1b3c5462d3",
+		planID:    "d06817b1-87ea-4320-8942-14b1d060206a",
+		location:  "southcentralus",
+	},
 }

--- a/tests/lifecycle/storage_cases_test.go
+++ b/tests/lifecycle/storage_cases_test.go
@@ -2,47 +2,26 @@
 
 package lifecycle
 
-import (
-	storageSDK "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-10-01/storage" // nolint: lll
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
-	"github.com/Azure/open-service-broker-azure/pkg/services/storage"
-)
-
-func getStorageCases(
-	azureEnvironment azure.Environment,
-	subscriptionID string,
-	authorizer autorest.Authorizer,
-	armDeployer arm.Deployer,
-) ([]serviceLifecycleTestCase, error) {
-	accountsClient := storageSDK.NewAccountsClientWithBaseURI(
-		azureEnvironment.ResourceManagerEndpoint,
-		subscriptionID,
-	)
-	accountsClient.Authorizer = authorizer
-	module := storage.New(armDeployer, accountsClient)
-	return []serviceLifecycleTestCase{
-		{ // General Purpose Storage Account
-			module:      module,
-			description: "general purpose storage account",
-			serviceID:   "2e2fc314-37b6-4587-8127-8f9ee8b33fea",
-			planID:      "6ddf6b41-fb60-4b70-af99-8ecc4896b3cf",
-			location:    "southcentralus",
-		},
-		{ // Blob Storage Account
-			module:      module,
-			description: "blob storage account",
-			serviceID:   "2e2fc314-37b6-4587-8127-8f9ee8b33fea",
-			planID:      "800a17e1-f20a-463d-a290-20516052f647",
-			location:    "southcentralus",
-		},
-		{ // Blob Storage Account + Blob Container
-			module:      module,
-			description: "blob storage account with a blob container",
-			serviceID:   "2e2fc314-37b6-4587-8127-8f9ee8b33fea",
-			planID:      "189d3b8f-8307-4b3f-8c74-03d069237f70",
-			location:    "southcentralus",
-		},
-	}, nil
+var storageTestCases = []serviceLifecycleTestCase{
+	{ // General Purpose Storage Account
+		group:     "storage",
+		name:      "general-purpose-account",
+		serviceID: "2e2fc314-37b6-4587-8127-8f9ee8b33fea",
+		planID:    "6ddf6b41-fb60-4b70-af99-8ecc4896b3cf",
+		location:  "southcentralus",
+	},
+	{ // Blob Storage Account
+		group:     "storage",
+		name:      "blob-account",
+		serviceID: "2e2fc314-37b6-4587-8127-8f9ee8b33fea",
+		planID:    "800a17e1-f20a-463d-a290-20516052f647",
+		location:  "southcentralus",
+	},
+	{ // Blob Storage Account + Blob Container
+		group:     "storage",
+		name:      "blob-account-with-container",
+		serviceID: "2e2fc314-37b6-4587-8127-8f9ee8b33fea",
+		planID:    "189d3b8f-8307-4b3f-8c74-03d069237f70",
+		location:  "southcentralus",
+	},
 }

--- a/tests/lifecycle/test_cases_test.go
+++ b/tests/lifecycle/test_cases_test.go
@@ -6,85 +6,27 @@ import (
 	"log"
 	"os"
 	"strings"
-	"time"
-
-	resourcesSDK "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources" // nolint: lll
-	"github.com/Azure/go-autorest/autorest"
-	azureSDK "github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure"
-	"github.com/Azure/open-service-broker-azure/pkg/azure/arm"
 )
 
 func getTestCases() ([]serviceLifecycleTestCase, error) {
-	azureConfig, err := azure.GetConfigFromEnvironment()
-	if err != nil {
-		return nil, err
-	}
+	testCases := rediscacheTestCases
+	testCases = append(testCases, aciTestCases...)
+	testCases = append(testCases, cosmosdbTestCases...)
+	testCases = append(testCases, eventhubsTestCases...)
+	testCases = append(testCases, keyvaultTestCases...)
+	testCases = append(testCases, mssqlTestCases...)
+	testCases = append(testCases, mysqlTestCases...)
+	testCases = append(testCases, postgresqlTestCases...)
+	testCases = append(testCases, searchTestCases...)
+	testCases = append(testCases, servicebusTestCases...)
+	testCases = append(testCases, storageTestCases...)
 
-	authorizer, err := azure.GetBearerTokenAuthorizer(
-		azureConfig.Environment,
-		azureConfig.TenantID,
-		azureConfig.ClientID,
-		azureConfig.ClientSecret,
-	)
-	if err != nil {
-		return nil, err
-	}
+	testCases = filter(testCases, getTestFilters())
 
-	resourceGroupsClient := resourcesSDK.NewGroupsClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
-	)
-	resourceGroupsClient.Authorizer = authorizer
-	resourceDeploymentsClient := resourcesSDK.NewDeploymentsClientWithBaseURI(
-		azureConfig.Environment.ResourceManagerEndpoint,
-		azureConfig.SubscriptionID,
-	)
-	resourceDeploymentsClient.Authorizer = authorizer
-	resourceDeploymentsClient.PollingDuration = time.Minute * 30
-	armDeployer := arm.NewDeployer(
-		resourceGroupsClient,
-		resourceDeploymentsClient,
-	)
-
-	testCases := []serviceLifecycleTestCase{}
-
-	getTestCaseFuncs := []func(
-		azureEnvironment azureSDK.Environment,
-		subscriptionID string,
-		authorizer autorest.Authorizer,
-		armDeployer arm.Deployer,
-	) ([]serviceLifecycleTestCase, error){
-		getRediscacheCases,
-		getACICases,
-		getCosmosdbCases,
-		getEventhubCases,
-		getKeyvaultCases,
-		getMssqlCases,
-		getMysqlCases,
-		getPostgresqlCases,
-		getSearchCases,
-		getServicebusCases,
-		getStorageCases,
-	}
-
-	testFilters := getTestFilters()
-
-	for _, getTestCaseFunc := range getTestCaseFuncs {
-		if tcs, err := getTestCaseFunc(
-			azureConfig.Environment,
-			azureConfig.SubscriptionID,
-			authorizer,
-			armDeployer,
-		); err == nil {
-			testCases = filter(append(testCases, tcs...), testFilters)
-		} else {
-			return nil, err
-		}
-	}
 	if len(testCases) == 0 {
 		log.Print("No test cases selected. Please check TEST_MODULES variable.")
 	}
+
 	return testCases, nil
 }
 
@@ -98,10 +40,10 @@ func filter(
 	}
 
 	// If filters is not empty, see if the testcase's module name is in the filter
-	//map
+	// map
 	filtered := testCases[:0]
 	for _, testCase := range testCases {
-		_, ok := filters[testCase.module.GetName()]
+		_, ok := filters[testCase.group]
 		if ok {
 			filtered = append(filtered, testCase)
 		}


### PR DESCRIPTION
I was starting to copy bits of the lifecycle tests to form the basis of some new e2e tests when I saw some easy cleanup to do.

Highlights:

- Instantiate the modules and catalog all in one place-- same as what the broker itself does on startup-- thus easier to understand
- Lifecycle tests cases are now _just_ data. They don't contain a reference to the module they test. The test framework simply finds the right service manager for each test case by looking it up in the catalog.
- Names of test cases are simplified.
- Functions for testing bindings/credentials eliminate a bit of unnecessary indirection. (We used to have a function return a binding/credential test function. Not sure why we did it that way, but it's not necessary.)

The biggest plus to this all, however, is that these changes will make the lifecycle tests look more like the e2e tests I'm pr'ing shortly. This will reduce the cognitive load required to understand _both_ test suites.