### PR TITLE
High priority fix for sql api service

### DIFF
--- a/pkg/services/cosmosdb/sql-api-provision.go
+++ b/pkg/services/cosmosdb/sql-api-provision.go
@@ -36,6 +36,7 @@ func (s *sqlAccountManager) deployARMTemplate(
 	if instance.Tags == nil {
 		instance.Tags = make(map[string]string)
 	}
+	instance.Tags["defaultExperience"] = "DocumentDB"
 
 	dt, sdt, err := s.cosmosAccountManager.deployARMTemplate(ctx, instance, p)
 

--- a/pkg/services/cosmosdb/sql-api-provision.go
+++ b/pkg/services/cosmosdb/sql-api-provision.go
@@ -33,11 +33,9 @@ func (s *sqlAccountManager) deployARMTemplate(
 	}
 
 	p := s.buildGoTemplateParams(pp, dt, "GlobalDocumentDB")
-	p["capability"] = "EnableTable"
 	if instance.Tags == nil {
 		instance.Tags = make(map[string]string)
 	}
-	instance.Tags["defaultExperience"] = "Table"
 
 	dt, sdt, err := s.cosmosAccountManager.deployARMTemplate(ctx, instance, p)
 


### PR DESCRIPTION
When we completed the changes to cosmosdb, the sql api
got tagged with the Table API experience, so it was marked as
table in the portal.

Fixes: #399