### PR TITLE
fix chart publishing issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
       - checkout
       - run:
           name: Publish Helm Chart
-          command: make publish-chart
+          command: REL_VERSION="${CIRCLE_TAG}" make publish-chart
 workflows:
   version: 2
   build-and-test-pr:


### PR DESCRIPTION
There's no point letting CI run on this. This change is only applicable to the CD / release pipeline.