### PR TITLE
log version information sooner

### DIFF
--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -37,11 +37,19 @@ func main() {
 		FullTimestamp: true,
 	}
 	log.SetFormatter(formatter)
+	log.SetLevel(log.InfoLevel)
+
+	log.WithFields(
+		log.Fields{
+			"version": version.GetVersion(),
+			"commit":  version.GetCommit(),
+		},
+	).Info("Open Service Broker for Azure starting")
+
 	logConfig, err := brokerLog.GetConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.SetLevel(log.InfoLevel)
 	logLevel := logConfig.GetLevel()
 	log.WithField(
 		"logLevel",
@@ -62,13 +70,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	log.WithFields(
-		log.Fields{
-			"version": version.GetVersion(),
-			"commit":  version.GetCommit(),
-		},
-	).Info("Open Service Broker for Azure starting")
 
 	// Storage
 	storageConfig, err := storage.GetConfigFromEnvironment()


### PR DESCRIPTION
This prints version information sooner because, currently, there are significant opportunities for errors to occur (e.g. because of missing or invalid environment variable) _before_ version information is printed.

I'd like a guarantee that this information is visible regardless of whatever errors may occur.