### PR TITLE
Adding ability to specify cosmos consistency policy

### DIFF
--- a/contrib/k8s/examples/cosmosdb/cosmosdb-instance.yaml
+++ b/contrib/k8s/examples/cosmosdb/cosmosdb-instance.yaml
@@ -11,4 +11,4 @@ spec:
     location: eastus
     resourceGroup: demo
     consistencyPolicy:
-      defaultConsistencyLevel: Strong
+      defaultConsistencyLevel: Eventual

--- a/contrib/k8s/examples/cosmosdb/cosmosdb-instance.yaml
+++ b/contrib/k8s/examples/cosmosdb/cosmosdb-instance.yaml
@@ -10,3 +10,5 @@ spec:
   parameters:
     location: eastus
     resourceGroup: demo
+    consistencyPolicy:
+      defaultConsistencyLevel: Strong

--- a/docs/modules/cosmosdb.md
+++ b/docs/modules/cosmosdb.md
@@ -141,8 +141,9 @@ Provisions a new CosmosDB database account that can be accessed through any of t
 | `ipFilters.allowedIPRanges` | `array` | Values to include in IP Filter. Can be IP Address or CIDR range. | N | If not specified, no additional values will be included in filters. |
 | `consistencyPolicy` | `object` | The consistency policy for the Cosmos DB account. | N | |
 | `consistencyPolicy.defaultConsistencyLevel` | `string` | The default consistency level and configuration settings of the Cosmos DB account. - Eventual, Session, BoundedStaleness, Strong, ConsistentPrefix | Y | |
-| `consistencyPolicy.maxStalenessPrefix` | `integer` | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
-| `consistencyPolicy.maxIntervalInSeconds` | `integer` | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
+| `consistencyPolicy.boundedStaleness` | object | Settings for to determine staleness when used with `BoundedStaleness` consistency | Yes - If using `BoundedStaleness` consistency | | 
+| `consistencyPolicy.boundedStaleness.maxStalenessPrefix` | `integer` | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
+| `consistencyPolicy.boundedStaleness.maxIntervalInSeconds` | `integer` | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
 
 ##### Bind
 

--- a/docs/modules/cosmosdb.md
+++ b/docs/modules/cosmosdb.md
@@ -2,7 +2,6 @@
 
 _Note: This module is EXPERIMENTAL and future releases may break the API._
 
-
 ## Services & Plans
 
 ### Service: azure-cosmosdb-sql-account

--- a/docs/modules/cosmosdb.md
+++ b/docs/modules/cosmosdb.md
@@ -57,7 +57,7 @@ Does nothing.
   
 ##### Deprovision
 
-Deletes the CosmosDB database.
+Deletes the CosmosDB database account.
 
 ### Service: azure-cosmosdb-mongo-account
 
@@ -114,7 +114,7 @@ Does nothing.
 
 ##### Deprovision
 
-Deletes the CosmosDB database.
+Deletes the CosmosDB database account.
 
 ### Service: azure-cosmosdb-graph-account
 
@@ -169,7 +169,7 @@ Does nothing.
   
 ##### Deprovision
 
-Deletes the CosmosDB database.
+Deletes the CosmosDB database account.
 
 ### Service: azure-cosmosdb-table-account
 
@@ -223,4 +223,4 @@ Does nothing.
   
 ##### Deprovision
 
-Deletes the CosmosDB database.
+Deletes the CosmosDB database account.

--- a/docs/modules/cosmosdb.md
+++ b/docs/modules/cosmosdb.md
@@ -27,6 +27,10 @@ Provisions a new CosmosDB database account that can be accessed through any of t
 | `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account.Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowAccessFromPortal` | `string` | Specifies if the Azure Portal should be able to access the CosmosDB account. If `allowAccessFromAzure` is set to enabled, this value is ignored. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowedIPRanges` | `array` | Values to include in IP Filter. Can be IP Address or CIDR range. | N | If not specified, no additional values will be included in filters. |
+| `consistencyPolicy` | `object` | The consistency policy for the Cosmos DB account. | N | |
+| `consistencyPolicy.defaultConsistencyLevel` | `string` | The default consistency level and configuration settings of the Cosmos DB account. - Eventual, Session, BoundedStaleness, Strong, ConsistentPrefix | Y | |
+| `consistencyPolicy.maxStalenessPrefix` | `integer` | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
+| `consistencyPolicy.maxIntervalInSeconds` | `integer` | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
 
 ##### Bind
 
@@ -77,6 +81,10 @@ Provisions a new CosmosDB database account that can be accessed through the Mong
 | `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account.Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowAccessFromPortal` | `string` | Specifies if the Azure Portal should be able to access the CosmosDB account. If `allowAccessFromAzure` is set to enabled, this value is ignored. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowedIPRanges` | `array` | Values to include in IP Filter. Can be IP Address or CIDR range. | N | If not specified, no additional values will be included in filters. |
