### PR TITLE
Adding required version info to docs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,10 +1,13 @@
 # FAQ
 _What to do when things go sideways_
 
-# Troubleshooting
+
+
+## Troubleshooting
+
 Here are some issues that people have run into in the past:
 
-## OSBA Pod in CrashLoopBackOff, can't lookup osba-redis
+### OSBA Pod in CrashLoopBackOff, can't lookup osba-redis
 
 ```console
 $ kubectl get pod -n osba
@@ -24,7 +27,7 @@ After checking on the health of the kube-system pods, kube-dns was not working. 
 to be unable to connect to its Redis instance. The problem was resolved by deleting the
 kube-dns pods, so that Kubernetes would recreate them.
 
-## I don't see all the services
+### I don't see all the services
 
 Open Service Broker for Azure provides a number of services and each of these services is implemented by a separate module. The stability of individual modules is independent of overall broker stability and is ranked on a scale of `experimental`, `preview`, and `stable`. The broker can be configured to only load modules at or above a specified stability threshold. By default, the helm chart configures the broker to only load modules that are marked as `preview` or `stable`. This currently includes Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database. If you would like to use other services, you will need to add an additional flag to your helm install command:
 
@@ -35,4 +38,12 @@ helm install azure/open-service-broker-azure --name osba --namespace osba \
   --set azure.clientId=$AZURE_CLIENT_ID \
   --set azure.clientSecret=$AZURE_CLIENT_SECRET \
   --set modules.minStability=EXPERIMENTAL
+```
+
+## "osba" is forbidden: not yet ready to handle request
+
+[Service Catalog](https://github.com/kubernetes-incubator/service-catalog) in used to integrate Open Service Broker for Azure. Service Catalog currently works with Kubernetes version 1.9.x and higher. If you are receive this error message when trying to install Open Service Broker For Azure, check the version of your Kubernetes cluster. If you are running a version less than 1.9, please upgrade. If you are making a new cluster with AKS, you can specify the version with the `--kubernetes-version` flag like so:
+
+```console
+az aks create --resource-group osba --name my-aks-cluster --generate-ssh-keys --kubernetes-version 1.9.6
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,7 +42,7 @@ helm install azure/open-service-broker-azure --name osba --namespace osba \
 
 ## "osba" is forbidden: not yet ready to handle request
 
-[Service Catalog](https://github.com/kubernetes-incubator/service-catalog) is the software component that is used to integrate Open Service Broker for Azure with Kubernetes. Service Catalog currently works with Kubernetes version 1.9.0 and higher, so you will need a Kubernetes cluster that is version 1.9.0 or higher. If you receive this error message when trying to install Open Service Broker For Azure, check the version of your Kubernetes cluster. If you are running a version less than 1.9.0, please upgrade. If you are making a new cluster with AKS, you can specify the version with the `--kubernetes-version` flag like so:
+[Service Catalog](https://github.com/kubernetes-incubator/service-catalog) is the software component that is used to integrate Open Service Broker for Azure with Kubernetes clusters. Service Catalog currently works with Kubernetes version 1.9.0 and higher, so you will need a Kubernetes cluster that is version 1.9.0 or higher. If you receive this error message when trying to install Open Service Broker For Azure, check the version of your Kubernetes cluster. If you are running a version less than 1.9.0, please upgrade. If you are making a new cluster with AKS, you can specify the version with the `--kubernetes-version` flag like so:
 
 ```console
 az aks create --resource-group osba --name my-aks-cluster --generate-ssh-keys --kubernetes-version 1.9.6

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,8 +42,30 @@ helm install azure/open-service-broker-azure --name osba --namespace osba \
 
 ## "osba" is forbidden: not yet ready to handle request
 
-[Service Catalog](https://github.com/kubernetes-incubator/service-catalog) in used to integrate Open Service Broker for Azure. Service Catalog currently works with Kubernetes version 1.9.x and higher. If you are receive this error message when trying to install Open Service Broker For Azure, check the version of your Kubernetes cluster. If you are running a version less than 1.9, please upgrade. If you are making a new cluster with AKS, you can specify the version with the `--kubernetes-version` flag like so:
+[Service Catalog](https://github.com/kubernetes-incubator/service-catalog) is the software component that is used to integrate Open Service Broker for Azure with Kubernetes. Service Catalog currently works with Kubernetes version 1.9.0 and higher, so you will need a Kubernetes cluster that is version 1.9.0 or higher. If you receive this error message when trying to install Open Service Broker For Azure, check the version of your Kubernetes cluster. If you are running a version less than 1.9.0, please upgrade. If you are making a new cluster with AKS, you can specify the version with the `--kubernetes-version` flag like so:
 
 ```console
 az aks create --resource-group osba --name my-aks-cluster --generate-ssh-keys --kubernetes-version 1.9.6
+```
+
+To see available versions, you can use the `az aks get-versions` command:
+
+```console
+$ az aks get-versions -l eastus -o table
+KubernetesVersion    Upgrades
+-------------------  -------------------------------------------------------------------------
+1.9.6                None available
+1.9.2                1.9.6
+1.9.1                1.9.2, 1.9.6
+1.8.11               1.9.1, 1.9.2, 1.9.6
+1.8.10               1.8.11, 1.9.1, 1.9.2, 1.9.6
+1.8.7                1.8.10, 1.8.11, 1.9.1, 1.9.2, 1.9.6
+1.8.6                1.8.7, 1.8.10, 1.8.11, 1.9.1, 1.9.2, 1.9.6
+1.8.2                1.8.6, 1.8.7, 1.8.10, 1.8.11, 1.9.1, 1.9.2, 1.9.6
+1.8.1                1.8.2, 1.8.6, 1.8.7, 1.8.10, 1.8.11, 1.9.1, 1.9.2, 1.9.6
+1.7.16               1.8.1, 1.8.2, 1.8.6, 1.8.7, 1.8.10, 1.8.11
+1.7.15               1.7.16, 1.8.1, 1.8.2, 1.8.6, 1.8.7, 1.8.10, 1.8.11
+1.7.12               1.7.15, 1.7.16, 1.8.1, 1.8.2, 1.8.6, 1.8.7, 1.8.10, 1.8.11
+1.7.9                1.7.12, 1.7.15, 1.7.16, 1.8.1, 1.8.2, 1.8.6, 1.8.7, 1.8.10, 1.8.11
+1.7.7                1.7.9, 1.7.12, 1.7.15, 1.7.16, 1.8.1, 1.8.2, 1.8.6, 1.8.7, 1.8.10, 1.8.11
 ```

--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -167,8 +167,10 @@ You should also ensure that the `Microsoft.Compute` and `Microsoft.Network` prov
 
 1. Create the AKS cluster!
     ```console
-    az aks create --resource-group aks-group --name osba-quickstart-cluster --generate-ssh-keys
+    az aks create --resource-group aks-group --name osba-quickstart-cluster --generate-ssh-keys --kubernetes-version 1.9.6
     ```
+
+    Note: Service Catalog may not work with Kubernetes versions less than 1.9.x. If you are attempting to use an older AKS cluster, please upgrade to at least version 1.9.6
 
 1. Configure kubectl to use the new cluster
     ```console

--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -170,7 +170,7 @@ You should also ensure that the `Microsoft.Compute` and `Microsoft.Network` prov
     az aks create --resource-group aks-group --name osba-quickstart-cluster --generate-ssh-keys --kubernetes-version 1.9.6
     ```
 
-    Note: Service Catalog may not work with Kubernetes versions less than 1.9.0. If you are attempting to use an older AKS cluster, please upgrade to at least version 1.9.1
+    Note: Service Catalog may not work with Kubernetes versions less than 1.9.0. If you are attempting to use an older AKS cluster, you will need to upgrade. The earliest 1.9.x release available from AKS is 1.9.1, so you will need to upgrade to at least that version.
 
 1. Configure kubectl to use the new cluster
     ```console

--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -170,7 +170,7 @@ You should also ensure that the `Microsoft.Compute` and `Microsoft.Network` prov
     az aks create --resource-group aks-group --name osba-quickstart-cluster --generate-ssh-keys --kubernetes-version 1.9.6
     ```
 
-    Note: Service Catalog may not work with Kubernetes versions less than 1.9.x. If you are attempting to use an older AKS cluster, please upgrade to at least version 1.9.6
+    Note: Service Catalog may not work with Kubernetes versions less than 1.9.0. If you are attempting to use an older AKS cluster, please upgrade to at least version 1.9.1
 
 1. Configure kubectl to use the new cluster
     ```console

--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -30,7 +30,7 @@ save the connection information in Kubernetes secrets, and then bind them to our
 
 ### Install Minikube
 
-[Minikube](https://github.com/kubernetes/minikube) is a tool that makes it easy to run Kubernetes locally. Minikube runs a single-node Kubernetes cluster inside a VM on your computer. For this quickstart guide, you'll want to install Minikube v0.26.
+[Minikube](https://github.com/kubernetes/minikube) is a tool that makes it easy to run Kubernetes locally. Minikube runs a single-node Kubernetes cluster inside a VM on your computer. For this quickstart guide, you'll want to install Minikube v0.26.1.
 
 #### MacOS
 
@@ -179,7 +179,7 @@ Next we will create a local cluster using Minikube. You can also [try OSBA on th
     minikube start
     ```
 
-    Note: Service Catalog may not work with Kubernetes versions less than 1.9.x. If you are using a version of Minikube older than 0.26, you will need to upgrade to 0.26 to ensure the cluster is compatible with Service Catalog and OSBA.
+    Note: Service Catalog may not work with Kubernetes versions less than 1.9.x. If you are using a version of Minikube older than 0.26.1, you will need to upgrade to 0.26 to ensure the cluster is compatible with Service Catalog and OSBA. Minikube 0.26.1 will install a Kubernetes 1.10 cluster for you by default.
 
 ### Configure the cluster with Open Service Broker for Azure
 

--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -176,10 +176,10 @@ Next we will create a local cluster using Minikube. You can also [try OSBA on th
 
 1. Create a Minikube Cluster:
     ```console
-    minikube start
+    minikube start --bootstrapper=kubeadm
     ```
 
-    Note: Service Catalog may not work with Kubernetes versions less than 1.9.x. If you are using a version of Minikube older than 0.26.1, you will need to upgrade to 0.26 to ensure the cluster is compatible with Service Catalog and OSBA. Minikube 0.26.1 will install a Kubernetes 1.10 cluster for you by default.
+    Note: Service Catalog may not work with Kubernetes versions less than 1.9.0. If you are using a version of Minikube older than 0.25, you will need to upgrade to at least 0.25 to ensure the cluster is compatible with Service Catalog and OSBA.
 
 ### Configure the cluster with Open Service Broker for Azure
 

--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -30,7 +30,7 @@ save the connection information in Kubernetes secrets, and then bind them to our
 
 ### Install Minikube
 
-[Minikube](https://github.com/kubernetes/minikube) is a tool that makes it easy to run Kubernetes locally. Minikube runs a single-node Kubernetes cluster inside a VM on your computer. For this quickstart guide, you'll want to install Minikube v0.25.
+[Minikube](https://github.com/kubernetes/minikube) is a tool that makes it easy to run Kubernetes locally. Minikube runs a single-node Kubernetes cluster inside a VM on your computer. For this quickstart guide, you'll want to install Minikube v0.26.
 
 #### MacOS
 
@@ -176,8 +176,10 @@ Next we will create a local cluster using Minikube. You can also [try OSBA on th
 
 1. Create a Minikube Cluster:
     ```console
-    minikube start --bootstrapper=kubeadm
+    minikube start
     ```
+
+    Note: Service Catalog may not work with Kubernetes versions less than 1.9.x. If you are using a version of Minikube older than 0.26, you will need to upgrade to 0.26 to ensure the cluster is compatible with Service Catalog and OSBA.
 
 ### Configure the cluster with Open Service Broker for Azure
 

--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -30,7 +30,7 @@ save the connection information in Kubernetes secrets, and then bind them to our
 
 ### Install Minikube
 
-[Minikube](https://github.com/kubernetes/minikube) is a tool that makes it easy to run Kubernetes locally. Minikube runs a single-node Kubernetes cluster inside a VM on your computer. For this quickstart guide, you'll want to install Minikube v0.26.1.
+[Minikube](https://github.com/kubernetes/minikube) is a tool that makes it easy to run Kubernetes locally. Minikube runs a single-node Kubernetes cluster inside a VM on your computer. For this quickstart guide, you'll want to install Minikube v0.25.
 
 #### MacOS
 


### PR DESCRIPTION
Adds some verbiage about what versions of Kubernetes are required in order to use service catalog and OSBA. 

Fixes #406