### PR TITLE
fix chart release; also publish chart release candidates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
       - run:
           name: Publish Release Images to Docker Hub
           command: REL_VERSION="${CIRCLE_TAG}" make push-release
-  publish-chart:
+  publish-rc-chart:
     docker:
       - image: *chart-image
     environment:
@@ -189,7 +189,18 @@ jobs:
       - checkout
       - run:
           name: Publish Helm Chart
-          command: REL_VERSION="${CIRCLE_TAG}" make publish-chart
+          command: make publish-rc-chart
+  publish-release-chart:
+    docker:
+      - image: *chart-image
+    environment:
+      SKIP_DOCKER: true
+    working_directory: /go/src/github.com/Azure/open-service-broker-azure
+    steps:
+      - checkout
+      - run:
+          name: Publish Helm Chart
+          command: REL_VERSION="${CIRCLE_TAG}" make publish-release-chart
 
 base-pr-step: &base-pr-step
   filters:
@@ -291,13 +302,25 @@ workflows:
             - build
             - test-generate-pcf-tile
             - test-service-lifecycles
+      - publish-rc-chart:
+          <<: *base-master-step
+          requires:
+            - lint
+            - lint-chart
+            - verify-vendored-code
+            - test-unit
+            - test-api-compliance
+            - build
+            - test-generate-pcf-tile
+            - test-service-lifecycles
+            - publish-rc-images
   release:
     jobs:
       - generate-pcf-tile:
           <<: *base-release-step
       - publish-release-images:
           <<: *base-release-step
-      - publish-chart:
+      - publish-release-chart:
           <<: *base-release-step
           requires:
             - publish-release-images

--- a/Makefile
+++ b/Makefile
@@ -317,18 +317,42 @@ else
 	$(DOCKER_HELM_CMD) $(LINT_CHART_CMD)
 endif
 
-PUBLISH_CHART_CMD := bash -c ' \
+PUBLISH_RC_CHART_CMD := bash -c ' \
 	cd contrib/k8s/charts \
 	&& rm -rf repo \
 	&& mkdir repo \
 	&& cd repo \
-	&& sed -i s/0.0.1/$(REL_VERSION)/g ../open-service-broker-azure/Chart.yaml \
+	&& sed -i "s/^version:.*/version: 0.0.1+$(GIT_VERSION)/g" ../open-service-broker-azure/Chart.yaml \
+	&& sed -i "s/^appVersion:.*/appVersion: 0.0.1+$(GIT_VERSION)/g" ../open-service-broker-azure/Chart.yaml \
+	&& sed -i "s/^  tag:.*/  tag: $(GIT_VERSION)/g" ../open-service-broker-azure/values.yaml \
+	&& helm dep build ../open-service-broker-azure \
+	&& helm package ../open-service-broker-azure \
+	&& az storage blob upload \
+		-c azure-rc \
+		--file open-service-broker-azure-0.0.1+$(GIT_VERSION).tgz \
+		--name open-service-broker-azure-0.0.1+$(GIT_VERSION).tgz \
+	&& az storage container lease acquire -c azure-rc --lease-duration 60 \
+	&& helm repo index --url https://kubernetescharts.blob.core.windows.net/azure-rc . \
+	&& az storage blob upload \
+		-c azure-rc \
+		--file index.yaml \
+		--name index.yaml'
+
+PUBLISH_RELEASE_CHART_CMD := bash -c ' \
+	SIMPLE_REL_VERSION=$$(echo $(REL_VERSION) | cut -c 2-) \
+	&& cd contrib/k8s/charts \
+	&& rm -rf repo \
+	&& mkdir repo \
+	&& cd repo \
+	&& sed -i "s/^version:.*/version: $${SIMPLE_REL_VERSION}/g" ../open-service-broker-azure/Chart.yaml \
+	&& sed -i "s/^appVersion:.*/appVersion: $${SIMPLE_REL_VERSION}/g" ../open-service-broker-azure/Chart.yaml \
+	&& sed -i "s/^  tag:.*/  tag: $(REL_VERSION)/g" ../open-service-broker-azure/values.yaml \
 	&& helm dep build ../open-service-broker-azure \
 	&& helm package ../open-service-broker-azure \
 	&& az storage blob upload \
 		-c azure \
-		--file open-service-broker-azure-$(REL_VERSION).tgz \
-		--name open-service-broker-azure-$(REL_VERSION).tgz \
+		--file open-service-broker-azure-$${SIMPLE_REL_VERSION}.tgz \
+		--name open-service-broker-azure-$${SIMPLE_REL_VERSION}.tgz \
 	&& az storage container lease acquire -c azure --lease-duration 60 \
 	&& az storage blob download \
 		-c azure \
@@ -340,8 +364,19 @@ PUBLISH_CHART_CMD := bash -c ' \
 		--file index.yaml \
 		--name index.yaml'
 