+| `consistencyPolicy` | `object` | The consistency policy for the Cosmos DB account. | N | |
+| `consistencyPolicy.defaultConsistencyLevel` | `string` | The default consistency level and configuration settings of the Cosmos DB account. - Eventual, Session, BoundedStaleness, Strong, ConsistentPrefix | Y | |
+| `consistencyPolicy.maxStalenessPrefix` | `integer` | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
+| `consistencyPolicy.maxIntervalInSeconds` | `integer` | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
 
 ##### Bind
 
@@ -129,6 +137,10 @@ Provisions a new CosmosDB database account that can be accessed through any of t
 | `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account.Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowAccessFromPortal` | `string` | Specifies if the Azure Portal should be able to access the CosmosDB account. If `allowAccessFromAzure` is set to enabled, this value is ignored. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowedIPRanges` | `array` | Values to include in IP Filter. Can be IP Address or CIDR range. | N | If not specified, no additional values will be included in filters. |
+| `consistencyPolicy` | `object` | The consistency policy for the Cosmos DB account. | N | |
+| `consistencyPolicy.defaultConsistencyLevel` | `string` | The default consistency level and configuration settings of the Cosmos DB account. - Eventual, Session, BoundedStaleness, Strong, ConsistentPrefix | Y | |
+| `consistencyPolicy.maxStalenessPrefix` | `integer` | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
+| `consistencyPolicy.maxIntervalInSeconds` | `integer` | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
 
 ##### Bind
 
@@ -179,6 +191,10 @@ Provisions a new CosmosDB database account that can be accessed through any of t
 | `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account.Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowAccessFromPortal` | `string` | Specifies if the Azure Portal should be able to access the CosmosDB account. If `allowAccessFromAzure` is set to enabled, this value is ignored. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowedIPRanges` | `array` | Values to include in IP Filter. Can be IP Address or CIDR range. | N | If not specified, no additional values will be included in filters. |
+| `consistencyPolicy` | `object` | The consistency policy for the Cosmos DB account. | N | |
+| `consistencyPolicy.defaultConsistencyLevel` | `string` | The default consistency level and configuration settings of the Cosmos DB account. - Eventual, Session, BoundedStaleness, Strong, ConsistentPrefix | Y | |
+| `consistencyPolicy.maxStalenessPrefix` | `integer` | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
+| `consistencyPolicy.maxIntervalInSeconds` | `integer` | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
 
 ##### Bind
 

--- a/docs/modules/cosmosdb.md
+++ b/docs/modules/cosmosdb.md
@@ -2,6 +2,7 @@
 
 _Note: This module is EXPERIMENTAL and future releases may break the API._
 
+
 ## Services & Plans
 
 ### Service: azure-cosmosdb-sql-account

--- a/docs/modules/cosmosdb.md
+++ b/docs/modules/cosmosdb.md
@@ -29,8 +29,9 @@ Provisions a new CosmosDB database account that can be accessed through any of t
 | `ipFilters.allowedIPRanges` | `array` | Values to include in IP Filter. Can be IP Address or CIDR range. | N | If not specified, no additional values will be included in filters. |
 | `consistencyPolicy` | `object` | The consistency policy for the Cosmos DB account. | N | |
 | `consistencyPolicy.defaultConsistencyLevel` | `string` | The default consistency level and configuration settings of the Cosmos DB account. - Eventual, Session, BoundedStaleness, Strong, ConsistentPrefix | Y | |
