### PR TITLE
Added some words about stability and the helm chart

### DIFF
--- a/contrib/cf/pcf-tile/tile.yml
+++ b/contrib/cf/pcf-tile/tile.yml
@@ -2,9 +2,9 @@
 # The high-level description of your tile.
 # Replace these properties with real values.
 #
-name: open-service-broker-azure
+name: azure-open-service-broker-pcf
 icon_file: resources/icon.png
-label: Microsoft Open Service Broker for Azure
+label: Azure Open Service Broker for PCF
 description: A service broker for Microsoft Azure services
 
 # Global defaults (all optional)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,3 +23,19 @@ time="2018-03-13T12:08:31Z" level=fatal msg="async engine stopped: error sending
 After checking on the health of the kube-system pods, kube-dns was not working. This caused osba 
 to be unable to connect to its Redis instance. The problem was resolved by deleting the
 kube-dns pods, so that Kubernetes would recreate them.
+
+## I don't see all the services
+
+The helm chart is configured to set the minimum stability level of the broker to `preview`,
+meaning that only services that are marked `preview` or `stable` will be available from the broker.
+This is currently Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database.
+If you would like to use other services, you will need to add an additional flag to your helm install command:
+
+```console
+helm install azure/open-service-broker-azure --name osba --namespace osba \
+  --set azure.subscriptionId=$AZURE_SUBSCRIPTION_ID \
+  --set azure.tenantId=$AZURE_TENANT_ID \
+  --set azure.clientId=$AZURE_CLIENT_ID \
+  --set azure.clientSecret=$AZURE_CLIENT_SECRET \
+  --set modules.minStability=EXPERIMENTAL
+```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,10 +26,7 @@ kube-dns pods, so that Kubernetes would recreate them.
 
 ## I don't see all the services
 
-The helm chart is configured to set the minimum stability level of the broker to `preview`,
-meaning that only services that are marked `preview` or `stable` will be available from the broker.
-This is currently Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database.
-If you would like to use other services, you will need to add an additional flag to your helm install command:
+Open Service Broker for Azure provides a number of services and each of these services is implemented by a separate module. The module stability is independent of the broker stability level and each module defines it's stability level, ranging from `experimental` to `stable`. The broker can be configured to expose only services above a stability threshold. The helm chart currently configures the broker only load services that are marked `preview` or `stable`. This is currently Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database. If you would like to use other services, you will need to add an additional flag to your helm install command:
 
 ```console
 helm install azure/open-service-broker-azure --name osba --namespace osba \

--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -220,11 +220,7 @@ You should also ensure that the `Microsoft.Compute` and `Microsoft.Network` prov
     ```
 
     **Note**
-    The helm chart is configured to set the minimum stability level of the broker to `preview`,
-    meaning that only services that are marked `preview` or `stable` will be available from the broker.
-    This is currently Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database.
-    If you would like to use other services, you will need to add an additional flag to your helm install
-    command:
+    Open Service Broker for Azure provides a number of services and each of these services is implemented by a separate module. The module stability is independent of the broker stability level and each module defines it's stability level, ranging from `experimental` to `stable`. The broker can be configured to expose only services above a stability threshold. The helm chart currently configures the broker only load services that are marked `preview` or `stable`. This is currently Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database. If you would like to use other services, you will need to add an additional flag to your helm install command:
 
     ```console
     helm install azure/open-service-broker-azure --name osba --namespace osba \

--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -219,6 +219,22 @@ You should also ensure that the `Microsoft.Compute` and `Microsoft.Network` prov
       --set azure.clientSecret=$env:AZURE_CLIENT_SECRET
     ```
 
+    **Note**
+    The helm chart is configured to set the minimum stability level of the broker to `preview`,
+    meaning that only services that are marked `preview` or `stable` will be available from the broker.
+    This is currently Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database.
+    If you would like to use other services, you will need to add an additional flag to your helm install
+    command:
+
+    ```console
+    helm install azure/open-service-broker-azure --name osba --namespace osba \
+      --set azure.subscriptionId=$AZURE_SUBSCRIPTION_ID \
+      --set azure.tenantId=$AZURE_TENANT_ID \
+      --set azure.clientId=$AZURE_CLIENT_ID \
+      --set azure.clientSecret=$AZURE_CLIENT_SECRET \
+      --set modules.minStability=EXPERIMENTAL
+    ```
+
 1. Check on the status of everything that we have installed by running the
     following command and checking that every pod is in the `Running` state.
     You may need to wait a few minutes, rerunning the command until all of the

--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -229,11 +229,7 @@ Next we will create a local cluster using Minikube. You can also [try OSBA on th
     ```
 
    **Note**
-   The helm chart is configured to set the minimum stability level of the broker to `preview`,
-   meaning that only services that are marked `preview` or `stable` will be available from the broker.
-   This is currently Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database.
-   If you would like to use other services, you will need to add an additional flag to your helm install
-   command:
+    Open Service Broker for Azure provides a number of services and each of these services is implemented by a separate module. The module stability is independent of the broker stability level and each module defines it's stability level, ranging from `experimental` to `stable`. The broker can be configured to expose only services above a stability threshold. The helm chart currently configures the broker only load services that are marked `preview` or `stable`. This is currently Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database. If you would like to use other services, you will need to add an additional flag to your helm install command:
 
    ```console
    helm install azure/open-service-broker-azure --name osba --namespace osba \

--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -228,6 +228,22 @@ Next we will create a local cluster using Minikube. You can also [try OSBA on th
       --set azure.clientSecret=$env:AZURE_CLIENT_SECRET
     ```
 
+   **Note**
+   The helm chart is configured to set the minimum stability level of the broker to `preview`,
+   meaning that only services that are marked `preview` or `stable` will be available from the broker.
+   This is currently Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database.
+   If you would like to use other services, you will need to add an additional flag to your helm install
+   command:
+
+   ```console
+   helm install azure/open-service-broker-azure --name osba --namespace osba \
+      --set azure.subscriptionId=$AZURE_SUBSCRIPTION_ID \
+      --set azure.tenantId=$AZURE_TENANT_ID \
+      --set azure.clientId=$AZURE_CLIENT_ID \
+      --set azure.clientSecret=$AZURE_CLIENT_SECRET \
+      --set modules.minStability=EXPERIMENTAL
+   ```
+
 1. Check on the status of Open Service Broker for Azure by running the
     following command and checking that every pod is in the `Running` state.
     You may need to wait a few minutes, rerunning the command until all of the


### PR DESCRIPTION
We've recently updated the helm chart to set the broker's minimum stability level
to preview. This means that any of the experimental moduels are not going to be included
in the catalog. If people want to use them, they will need to use that flag. This adds it
to the two quick start guides and the FAQ.

Closes #393