-.PHONY: publish-chart
-publish-chart:
+.PHONY: publish-rc-chart
+publish-rc-chart:
+ifndef AZURE_STORAGE_CONNECTION_STRING
+	$(error AZURE_STORAGE_CONNECTION_STRING is not defined)
+endif
+ifdef SKIP_DOCKER
+	$(PUBLISH_RC_CHART_CMD)
+else
+	$(DOCKER_HELM_CMD) $(PUBLISH_RC_CHART_CMD)
+endif
+
+.PHONY: publish-release-chart
+publish-release-chart:
 ifndef REL_VERSION
 	$(error REL_VERSION is undefined)
 endif
@@ -349,9 +384,9 @@ ifndef AZURE_STORAGE_CONNECTION_STRING
 	$(error AZURE_STORAGE_CONNECTION_STRING is not defined)
 endif
 ifdef SKIP_DOCKER
-	$(PUBLISH_CHART_CMD)
+	$(PUBLISH_RELEASE_CHART_CMD)
 else
-	$(DOCKER_HELM_CMD) $(PUBLISH_CHART_CMD)
+	$(DOCKER_HELM_CMD) $(PUBLISH_RELEASE_CHART_CMD)
 endif
 
 ################################################################################

--- a/contrib/k8s/charts/open-service-broker-azure/Chart.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Open Service Broker For Azure
 name: open-service-broker-azure
-version: 0.0.1
-appVersion: 0.0.1
+version: v0.0.1 # This gets automatically overridden by our release process
+appVersion: v0.0.1 # This gets automatically overridden by our release process
 keywords:
   - azure
   - services

--- a/contrib/k8s/charts/open-service-broker-azure/README.md
+++ b/contrib/k8s/charts/open-service-broker-azure/README.md
@@ -101,7 +101,7 @@ Broker chart and their default values.
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image.repository` | Docker image location, _without_ the tag. | `"microsoft/azure-service-broker"` |
-| `image.tag` | Tag / version of the Docker image. | `"v0.4.0-alpha"` |
+| `image.tag` | Tag / version of the Docker image. | OSBA release matching chart version |
 | `image.pullPolicy` | `"IfNotPresent"`, `"Always"`, or `"Never"`; When launching a pod, this option indicates when to pull the OSBA Docker image. | `"IfNotPresent"` |
 | `registerBroker` | Whether to register this broker with the Kubernetes Service Catalog. If true, the Kubernetes Service Catalog must already be installed on the cluster. Marking this option false is useful for scenarios wherein one wishes to host the broker in a separate cluster than the Service Catalog (or other client) that will access it. | `true` |
 | `service.type` | Type of service; valid values are `"ClusterIP"`, `"LoadBalancer"`, and `"NodePort"`. `"ClusterIP"` is sufficient in the average case where OSBA only receives traffic from within the cluster-- e.g. from Kubernetes Service Catalog. | `"ClusterIP"` |

--- a/contrib/k8s/charts/open-service-broker-azure/values.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/values.yaml
@@ -4,7 +4,7 @@ image:
   ## Image location, NOT including the tag
   repository: microsoft/azure-service-broker
   ## Image tag
-  tag: v0.9.0-alpha
+  tag: v0.0.1 # This gets automatically overridden by our release process
   ## "IfNotPresent", "Always", or "Never"
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
We already treat the head of master as always (potentially) releasable. The head of master is always, therefore, a release candidate. We already publish "rc" images (tagged with git sha) as commits exit the master pipeline. I think it best if we _also_ publish an "rc" chart that goes along with it. This PR accomplishes that.

This also fixes a problem where the actual chart release process (release pipeline) wasn't getting the correct image tag set in `values.yaml` prior to publishing.