### PR TITLE
make client share nothing with api and service packages

### DIFF
--- a/contrib/cmd/cli/catalog.go
+++ b/contrib/cmd/cli/catalog.go
@@ -17,10 +17,10 @@ func catalog(c *cli.Context) error {
 		return fmt.Errorf("error retrieving catalog: %s", err)
 	}
 	fmt.Println()
-	for _, svc := range catalog.GetServices() {
-		fmt.Printf("service: %-20s id: %s\n", svc.GetName(), svc.GetID())
-		for _, plan := range svc.GetPlans() {
-			fmt.Printf("   plan: %-20s id: %s\n", plan.GetName(), plan.GetID())
+	for _, svc := range catalog.Services {
+		fmt.Printf("service: %-20s id: %s\n", svc.Name, svc.ID)
+		for _, plan := range svc.Plans {
+			fmt.Printf("   plan: %-20s id: %s\n", plan.Name, plan.ID)
 		}
 		fmt.Println()
 	}

--- a/contrib/cmd/cli/deprovision.go
+++ b/contrib/cmd/cli/deprovision.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/Azure/open-service-broker-azure/contrib/pkg/client"
-	"github.com/Azure/open-service-broker-azure/pkg/api"
 	log "github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -34,21 +33,21 @@ func deprovision(c *cli.Context) error {
 				username,
 				password,
 				instanceID,
-				api.OperationDeprovisioning,
+				client.OperationDeprovisioning,
 			)
 			if err != nil {
 				return fmt.Errorf("error polling for deprovisioning status: %s", err)
 			}
 			switch result {
-			case api.OperationStateInProgress:
+			case client.OperationStateInProgress:
 				fmt.Print(".")
-			case api.OperationStateGone:
+			case client.OperationStateGone:
 				fmt.Printf(
 					"\n\nService instance %s has been successfully deprovisioned\n\n",
 					instanceID,
 				)
 				return nil
-			case api.OperationStateFailed:
+			case client.OperationStateFailed:
 				return fmt.Errorf(
 					"Deprovisioning service instance %s has failed",
 					instanceID,

--- a/contrib/cmd/cli/poll.go
+++ b/contrib/cmd/cli/poll.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/Azure/open-service-broker-azure/contrib/pkg/client"
-	"github.com/Azure/open-service-broker-azure/pkg/api"
 	log "github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -22,9 +21,9 @@ func poll(c *cli.Context) error {
 	if operation == "" {
 		return fmt.Errorf("--%s is a required flag", flagOperation)
 	}
-	if operation != api.OperationProvisioning &&
-		operation != api.OperationDeprovisioning &&
-		operation != api.OperationUpdating {
+	if operation != client.OperationProvisioning &&
+		operation != client.OperationDeprovisioning &&
+		operation != client.OperationUpdating {
 		return fmt.Errorf("invalid value for flag --%s", flagOperation)
 	}
 	status, err := client.Poll(

--- a/contrib/cmd/cli/provision.go
+++ b/contrib/cmd/cli/provision.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/Azure/open-service-broker-azure/contrib/pkg/client"
-	"github.com/Azure/open-service-broker-azure/pkg/api"
 	log "github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -65,21 +64,21 @@ func provision(c *cli.Context) error {
 				username,
 				password,
 				instanceID,
-				api.OperationProvisioning,
+				client.OperationProvisioning,
 			)
 			if err != nil {
 				return fmt.Errorf("error polling for provisioning status: %s", err)
 			}
 			switch result {
-			case api.OperationStateInProgress:
+			case client.OperationStateInProgress:
 				fmt.Print(".")
-			case api.OperationStateSucceeded:
+			case client.OperationStateSucceeded:
 				fmt.Printf(
 					"\n\nService instance %s has been successfully provisioned\n\n",
 					instanceID,
 				)
 				return nil
-			case api.OperationStateFailed:
+			case client.OperationStateFailed:
 				return fmt.Errorf(
 					"Provisioning service instance %s has failed",
 					instanceID,

--- a/contrib/cmd/cli/update.go
+++ b/contrib/cmd/cli/update.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/Azure/open-service-broker-azure/contrib/pkg/client"
-	"github.com/Azure/open-service-broker-azure/pkg/api"
 	log "github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -51,21 +50,21 @@ func update(c *cli.Context) error {
 				username,
 				password,
 				instanceID,
-				api.OperationUpdating,
+				client.OperationUpdating,
 			)
 			if err != nil {
 				return fmt.Errorf("error polling for updating status: %s", err)
 			}
 			switch result {
-			case api.OperationStateInProgress:
+			case client.OperationStateInProgress:
 				fmt.Print(".")
-			case api.OperationStateSucceeded:
+			case client.OperationStateSucceeded:
 				fmt.Printf(
 					"\n\nService instance %s has been successfully updated\n\n",
 					instanceID,
 				)
 				return nil
-			case api.OperationStateFailed:
+			case client.OperationStateFailed:
 				return fmt.Errorf(
 					"Updating service instance %s has failed",
 					instanceID,

--- a/contrib/pkg/client/poll.go
+++ b/contrib/pkg/client/poll.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-
-	"github.com/Azure/open-service-broker-azure/pkg/api"
 )
 
 // Poll polls the status of an instance
@@ -41,7 +39,7 @@ func Poll(
 		return "", fmt.Errorf("error reading response body: %s", err)
 	}
 	defer resp.Body.Close() // nolint: errcheck
-	if operation == api.OperationDeprovisioning &&
+	if operation == OperationDeprovisioning &&
 		resp.StatusCode == http.StatusGone {
 		return "gone", nil
 	}

--- a/contrib/pkg/client/provision.go
+++ b/contrib/pkg/client/provision.go
@@ -1,10 +1,10 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
-	"github.com/Azure/open-service-broker-azure/pkg/api"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -26,16 +26,16 @@ func Provision(
 		instanceID,
 	)
 	params["tags"] = tags
-	provisioningRequest := &api.ProvisioningRequest{
+	provisioningRequest := ProvisioningRequest{
 		ServiceID:  serviceID,
 		PlanID:     planID,
 		Parameters: params,
 	}
-	json, err := provisioningRequest.ToJSON()
+	jsonBytes, err := json.Marshal(provisioningRequest)
 	if err != nil {
 		return "", fmt.Errorf("error encoding request body: %s", err)
 	}
-	req, err := newRequest(http.MethodPut, url, username, password, json)
+	req, err := newRequest(http.MethodPut, url, username, password, jsonBytes)
 	if err != nil {
 		return "", err
 	}

--- a/contrib/pkg/client/types.go
+++ b/contrib/pkg/client/types.go
@@ -1,0 +1,101 @@
+package client
+
+const (
+	// OperationProvisioning represents the "provisioning" operation
+	OperationProvisioning = "provisioning"
+	// OperationUpdating represents the "updating" operation
+	OperationUpdating = "updating"
+	// OperationDeprovisioning represents the "deprovisioning" operation
+	OperationDeprovisioning = "deprovisioning"
+	// OperationStateInProgress represents the state of an operation that is still
+	// pending completion
+	OperationStateInProgress = "in progress"
+	// OperationStateSucceeded represents the state of an operation that has
+	// completed successfully
+	OperationStateSucceeded = "succeeded"
+	// OperationStateFailed represents the state of an operation that has
+	// failed
+	OperationStateFailed = "failed"
+	// OperationStateGone is a pseudo oepration state represting the "state"
+	// of an operation against an entity that no longer exists
+	OperationStateGone = "gone"
+)
+
+// Catalog represents the full set of service/plan offerings provided by a
+// broker
+type Catalog struct {
+	Services []Service `json:"services"`
+}
+
+// Service represents a KIND of service
+type Service struct {
+	Name          string           `json:"name"`
+	ID            string           `json:"id"`
+	Description   string           `json:"description"`
+	Metadata      *ServiceMetadata `json:"metadata,omitempty"`
+	Plans         []Plan           `json:"plans"`
+	Tags          []string         `json:"tags"`
+	Bindable      bool             `json:"bindable"`
+	PlanUpdatable bool             `json:"plan_updateable"` // Misspelling is
+	// deliberate to match the spec
+}
+
+// ServiceMetadata represents optional, extended metadata for a service
+type ServiceMetadata struct {
+	DisplayName         string `json:"displayName,omitempty"`
+	ImageURL            string `json:"imageUrl,omitempty"`
+	LongDescription     string `json:"longDescription,omitempty"`
+	ProviderDisplayName string `json:"providerDisplayName,omitempty"`
+	DocumentationURL    string `json:"documentationUrl,omitempty"`
+	SupportURL          string `json:"supportUrl,omitempty"`
+}
+
+// Plan represents a concrete variation of a Service; typically these are
+// different SKUs for the same KIND of service
+type Plan struct {
+	ID          string               `json:"id"`
+	Name        string               `json:"name"`
+	Description string               `json:"description"`
+	Free        bool                 `json:"free"`
+	Metadata    *ServicePlanMetadata `json:"metadata,omitempty"`
+	// TODO: This currently omits schema information
+}
+
+// ServicePlanMetadata represents optional, extended metadata for a plan
+type ServicePlanMetadata struct {
+	DisplayName string   `json:"displayName,omitempty"`
+	Bullets     []string `json:"bullets,omitempty"`
+}
+
+// ProvisioningRequest represents a request to provision a service instance
+type ProvisioningRequest struct {
+	ServiceID  string                 `json:"service_id"`
+	PlanID     string                 `json:"plan_id"`
+	Parameters map[string]interface{} `json:"parameters"`
+}
+
+// UpdatingRequest represents a request to update a service
+type UpdatingRequest struct {
+	ServiceID      string                 `json:"service_id"`
+	PlanID         string                 `json:"plan_id"`
+	Parameters     map[string]interface{} `json:"parameters"`
+	PreviousValues UpdatingPreviousValues `json:"previous_values"`
+}
+
+// UpdatingPreviousValues represents the information about the service instance
+// prior to the update
+type UpdatingPreviousValues struct {
+	PlanID string `json:"plan_id"`
+}
+
+// BindingRequest represents a request to bind to a service
+type BindingRequest struct {
+	ServiceID  string                 `json:"service_id"`
+	PlanID     string                 `json:"plan_id"`
+	Parameters map[string]interface{} `json:"parameters"`
+}
+
+// BindingResponse represents the response to a binding request
+type BindingResponse struct {
+	Credentials map[string]interface{} `json:"credentials"`
+}

--- a/contrib/pkg/client/update.go
+++ b/contrib/pkg/client/update.go
@@ -1,10 +1,9 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
-
-	"github.com/Azure/open-service-broker-azure/pkg/api"
 )
 
 // Update initiates updating of an existing service instance
@@ -23,16 +22,16 @@ func Update(
 		getBaseURL(host, port),
 		instanceID,
 	)
-	updatingRequest := &api.UpdatingRequest{
+	updatingRequest := UpdatingRequest{
 		ServiceID:  serviceID,
 		PlanID:     planID,
 		Parameters: params,
 	}
-	json, err := updatingRequest.ToJSON()
+	jsonBytes, err := json.Marshal(updatingRequest)
 	if err != nil {
 		return fmt.Errorf("error encoding request body: %s", err)
 	}
-	req, err := newRequest(http.MethodPatch, url, username, password, json)
+	req, err := newRequest(http.MethodPatch, url, username, password, jsonBytes)
 	if err != nil {
 		return err
 	}

--- a/pkg/service/catalog.go
+++ b/pkg/service/catalog.go
@@ -116,28 +116,6 @@ func NewCatalog(services []Service) Catalog {
 	return c
 }
 
-// NewCatalogFromJSON returns a new Catalog unmarshalled from the provided JSON
-// []byte
-func NewCatalogFromJSON(jsonBytes []byte) (Catalog, error) {
-	c := &catalog{
-		services:        []Service{},
-		indexedServices: make(map[string]Service),
-	}
-	if err := json.Unmarshal(jsonBytes, c); err != nil {
-		return nil, err
-	}
-	for _, svcRawJSON := range c.Services {
-		svc, err := NewServiceFromJSON(svcRawJSON)
-		if err != nil {
-			return nil, err
-		}
-		c.services = append(c.services, svc)
-		c.indexedServices[svc.GetID()] = svc
-	}
-	c.Services = nil
-	return c, nil
-}
-
 // ToJSON returns a []byte containing a JSON representation of the catalog
 func (c *catalog) ToJSON() ([]byte, error) {
 	c.jsonMutex.Lock()


### PR DESCRIPTION
Fixes #357 

Recently, a certain decision re: how we marshal complex catalog data carried an implication that we couldn't easily unmarshal the resulting JSON back into a `catalog` struct. We decided at the time that we were fine with that, since the only code that had need to unmarshal that JSON was client code and per #357, we wished for client and server to share less code anyway. This elevated #357 in priortiy, so here we are...