### PR TITLE
add chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,19 @@ jobs:
             go install
             gometalinter --install
       - run:
-          name: Run Lint
+          name: Lint Go Code
           command: make lint
+  lint-chart:
+    docker:
+      - image: quay.io/deis/helm-chart-publishing-tools:v0.1.0
+    environment:
+      SKIP_DOCKER: true
+    working_directory: /go/src/github.com/Azure/open-service-broker-azure
+    steps:
+      - checkout
+      - run:
+          name: Run Lint Helm Chart
+          command: make lint-chart
   verify-vendored-code:
     docker:
       - image: quay.io/deis/lightweight-docker-go:v0.2.0
@@ -143,6 +154,17 @@ jobs:
       - run:
           name: Publish Release Images to Docker Hub
           command: REL_VERSION="${CIRCLE_TAG}" make push-release
+  publish-chart:
+    docker:
+      - image: quay.io/deis/helm-chart-publishing-tools:v0.1.0
+    environment:
+      SKIP_DOCKER: true
+    working_directory: /go/src/github.com/Azure/open-service-broker-azure
+    steps:
+      - checkout
+      - run:
+          name: Publish Helm Chart
+          command: make publish-chart
 workflows:
   version: 2
   build-and-test-pr:
@@ -158,6 +180,12 @@ workflows:
           filters:
             branches:
               ignore: master
+      - lint-chart:
+          requires:
+            - hold
+          filters:
+            branches:
+              ignore: master
       - verify-vendored-code:
           requires:
             - hold
@@ -186,6 +214,7 @@ workflows:
           requires:
             - hold
             - lint
+            - lint-chart
             - verify-vendored-code
             - test-unit
             - test-api-compliance
@@ -199,6 +228,10 @@ workflows:
           filters:
             branches:
               only: master
+      - lint-chart:
+          filters:
+            branches:
+              only: master
       - verify-vendored-code:
           filters:
             branches:
@@ -218,6 +251,7 @@ workflows:
       - test-service-lifecycles:
           requires:
             - lint
+            - lint-chart
             - verify-vendored-code
             - test-unit
             - test-api-compliance
@@ -228,6 +262,7 @@ workflows:
       - publish-rc-images:
           requires:
             - lint
+            - lint-chart
             - verify-vendored-code
             - test-unit
             - test-api-compliance
@@ -239,6 +274,14 @@ workflows:
   release:
     jobs:
       - publish-release-images:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(\-.+)?/
+      - publish-chart:
+          requires:
+            - publish-release-images
           filters:
             branches:
               ignore: /.*/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 bin/
 _vendor-*/
 vendor.orig/
+contrib/k8s/charts/repo/
+contrib/k8s/charts/open-service-broker-azure/charts/

--- a/contrib/k8s/charts/open-service-broker-azure/.helmignore
+++ b/contrib/k8s/charts/open-service-broker-azure/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/contrib/k8s/charts/open-service-broker-azure/Chart.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+description: A Helm chart for Open Service Broker For Azure
+name: open-service-broker-azure
+version: 0.0.1
+appVersion: 0.0.1
+keywords:
+  - azure
+  - services
+  - service broker
+home: https://github.com/azure/open-service-broker-azure
+sources:
+  - https://github.com/azure/open-service-broker-azure
+  - https://hub.docker.com/r/microsoft/azure-service-broker/
+maintainers:
+  - name: Kent Rancourt
+    email: kent.rancourt@microsoft.com
+  - name: Jeremy Rickard
+    email: jeremy.rickard@microsoft.com
+tillerVersion: ">=2.7.0-rc1"