-| `consistencyPolicy.maxStalenessPrefix` | `integer` | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
-| `consistencyPolicy.maxIntervalInSeconds` | `integer` | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | N | |
+| `consistencyPolicy.boundedStaleness` | `object` | Specifies the settings when using BoundedStaleness consistency. | Y - When Using `BoundedStaleness` | |
+| `consistencyPolicy.maxStalenessPrefix` | `integer` | When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | Y | |
+| `consistencyPolicy.maxIntervalInSeconds` | `integer` | When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 5 - 86400. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'. | Y | |
 
 ##### Bind
 
@@ -105,6 +106,7 @@ Binding returns the following connection details and shared credentials:
 | `username` | `string` | The name of the database user. |
 | `password` | `string` | The password for the database user. |
 | `connectionstring` | `string` | The full connection string, which includes the host, port, username, and password. |
+| `uri` | `string` | URI encoded string that represents the connection information |
 
 ##### Unbind
 

--- a/pkg/service/schema.go
+++ b/pkg/service/schema.go
@@ -100,6 +100,19 @@ func (a *ArrayParameterSchema) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// NumericParameterSchema represents a numeric type, either
+// integers or floating point numbers, that can have an upper or lower bound.
+type NumericParameterSchema struct {
+	Type             string      `json:"type"`
+	Description      string      `json:"description,omitempty"`
+	Required         bool        `json:"-"`
+	Default          interface{} `json:"default,omitempty"`
+	Minimum          interface{} `json:"minimum,omitempty"`
+	ExclusiveMinimum bool        `json:"exclusiveMinimum,omitempty"`
+	Maximum          interface{} `json:"maximum,omitempty"`
+	ExclusiveMaximum bool        `json:"exclusiveMaximum,omitempty"`
+}
+
 // ParameterSchema defines an interface representing a given Parameter schema.
 // This could be a provision or binding parameter.
 type ParameterSchema interface {
@@ -115,9 +128,12 @@ func (o *ObjectParameterSchema) isRequired() bool {
 	return o.Required
 }
 
-// IsRequired returns true if the property is required
 func (a *ArrayParameterSchema) isRequired() bool {
 	return a.Required
+}
+
+func (n *NumericParameterSchema) isRequired() bool {
+	return n.Required
 }
 
 func (o *ObjectParameterSchema) setRequiredProperties() {
@@ -134,6 +150,10 @@ func (a *ArrayParameterSchema) setRequiredProperties() {
 
 // NOOP method to implement the interface
 func (s *SimpleParameterSchema) setRequiredProperties() {
+}
+
+// NOOP method to implement the interface
+func (n *NumericParameterSchema) setRequiredProperties() {
 }
 
 func (p *parametersSchema) addProperties(

--- a/pkg/services/cosmosdb/common-types.go
+++ b/pkg/services/cosmosdb/common-types.go
@@ -5,13 +5,20 @@ import (
 )
 
 type provisioningParameters struct {
-	IPFilterRules *ipFilterRule `json:"ipFilters"`
+	IPFilterRules     *ipFilterRule      `json:"ipFilters"`
+	ConsistencyPolicy *consistencyPolicy `json:"consistencyPolicy,omitempty"`
 }
 
 type ipFilterRule struct {
 	Filters     []string `json:"allowedIPRanges"`
 	AllowAzure  string   `json:"allowAccessFromAzure,omitempty"`
 	AllowPortal string   `json:"allowAccessFromPortal,omitempty"`
+}
+
+type consistencyPolicy struct {
+	DefaultConsistency string `json:"defaultConsistencyLevel,omitempty"`
+	MaxStaleness       *int   `json:"maxStalenessPrefix,omitempty"`
+	MaxInternal        *int   `json:"maxIntervalInSeconds,omitempty"`
 }
 
 type cosmosdbInstanceDetails struct {
@@ -86,6 +93,49 @@ func (
 					Type:        "string",
 					Description: "Must be a valid IP address or CIDR",
 				},
+			},
+		},
+	}
+	maxStalenessPrefixMin := 1
+	maxStalenessPrefixMax := 2147483647
+	maxIntervalInSecondsMin := 5
+	maxIntervalInSecondsMax := 86400
+
+	p["consistencyPolicy"] = &service.ObjectParameterSchema{
+		Description: "The consistency policy for the Cosmos DB account.",
+		Properties: map[string]service.ParameterSchema{
+			"defaultConsistencyLevel": &service.SimpleParameterSchema{
+				Type: "string",
+				Description: "The default consistency level and" +
+					" configuration settings of the Cosmos DB account.",
+				Required: true,
+				AllowedValues: []string{
+					"Eventual",
+					"Session",
+					"BoundedStaleness",
+					"Strong",
+					"ConsistentPrefix",
+				},
+			},
+			"maxStalenessPrefix": &service.NumericParameterSchema{
+				Type: "integer",
+				Description: "When used with the Bounded Staleness " +
+					"consistency level, this value represents the number of " +
+					"stale requests tolerated" +
+					"Required when defaultConsistencyPolicy is set to " +
+					" 'BoundedStaleness'.",
+				Minimum: maxStalenessPrefixMin,
+				Maximum: maxStalenessPrefixMax,
+			},
+			"maxIntervalInSeconds": &service.NumericParameterSchema{
+				Type: "integer",
+				Description: "When used with the Bounded Staleness " +
+					"consistency level, this value represents the time " +
+					"amount of staleness (in seconds) tolerated. " +
+					"Required when defaultConsistencyPolicy is set to " +
+					" 'BoundedStaleness'.",
+				Minimum: maxIntervalInSecondsMin,
+				Maximum: maxIntervalInSecondsMax,
 			},
 		},
 	}

--- a/pkg/services/cosmosdb/common-types.go
+++ b/pkg/services/cosmosdb/common-types.go
@@ -15,10 +15,14 @@ type ipFilterRule struct {
 	AllowPortal string   `json:"allowAccessFromPortal,omitempty"`
 }
 
+type boundedStaleness struct {
+	MaxStaleness *int `json:"maxStalenessPrefix,omitempty"`
+	MaxInternal  *int `json:"maxIntervalInSeconds,omitempty"`
+}
+
 type consistencyPolicy struct {
-	DefaultConsistency string `json:"defaultConsistencyLevel,omitempty"`
-	MaxStaleness       *int   `json:"maxStalenessPrefix,omitempty"`
-	MaxInternal        *int   `json:"maxIntervalInSeconds,omitempty"`
+	DefaultConsistency string            `json:"defaultConsistencyLevel,omitempty"`
+	BoundedStaleness   *boundedStaleness `json:"boundedStaleness,omitempty"`
 }
 
 type cosmosdbInstanceDetails struct {
@@ -117,25 +121,32 @@ func (
 					"ConsistentPrefix",
 				},
 			},
-			"maxStalenessPrefix": &service.NumericParameterSchema{
-				Type: "integer",
-				Description: "When used with the Bounded Staleness " +
-					"consistency level, this value represents the number of " +
-					"stale requests tolerated" +
-					"Required when defaultConsistencyPolicy is set to " +
-					" 'BoundedStaleness'.",
-				Minimum: maxStalenessPrefixMin,
-				Maximum: maxStalenessPrefixMax,
-			},
-			"maxIntervalInSeconds": &service.NumericParameterSchema{
-				Type: "integer",
-				Description: "When used with the Bounded Staleness " +
-					"consistency level, this value represents the time " +
-					"amount of staleness (in seconds) tolerated. " +
-					"Required when defaultConsistencyPolicy is set to " +
-					" 'BoundedStaleness'.",
-				Minimum: maxIntervalInSecondsMin,
-				Maximum: maxIntervalInSecondsMax,
+			"boundedStaleness": &service.ObjectParameterSchema{
+				Description: "The staleness settings when using " +
+					"BoundedStaleness consistency.  Required when " +
+					"using BoundedStaleness",
+				Properties: map[string]service.ParameterSchema{
+					"maxStalenessPrefix": &service.NumericParameterSchema{
+						Type: "integer",
+						Description: "When used with the Bounded Staleness " +
+							"consistency level, this value represents the number of " +
+							"stale requests tolerated" +
+							"Required when defaultConsistencyPolicy is set to " +
+							" 'BoundedStaleness'.",
+						Minimum: maxStalenessPrefixMin,
+						Maximum: maxStalenessPrefixMax,
+					},
+					"maxIntervalInSeconds": &service.NumericParameterSchema{
+						Type: "integer",
+						Description: "When used with the Bounded Staleness " +
+							"consistency level, this value represents the time " +
+							"amount of staleness (in seconds) tolerated. " +
+							"Required when defaultConsistencyPolicy is set to " +
+							" 'BoundedStaleness'.",
+						Minimum: maxIntervalInSecondsMin,
+						Maximum: maxIntervalInSecondsMax,
+					},
+				},
 			},
 		},
 	}

--- a/pkg/services/cosmosdb/common_arm_template.go
+++ b/pkg/services/cosmosdb/common_arm_template.go
@@ -21,6 +21,17 @@ var armTemplateBytes = []byte(`
 			"name": "{{ .name }}",
 			"location": "[parameters('location')]",
 			"properties": {
+				{{ if .consistencyPolicy }}
+				"consistencyPolicy" : {
+					"defaultConsistencyLevel" : "{{ .consistencyPolicy.defaultConsistencyLevel }}"
+					{{ if .consistencyPolicy.maxStalenessPrefix }}
+						,"maxStalenessPrefix": {{ .consistencyPolicy.maxStalenessPrefix }}
+					{{ end }}
+					{{ if .consistencyPolicy.maxIntervalInSeconds }}
+						,"maxIntervalInSeconds" : {{ .consistencyPolicy.maxIntervalInSeconds }}
+					{{ end }}
+				},
+				{{ end }}
 				"databaseAccountOfferType": "Standard",
 				{{ if .ipFilters }} 
 				"ipRangeFilter" : "{{ .ipFilters }}",

--- a/pkg/services/cosmosdb/common_arm_template.go
+++ b/pkg/services/cosmosdb/common_arm_template.go
@@ -24,11 +24,11 @@ var armTemplateBytes = []byte(`
 				{{ if .consistencyPolicy }}
 				"consistencyPolicy" : {
 					"defaultConsistencyLevel" : "{{ .consistencyPolicy.defaultConsistencyLevel }}"
-					{{ if .consistencyPolicy.maxStalenessPrefix }}
-						,"maxStalenessPrefix": {{ .consistencyPolicy.maxStalenessPrefix }}
+					{{ if .consistencyPolicy.boundedStaleness }}
+						,"maxStalenessPrefix": {{ .consistencyPolicy.boundedStaleness.maxStalenessPrefix }}
 					{{ end }}
 					{{ if .consistencyPolicy.maxIntervalInSeconds }}
-						,"maxIntervalInSeconds" : {{ .consistencyPolicy.maxIntervalInSeconds }}
+						,"maxIntervalInSeconds" : {{ .consistencyPolicy.boundedStaleness.maxIntervalInSeconds }}
 					{{ end }}
 				},
 				{{ end }}

--- a/tests/lifecycle/cosmosdb_cases_test.go
+++ b/tests/lifecycle/cosmosdb_cases_test.go
@@ -36,6 +36,11 @@ var cosmosdbTestCases = []serviceLifecycleTestCase{
 			"ipFilters": map[string]interface{}{
 				"allowedIPRanges": []string{"0.0.0.0/0"},
 			},
+			"consistencyPolicy": map[string]interface{}{
+				"defaultConsistencyLevel": "BoundedStaleness",
+				"maxStalenessPrefix":      10,
+				"maxIntervalInSeconds":    500,
+			},
 		},
 	},
 	{ // Table API

--- a/tests/lifecycle/cosmosdb_cases_test.go
+++ b/tests/lifecycle/cosmosdb_cases_test.go
@@ -38,8 +38,10 @@ var cosmosdbTestCases = []serviceLifecycleTestCase{
 			},
 			"consistencyPolicy": map[string]interface{}{
 				"defaultConsistencyLevel": "BoundedStaleness",
-				"maxStalenessPrefix":      10,
-				"maxIntervalInSeconds":    500,
+				"boundedStaleness": map[string]interface{}{
+					"maxStalenessPrefix":   10,
+					"maxIntervalInSeconds": 500,
+				},
 			},
 		},
 	},


### PR DESCRIPTION
This PR adds the ability to specify the consistency policy
for a CosmosDB database account. It also adds a new type
to the schemas code, a numeric type with an upper and lower range.

Closes: #327