### PR TITLE
fix default environment in chart

### DIFF
--- a/contrib/k8s/charts/open-service-broker-azure/README.md
+++ b/contrib/k8s/charts/open-service-broker-azure/README.md
@@ -106,7 +106,7 @@ Broker chart and their default values.
 | `registerBroker` | Whether to register this broker with the Kubernetes Service Catalog. If true, the Kubernetes Service Catalog must already be installed on the cluster. Marking this option false is useful for scenarios wherein one wishes to host the broker in a separate cluster than the Service Catalog (or other client) that will access it. | `true` |
 | `service.type` | Type of service; valid values are `"ClusterIP"`, `"LoadBalancer"`, and `"NodePort"`. `"ClusterIP"` is sufficient in the average case where OSBA only receives traffic from within the cluster-- e.g. from Kubernetes Service Catalog. | `"ClusterIP"` |
 | `service.nodePort.port` | _If and only if_ `service.type` is set to `"NodePort"`, `service.nodePort.port` indicates the port this service should bind to on each Kubernetes node. | `30080` |
-| `azure.environment` | Indicates which Azure public cloud to use. Valid values are `"AzureCloud"` and `"AzureChinaCloud"`. | `"AzureCloud"` |
+| `azure.environment` | Indicates which Azure public cloud to use. Valid values are `"AzurePublicCloud"` and `"AzureChinaCloud"`. | `"AzurePublicCloud"` |
 | `azure.subscriptionId` | Identifies the Azure subscription into which OSBA will provision services. | none |
 | `azure.tenantId` | Identifies the Azure Active Directory to which the _service principal_ used by OSBA to access the Azure subscription belongs. | none |
 | `azure.clientId` | Identifies the _service principal_ used by OSBA to access the Azure subscription. | none |

--- a/contrib/k8s/charts/open-service-broker-azure/values.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/values.yaml
@@ -28,8 +28,8 @@ service:
     port: 30080
 
 azure:
-  ## Valid values are "AzureCloud" and "AzureChinaCloud"
-  environment: AzureCloud
+  ## Valid values are "AzurePublicCloud" and "AzureChinaCloud"
+  environment: AzurePublicCloud
   ## Required; this is the identifier for the Azure account into which services
   ## will be provisioned. BE AWARE THAT DOING SO WILL COST YOU MONEY!
   subscriptionId: 


### PR DESCRIPTION
```
$ k logs -f osba-open-service-broker-azure-6d966487d-8qw6p -n osba
time="2018-04-09T19:36:00Z" level=info msg="Open Service Broker for Azure starting" commit=8ed9bff version=devel
time="2018-04-09T19:36:00Z" level=info msg="Setting log level" logLevel=INFO
time="2018-04-09T19:36:00Z" level=fatal msg="autorest/azure: There is no cloud environment matching the name \"AZURECLOUD\""
```

The default environment set in the chart is wrong-- does not exist. Not sure how we got away with this for so long...