--- a/contrib/k8s/charts/open-service-broker-azure/README.md
+++ b/contrib/k8s/charts/open-service-broker-azure/README.md
@@ -1,0 +1,136 @@
+# Open Service Broker for Azure
+
+[Open Service Broker for Azure](https://github.com/Azure/open-service-broker-azure) is the
+open source, [Open Service Broker](https://www.openservicebrokerapi.org/)
+compatible API server that provisions managed services in the Microsoft
+Azure public cloud.
+
+This chart bootstraps Open Service Broker for Azure in your Kubernetes cluster.
+
+## Prerequisites
+
+- [Kubernetes](https://kubernetes.io/) 1.7+ with RBAC enabled
+- The
+  [Kubernetes Service Catalog](https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/install.md)
+  software has been installed
+- An [Azure subscription](https://azure.microsoft.com/en-us/free/)
+- The Azure CLI: You can
+[install it locally](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+or use it in the
+[Azure Cloud Shell](https://docs.microsoft.com/en-us/azure/cloud-shell/overview?view=azure-cli-latest)
+- A _service principal_ with the `Contributor` role on your Azure subscription
+
+## Obtain Your Subscription ID
+
+```console
+$ export AZURE_SUBSCRIPTION_ID=$(az account show --query id | sed s/\"//g)
+```
+
+## Creating a Service Principal
+  
+```console
+$ az ad sp create-for-rbac
+```
+
+The new service principal will be assigned, by default, to the `Contributor`
+role. The output of the command above will be similar to the following:
+
+```console
+{
+  "appId": "redacted",
+  "displayName": "azure-cli-xxxxxx",
+  "name": "http://azure-cli-xxxxxx",
+  "password": "redacted",
+  "tenant": "redacted"
+}
+```
+
+For convenience in subsequent steps, we will export several of the fields above
+as environment variables:
+
+```console
+$ export AZURE_TENANT_ID=<tenant>
+$ export AZURE_CLIENT_ID=<appId>
+$ export AZURE_CLIENT_SECRET=<password>
+```
+
+## Installing the Chart
+
+Installation of this chart is simple. First, ensure that you've [added the
+`azure` repository](../README.md#installing-charts). Then, install from the
+`azure` repo:
+
+```console
+$ helm install azure/open-service-broker-azure --name osba --namespace osba \
+  --set azure.subscriptionId=$AZURE_SUBSCRIPTION_ID \
+  --set azure.tenantId=$AZURE_TENANT_ID \
+  --set azure.clientId=$AZURE_CLIENT_ID \
+  --set azure.clientSecret=$AZURE_CLIENT_SECRET
+```
+
+If you'd like to customize the installation, please see the 
+[configuration](#configuration) section to see options that can be
+configured during installation.
+
+To verify the service broker has been deployed and show installed service classes and plans:
+
+```console
+$ kubectl get clusterservicebroker -o yaml
+
+$ kubectl get clusterserviceclasses -o=custom-columns=NAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName
+
+$ kubectl get clusterserviceplans -o=custom-columns=NAME:.metadata.name,EXTERNAL\ NAME:.spec.externalName,SERVICE\ CLASS:.spec.clusterServiceClassRef.name --sort-by=.spec.clusterServiceClassRef.name
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `osba` deployment:
+
+```console
+$ helm delete osba --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the Azure Service
+Broker chart and their default values.
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `image.repository` | Docker image location, _without_ the tag. | `"microsoft/azure-service-broker"` |
+| `image.tag` | Tag / version of the Docker image. | `"v0.4.0-alpha"` |
+| `image.pullPolicy` | `"IfNotPresent"`, `"Always"`, or `"Never"`; When launching a pod, this option indicates when to pull the OSBA Docker image. | `"IfNotPresent"` |
+| `registerBroker` | Whether to register this broker with the Kubernetes Service Catalog. If true, the Kubernetes Service Catalog must already be installed on the cluster. Marking this option false is useful for scenarios wherein one wishes to host the broker in a separate cluster than the Service Catalog (or other client) that will access it. | `true` |
+| `service.type` | Type of service; valid values are `"ClusterIP"`, `"LoadBalancer"`, and `"NodePort"`. `"ClusterIP"` is sufficient in the average case where OSBA only receives traffic from within the cluster-- e.g. from Kubernetes Service Catalog. | `"ClusterIP"` |
+| `service.nodePort.port` | _If and only if_ `service.type` is set to `"NodePort"`, `service.nodePort.port` indicates the port this service should bind to on each Kubernetes node. | `30080` |
+| `azure.environment` | Indicates which Azure public cloud to use. Valid values are `"AzureCloud"` and `"AzureChinaCloud"`. | `"AzureCloud"` |
+| `azure.subscriptionId` | Identifies the Azure subscription into which OSBA will provision services. | none |
+| `azure.tenantId` | Identifies the Azure Active Directory to which the _service principal_ used by OSBA to access the Azure subscription belongs. | none |
+| `azure.clientId` | Identifies the _service principal_ used by OSBA to access the Azure subscription. | none |
+| `azure.clientSecret` | Key/password for the _service principal_ used by OSBA to access the Azure subscription. | none |
+| `basicAuth.username` | Specifies the basic auth username that clients (e.g. the Kubernetes Service Catalog) must use when connecting to OSBA. | `"username"`; __Do not use this default value in production!__ |
+| `basicAuth.password` | Specifies the basic auth password that clients (e.g. the Kubernetes Service Catalog) must use when connecting to OSBA. | `"password"`; __Do not use this default value in production!__ |
+| `encryptionKey` | Specifies the key used by OSBA for applying AES-256 encryption to sensitive (or potentially sensitive) data. | `"This is a key that is 256 bits!!"`; __Do not use this default value in production!__ |
+| `modules.minStability` | Specifies the minimum level of stability an OSBA module must meet for the services and plans it provides to be included in OSBA's catalog of offerings. Valid values are `"ALPHA"`, `"BETA"`, and `"STABLE"`. | `"ALPHA"`; __Only use `"STABLE"` modules in production!__ |
+| `redis.embedded` | OSBA uses Redis for data persistence and as a message queue. This option indicates whether an on-cluster Redis deployment should be included when installing this chart. If set to `false`, connection details for a remote Redis cache must be provided. | `true`; __Do not use the embedded Redis cache in production!__ |
+| `redis.host` | _If and only if_ `redis.embedded` is `false`, this option specifies the location of the remote Redis cache. | none |
+| `redis.port` | _If and only if_ `redis.embedded` is `false`, this option specifies the port to connect to on the remote Redis host. | `6380` |
+| `redis.redisPassword` | Specifies the Redis password. If `redis.embedded` is `true`, this option sets the password on the Redis cache itself _and_ provides it to OSBA. If `redis.embedded` is `false`, this option only provides the password to OSBA. In that case, the value of this option must be the correct password for the remote Redis cache. | `"password"`; __Do not use this default value in production!__ |
+| `redis.enableTls` | _If and only if_ `redis.embedded` is `false`, this option specifies whether to use a secure connection to the remote Redis host. | `true` |
+
+Specify a value for each option using the `--set <key>=<value>` switch on the
+`helm install` command. That switch can be invoked multiple times to set
+multiple options.
+
+Alternatively, copy the charts default values to a file, edit the file to your
+liking, and reference that file in your `helm install` command:
+
+```console
+$ helm inspect values azure/open-service-broker-azure > values.yaml
+$ vim my-values.yaml
+$ helm install azure/open-service-broker-azure --name osba --namespace osba --values my-values.yaml
+```
+

--- a/contrib/k8s/charts/open-service-broker-azure/requirements.lock
+++ b/contrib/k8s/charts/open-service-broker-azure/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.10.0
+digest: sha256:9d6cb823d583ff265cc859ffd295a64cb8e5e22acb09ce7a266417b388d9f99c
+generated: 2018-03-02T08:22:27.387839687-07:00

--- a/contrib/k8s/charts/open-service-broker-azure/requirements.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: redis
+  version: 0.10.0
+  condition: redis.embedded
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/contrib/k8s/charts/open-service-broker-azure/templates/NOTES.txt
+++ b/contrib/k8s/charts/open-service-broker-azure/templates/NOTES.txt
@@ -1,0 +1,22 @@
+{{- if and (not .Values.registerBroker) (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
+{{- if eq .Values.service.type "LoadBalancer" }}
+1. To get Open Service Broker for Azure's load balancer IP/hostname:
+
+    NOTE: It may take a few minutes for this to become available.
+
+    You can watch the status by running:
+
+        $ kubectl get svc {{ template "fullname" . }} -n {{ .Release.Namespace }} -w
+
+    Once 'EXTERNAL-IP' is no longer '<pending>':
+
+        $ kubectl describe svc {{ template "fullname" . }} -n {{ .Release.Namespace }} | grep Ingress: | awk '{print $3}'
+{{ end }}
+{{- if eq .Values.service.type "NodePort" }}
+1. Open Service Broker for Azure's node port: {{ .Values.service.nodePort.port }}
+{{ end }}
+2. Credentials for connecting to the broker:
+
+    Username: {{ .Values.basicAuth.username }}
+    Password: {{ .Values.basicAuth.password }}
+{{- end }}

--- a/contrib/k8s/charts/open-service-broker-azure/templates/_helpers.tpl
+++ b/contrib/k8s/charts/open-service-broker-azure/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/contrib/k8s/charts/open-service-broker-azure/templates/auth-secret.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/templates/auth-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}-auth
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  username: {{ b64enc .Values.basicAuth.username }}
+  password: {{ b64enc .Values.basicAuth.password }}

--- a/contrib/k8s/charts/open-service-broker-azure/templates/broker.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/templates/broker.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.registerBroker }}
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ClusterServiceBroker
+metadata:
+  name: osba
+spec:
+  url: http://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  authInfo:
+    basic:
+      secretRef:
+        name: "{{ template "fullname" . }}-auth"
+        namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/contrib/k8s/charts/open-service-broker-azure/templates/deployment.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/templates/deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      containers:
+        - name: open-service-broker-azure
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: ENVIRONMENT
+            value: {{ .Values.azure.environment }}
+          - name: AZURE_SUBSCRIPTION_ID
+            value: {{ required "A value is required for azure.subscriptionId" .Values.azure.subscriptionId }}
+          - name: AZURE_TENANT_ID
+            value: {{ required "A value is required for azure.tenantId" .Values.azure.tenantId }}
+          - name: AZURE_CLIENT_ID
+            value: {{ required "A value is required for azure.clientId" .Values.azure.clientId }}
+          - name: AZURE_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}
+                key: azure-client-secret
+          - name: AZURE_DEFAULT_LOCATION
+            value: {{ .Values.azure.defaultLocation }}
+          - name: REDIS_HOST
+            {{- if .Values.redis.embedded }}
+            value: {{ .Release.Name }}-redis
+            {{- else }}
+            value: {{ required "A value is required for redis.host" .Values.redis.host }}
+          - name: REDIS_PORT
+            value: {{ .Values.redis.port | quote }}
+          - name: REDIS_ENABLE_TLS
+            value: {{ .Values.redis.enableTls | quote }}
+            {{- end }}
+          - name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}
+                key: redis-password
+          - name: AES256_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}
+                key: encryption-key
+          - name: BASIC_AUTH_USERNAME
+            value: {{ .Values.basicAuth.username }}
+          - name: BASIC_AUTH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}
+                key: basic-auth-password
+          - name: MIN_STABILITY
+            value: {{ .Values.modules.minStability }}
+          ports:
+          - containerPort: 8080
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2

--- a/contrib/k8s/charts/open-service-broker-azure/templates/secret.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+stringData:
+  azure-client-secret: {{ required "A value is required for azure.clientSecret" .Values.azure.clientSecret }}
+  encryption-key: {{ .Values.encryptionKey }}
+  redis-password: {{ .Values.redis.redisPassword | quote }}
+  basic-auth-password: {{ .Values.basicAuth.password | quote }}
+  

--- a/contrib/k8s/charts/open-service-broker-azure/templates/service.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ template "fullname" . }}
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    {{- if eq .Values.service.type "NodePort" }}
+    nodePort: {{ .Values.service.nodePort.port }}
+    {{- end }}
+    targetPort: 8080

--- a/contrib/k8s/charts/open-service-broker-azure/values.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/values.yaml
@@ -1,0 +1,86 @@
+replicaCount: 1
+
+image:
+  ## Image location, NOT including the tag
+  repository: microsoft/azure-service-broker
+  ## Image tag
+  tag: v0.9.0-alpha
+  ## "IfNotPresent", "Always", or "Never"
+  pullPolicy: IfNotPresent
+
+## Whether to register this broker with the Kubernetes Service Catalog. If true,
+## the Kubernetes Service Catalog must already be installed on the cluster.
+## Marking this option false is useful for scenarios wherein one wishes to host
+## the broker in a separate cluster than the Service Catalog (or other client)
+## that will access it.
+registerBroker: true
+
+service:
+  ## Type of service; valid values are "ClusterIP", "LoadBalancer", and
+  ## "NodePort". "ClusterIP" is sufficient in the average case where a service
+  ## catalog installation in the same cluster is the only client that needs to
+  ## communicate with this broker. i.e. The broker does not need to receive
+  ## inbound requests from outside the cluster.
+  type: ClusterIP
+  ## Further configuration if service is of type "NodePort"
+  nodePort:
+    ## Available port in allowable range (e.g. 30000 - 32767 on minikube)
+    port: 30080
+
+azure:
+  ## Valid values are "AzureCloud" and "AzureChinaCloud"
+  environment: AzureCloud
+  ## Required; this is the identifier for the Azure account into which services
+  ## will be provisioned. BE AWARE THAT DOING SO WILL COST YOU MONEY!
+  subscriptionId: 
+  ## Required; this is the identifier of the Azure Service Directory that
+  ## contains the service principal the broker will use for interacting with
+  ## Azure.
+  tenantId: 
+  ## Required; this identifies the service principal. When viewed in Azure
+  ## Active Directory, this is also known as the Application ID.
+  clientId: 
+  ## Required
+  clientSecret: 
+  ## Optional; default Azure location for provisioning resources
+  defaultLocation: 
+
+## Basic auth credentials that can later be used to access this broker
+basicAuth:
+  ## DO NOT USE THIS DEFAULT VALUE IN PRODUCTION
+  username: username
+  ## DO NOT USE THIS DEFAULT VALUE IN PRODUCTION
+  password: password
+
+## A 256 bit key used for database encryption
+## NB: 32 ascii characters == 256 bits
+## DO NOT USE THIS DEFAULT VALUE IN PRODUCTION
+encryptionKey: This is a key that is 256 bits!!
+
+modules:
+  ## Minimum stability required for a module's services and plans to be listed
+  ## in the broker's catalog. For production, use STABLE only!
+  minStability: EXPERIMENTAL
+
+## Redis configuration 
+redis:
+  ## Should a containerized Redis server be included in the Helm release?
+  embedded: true
+
+  ## Required if not embedded
+  host: 
+
+  ## If not embedded, specifies the port for the client to connect to.
+  ## 6380 is the port often used for Redis secured using TLS.
+  port: 6380
+
+  ## If embedded, specifies the password the server will require AND the
+  ## password the client will use. If not embedded, this only specifies the
+  ## password the client will use. It must be the correct password for whatever
+  ## external Redis server it connects to.
+  ## DO NOT USE THIS DEFAULT VALUE IN PRODUCTION
+  redisPassword: password
+
+  ## If not emnedded, specifies whether to use a secure connection to the
+  ## remote Redis host
+  enableTls: true

--- a/tests/lifecycle/test_case_test.go
+++ b/tests/lifecycle/test_case_test.go
@@ -39,7 +39,7 @@ func (s serviceLifecycleTestCase) execute(
 	catalog service.Catalog,
 	resourceGroup string,
 ) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*20)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*40)
 	defer cancel()
 
 	name := s.getName()


### PR DESCRIPTION
This (re-)adds the Helm chart for OSBA to the repository, along with make targets, CI/CD machinery, etc. required for linting and publishing the chart.

This should be merged _after_ https://github.com/Azure/helm-charts/pull/124