### PR TITLE
change naming/versioning strategy for rc charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,15 +322,15 @@ PUBLISH_RC_CHART_CMD := bash -c ' \
 	&& rm -rf repo \
 	&& mkdir repo \
 	&& cd repo \
-	&& sed -i "s/^version:.*/version: 0.0.1+$(GIT_VERSION)/g" ../open-service-broker-azure/Chart.yaml \
-	&& sed -i "s/^appVersion:.*/appVersion: 0.0.1+$(GIT_VERSION)/g" ../open-service-broker-azure/Chart.yaml \
+	&& sed -i "s/^version:.*/version: 0.0.1-$(GIT_VERSION)/g" ../open-service-broker-azure/Chart.yaml \
+	&& sed -i "s/^appVersion:.*/appVersion: $(GIT_VERSION)/g" ../open-service-broker-azure/Chart.yaml \
 	&& sed -i "s/^  tag:.*/  tag: $(GIT_VERSION)/g" ../open-service-broker-azure/values.yaml \
 	&& helm dep build ../open-service-broker-azure \
 	&& helm package ../open-service-broker-azure \
 	&& az storage blob upload \
 		-c azure-rc \
-		--file open-service-broker-azure-0.0.1+$(GIT_VERSION).tgz \
-		--name open-service-broker-azure-0.0.1+$(GIT_VERSION).tgz \
+		--file open-service-broker-azure-0.0.1-$(GIT_VERSION).tgz \
+		--name open-service-broker-azure-0.0.1-$(GIT_VERSION).tgz \
 	&& az storage container lease acquire -c azure-rc --lease-duration 60 \
 	&& helm repo index --url https://kubernetescharts.blob.core.windows.net/azure-rc . \
 	&& az storage blob upload \


### PR DESCRIPTION
Although Helm uses semver 2 and _does_ allow build metadata (like commit sha, for instance) to be appended to the `version` field in `Chart.yaml` after a `+`, it is common practice in charts for this information to be incorporated into labels like so:

```
labels:
    ...
    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
    ...
```

The problem with this, however, is that `+` is a disallowed character in that context.

This PR switches our RC charts from being represented as `v0.0.1+<sha>` to `v0.0.1-<sha>`. According to semver, anything after the dash represents information about a pre-release. So, every RC is a pre-release of `0.0.1` (which was previously, arbitrarily chosen to represent the "edge" of OSBA).

There's no point running CI on the PR because this change only affects the master pipeline.

@jeremyrickard if this LGTY, let's merge it right away, please.
