### PR TITLE
Rename PCF tile and its label

### DIFF
--- a/contrib/cf/pcf-tile/tile.yml
+++ b/contrib/cf/pcf-tile/tile.yml
@@ -2,9 +2,9 @@
 # The high-level description of your tile.
 # Replace these properties with real values.
 #
-name: open-service-broker-azure
+name: azure-open-service-broker-pcf
 icon_file: resources/icon.png
-label: Microsoft Open Service Broker for Azure
+label: Azure Open Service Broker for PCF
 description: A service broker for Microsoft Azure services
 
 # Global defaults (all optional)


### PR DESCRIPTION
According to Ning and Pivotal's discussion, we need to rename the tile to **Azure Open Service Broker for PCF** to distinguish from a PKS tile. And we keep using **open-service-broker-azure** as the broker app name.

CC: @arschles 