### PR TITLE
Adding to the Redis binding

### DIFF
--- a/pkg/services/rediscache/bind.go
+++ b/pkg/services/rediscache/bind.go
@@ -37,14 +37,13 @@ func (s *serviceManager) GetCredentials(
 		return nil, err
 	}
 
-	uriStringTemplate := "redis://:%s@%s:%d"
 	redisPort := 6379
 	return credentials{
 		Host:     dt.FullyQualifiedDomainName,
 		Password: sdt.PrimaryKey,
 		Port:     redisPort,
 		URI: fmt.Sprintf(
-			uriStringTemplate,
+			"redis://:%s@%s:%d",
 			url.QueryEscape(sdt.PrimaryKey),
 			dt.FullyQualifiedDomainName,
 			redisPort,

--- a/pkg/services/rediscache/bind.go
+++ b/pkg/services/rediscache/bind.go
@@ -1,6 +1,9 @@
 package rediscache
 
 import (
+	"fmt"
+	"net/url"
+
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
@@ -33,9 +36,18 @@ func (s *serviceManager) GetCredentials(
 	if err := service.GetStructFromMap(instance.SecureDetails, &sdt); err != nil {
 		return nil, err
 	}
+
+	uriStringTemplate := "redis://:%s@%s:%d"
+	redisPort := 6379
 	return credentials{
 		Host:     dt.FullyQualifiedDomainName,
 		Password: sdt.PrimaryKey,
-		Port:     6379,
+		Port:     redisPort,
+		URI: fmt.Sprintf(
+			uriStringTemplate,
+			url.QueryEscape(sdt.PrimaryKey),
+			dt.FullyQualifiedDomainName,
+			redisPort,
+		),
 	}, nil
 }

--- a/pkg/services/rediscache/types.go
+++ b/pkg/services/rediscache/types.go
@@ -16,7 +16,7 @@ type credentials struct {
 	Host     string `json:"host"`
 	Port     int    `json:"port"`
 	Password string `json:"password"`
-	URI      string `json:"uri,omitempty"`
+	URI      string `json:"uri"`
 }
 
 func (s *serviceManager) SplitProvisioningParameters(

--- a/pkg/services/rediscache/types.go
+++ b/pkg/services/rediscache/types.go
@@ -16,6 +16,7 @@ type credentials struct {
 	Host     string `json:"host"`
 	Port     int    `json:"port"`
 	Password string `json:"password"`
+	URI      string `json:"uri,omitempty"`
 }
 
 func (s *serviceManager) SplitProvisioningParameters(


### PR DESCRIPTION
Adding to the Redis binding to allow it to work out of the box with the Spring
Cloud Connectors. By default, they look for a thing in the credentials called "uri"
that has the form redis://<username>:<password>@<host>:<port>

We were already exposing this data but this makes it easier.

Tested with https://github.com/jeremyrickard/redis-test-app/

Closes: #283