### PR TITLE
Add "uri" to the MongoDB credential.

### DIFF
--- a/pkg/services/cosmosdb/common-types.go
+++ b/pkg/services/cosmosdb/common-types.go
@@ -29,9 +29,9 @@ type cosmosdbSecureInstanceDetails struct {
 // cosmosCredentials encapsulates CosmosDB-specific details for connecting via
 // a variety of APIs. This excludes MongoDB.
 type cosmosCredentials struct {
-	URI                     string `json:"uri,omitempty"`
-	PrimaryConnectionString string `json:"primaryConnectionString,omitempty"`
-	PrimaryKey              string `json:"primaryKey,omitempty"`
+	URI                     string `json:"uri"`
+	PrimaryConnectionString string `json:"primaryConnectionString"`
+	PrimaryKey              string `json:"primaryKey"`
 }
 
 func (c *cosmosAccountManager) SplitProvisioningParameters(

--- a/pkg/services/cosmosdb/mongodb-bind.go
+++ b/pkg/services/cosmosdb/mongodb-bind.go
@@ -23,5 +23,6 @@ func (m *mongoAccountManager) GetCredentials(
 		Username:         dt.DatabaseAccountName,
 		Password:         sdt.PrimaryKey,
 		ConnectionString: sdt.ConnectionString,
+		URI:              sdt.ConnectionString,
 	}, nil
 }

--- a/pkg/services/cosmosdb/mongodb-types.go
+++ b/pkg/services/cosmosdb/mongodb-types.go
@@ -3,10 +3,10 @@ package cosmosdb
 // mongoCredentials encapsulates CosmosDB-specific connection details and
 // credentials for connecting with the MongoDB API.
 type mongoCredentials struct {
-	Host             string `json:"host,omitempty"`
-	Port             int    `json:"port,omitempty"`
-	Username         string `json:"username,omitempty"`
-	Password         string `json:"password,omitempty"`
-	ConnectionString string `json:"connectionString,omitempty"`
-	URI              string `json:"uri,omitempty"`
+	Host             string `json:"host"`
+	Port             int    `json:"port"`
+	Username         string `json:"username"`
+	Password         string `json:"password"`
+	ConnectionString string `json:"connectionString"`
+	URI              string `json:"uri"`
 }

--- a/pkg/services/cosmosdb/mongodb-types.go
+++ b/pkg/services/cosmosdb/mongodb-types.go
@@ -8,4 +8,5 @@ type mongoCredentials struct {
 	Username         string `json:"username,omitempty"`
 	Password         string `json:"password,omitempty"`
 	ConnectionString string `json:"connectionString,omitempty"`
+	URI              string `json:"uri,omitempty"`
 }


### PR DESCRIPTION
This PR adds a duplicate entry to the binding credential with the
"uri" property. This is the same value as the "connectionString" property
but will add better support for the Spring Cloud Foundry connector for
MongoDB. By default, it will look for a "uri" field. This should enable
applications to consume our MongoDB API service offering with no special
handling on CF.

Closes #282 