### PR TITLE
CosmosDB SQL API: Now also create a database

### DIFF
--- a/contrib/k8s/examples/cosmosdb/cosmosdb-instance.yaml
+++ b/contrib/k8s/examples/cosmosdb/cosmosdb-instance.yaml
@@ -5,8 +5,8 @@ metadata:
   name: my-cosmosdb-instance
   namespace: default
 spec:
-  clusterServiceClassExternalName: azure-cosmosdb-sql-account
-  clusterServicePlanExternalName: account
+  clusterServiceClassExternalName: azure-cosmosdb-sql
+  clusterServicePlanExternalName: sql-api
   parameters:
     location: eastus
     resourceGroup: demo

--- a/docs/modules/cosmosdb.md
+++ b/docs/modules/cosmosdb.md
@@ -2,8 +2,62 @@
 
 _Note: This module is EXPERIMENTAL and future releases may break the API._
 
-
 ## Services & Plans
+
+### Service: azure-cosmosdb-sql
+
+| Plan Name | Description |
+|-----------|-------------|
+| `sql-api` | Database Account and Database configured to use SQL API |
+
+#### Behaviors
+
+##### Provision
+
+Provisions a new CosmosDB database account that can be accessed through any of the SQL API. The new database account is named using a new UUID. Additionally
+provisions an empty Database. Ready to use with existing Azure CosmosDB libraries.
+
+###### Provisioning Parameters
+
+| Parameter Name | Type | Description | Required | Default Value |
+|----------------|------|-------------|----------|---------------|
+| `location` | `string` | The Azure region in which to provision applicable resources. | Required _unless_ an administrator has configured the broker itself with a default location. | The broker's default location, if configured. |
+| `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and none is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
+| `tags` | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
+| `ipFilters` | `object` | IP Range Filter to be applied to new CosmosDB account | N | A default filter is created that allows only Azure service access |
+| `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
+| `ipFilters.allowAccessFromPortal` | `string` | Specifies if the Azure Portal should be able to access the CosmosDB account. If `allowAccessFromAzure` is set to enabled, this value is ignored. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
+| `ipFilters.allowedIPRanges` | `array` | Values to include in IP Filter. Can be IP Address or CIDR range. | N | If not specified, no additional values will be included in filters. |
+
+##### Bind
+
+Returns a copy of one shared set of credentials.
+
+###### Binding Parameters
+
+This binding operation does not support any parameters.
+
+###### Credentials
+
+Binding returns the following connection details and shared credentials:
+
+| Field Name | Type | Description |
+|------------|------|-------------|
+| `uri` | `string` | The fully-qualified address and port of the CosmosDB database account. |
+| `primaryKey` | `string` | A secret key used for connecting to the CosmosDB database. |
+| `primaryConnectionString` | `string` | The full connection string, which includes the URI and primary key. |
+| `databaseName` | `string` | The generated database name. |
+| `documentdb_database_id` | `string` | The database name provided in a legacy key for use with Azure libraries. |
+| `documentdb_host_endpoint` | `string` | The fully-qualified address and port of the CosmosDB database account provided in a legacy key for use with Azure libraries. |
+| `documentdb_master_key` | `string` | A secret key used for connecting to the CosmosDB database provided in a legacy key for use with Azure libraries. |
+
+##### Unbind
+
+Does nothing.
+
+##### Deprovision
+
+Deletes the CosmosDB database account and database.
 
 ### Service: azure-cosmosdb-sql-account
 
@@ -22,10 +76,11 @@ Provisions a new CosmosDB database account that can be accessed through any of t
 | Parameter Name | Type | Description | Required | Default Value |
 |----------------|------|-------------|----------|---------------|
 | `location` | `string` | The Azure region in which to provision applicable resources. | Required _unless_ an administrator has configured the broker itself with a default location. | The broker's default location, if configured. |
-| `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and nonde is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
+| `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and none is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
+| `alias` | `string` | Specifies an alias that can be used by later provision actions to create databases on this DBMS. | Y | |
 | `tags` | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
 | `ipFilters` | `object` | IP Range Filter to be applied to new CosmosDB account | N | A default filter is created that allows only Azure service access |
-| `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account.Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
+| `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowAccessFromPortal` | `string` | Specifies if the Azure Portal should be able to access the CosmosDB account. If `allowAccessFromAzure` is set to enabled, this value is ignored. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowedIPRanges` | `array` | Values to include in IP Filter. Can be IP Address or CIDR range. | N | If not specified, no additional values will be included in filters. |
 | `consistencyPolicy` | `object` | The consistency policy for the Cosmos DB account. | N | |
@@ -48,17 +103,65 @@ Binding returns the following connection details and shared credentials:
 
 | Field Name | Type | Description |
 |------------|------|-------------|
-| `uri` | `string` | The fully-qualified address and port of the CosmosDB database. ||
-| `primarykey` | `string` | A secret key used for connecting to the CosmosDB database. |
-| `primaryconnectionstring` | `string` | The full connection string, which includes the URI and primary key. |
+| `uri` | `string` | The fully-qualified address and port of the CosmosDB database account. |
+| `primaryKey` | `string` | A secret key used for connecting to the CosmosDB database. |
+| `primaryConnectionString` | `string` | The full connection string, which includes the URI and primary key. |
 
 ##### Unbind
 
 Does nothing.
-  
+
 ##### Deprovision
 
 Deletes the CosmosDB database account.
+
+### Service: azure-cosmosdb-sql-database
+
+| Plan Name | Description |
+|-----------|-------------|
+| `database` | Database on existing CosmosDB database account configured to use SQL API |
+
+#### Behaviors
+
+##### Provision
+
+Provisions a new CosmosDB database onto an existing database account that can be accessed through any of the SQL API. The new database is named using a new UUID.
+
+###### Provisioning Parameters
+
+| Parameter Name | Type | Description | Required | Default Value |
+|----------------|------|-------------|----------|---------------|
+| `parentAlias` | `string` | Specifies the alias of the CosmosDB database account upon which the database should be provisioned. | Y | |
+
+##### Bind
+
+Returns a copy of one shared set of credentials.
+
+###### Binding Parameters
+
+This binding operation does not support any parameters.
+
+###### Credentials
+
+Binding returns the following connection details and shared credentials:
+
+| Field Name | Type | Description |
+|------------|------|-------------|
+| `uri` | `string` | The fully-qualified address and port of the CosmosDB database account. |
+| `primaryKey` | `string` | A secret key used for connecting to the CosmosDB database. |
+| `primaryConnectionString` | `string` | The full connection string, which includes the URI and primary key. |
+| `databaseName` | `string` | The generated database name. |
+| `documentdb_database_id` | `string` | The database name provided in a legacy key for use with Azure libraries. |
+| `documentdb_host_endpoint` | `string` | The fully-qualified address and port of the CosmosDB database account provided in a legacy key for use with Azure libraries. |
+| `documentdb_master_key` | `string` | A secret key used for connecting to the CosmosDB database provided in a legacy key for use with Azure libraries. |
+
+##### Unbind
+
+Does nothing.
+
+##### Deprovision
+
+Deletes the CosmosDB database. The existing database account is not deleted.
 
 ### Service: azure-cosmosdb-mongo-account
 
@@ -77,10 +180,10 @@ Provisions a new CosmosDB database account that can be accessed through the Mong
 | Parameter Name | Type | Description | Required | Default Value |
 |----------------|------|-------------|----------|---------------|
 | `location` | `string` | The Azure region in which to provision applicable resources. | Required _unless_ an administrator has configured the broker itself with a default location. | The broker's default location, if configured. |
-| `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and nonde is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
+| `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and none is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
 | `tags` | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
 | `ipFilters` | `object` | IP Range Filter to be applied to new CosmosDB account | N | A default filter is created that allows only Azure service access |
-| `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account.Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
+| `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowAccessFromPortal` | `string` | Specifies if the Azure Portal should be able to access the CosmosDB account. If `allowAccessFromAzure` is set to enabled, this value is ignored. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowedIPRanges` | `array` | Values to include in IP Filter. Can be IP Address or CIDR range. | N | If not specified, no additional values will be included in filters. |
 | `consistencyPolicy` | `object` | The consistency policy for the Cosmos DB account. | N | |
@@ -102,8 +205,8 @@ Binding returns the following connection details and shared credentials:
 
 | Field Name | Type | Description |
 |------------|------|-------------|
-| `host` | `string` | The fully-qualified address of the CosmosDB database. |
-| `port` | `int` | The port number to connect to on the CosmosDB database. |
+| `host` | `string` | The fully-qualified address of the CosmosDB database account. |
+| `port` | `int` | The port number to connect to on the CosmosDB database account. |
 | `username` | `string` | The name of the database user. |
 | `password` | `string` | The password for the database user. |
 | `connectionstring` | `string` | The full connection string, which includes the host, port, username, and password. |
@@ -134,10 +237,10 @@ Provisions a new CosmosDB database account that can be accessed through any of t
 | Parameter Name | Type | Description | Required | Default Value |
 |----------------|------|-------------|----------|---------------|
 | `location` | `string` | The Azure region in which to provision applicable resources. | Required _unless_ an administrator has configured the broker itself with a default location. | The broker's default location, if configured. |
-| `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and nonde is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
+| `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and none is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
 | `tags` | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
 | `ipFilters` | `object` | IP Range Filter to be applied to new CosmosDB account | N | A default filter is created that allows only Azure service access |
-| `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account.Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
+| `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowAccessFromPortal` | `string` | Specifies if the Azure Portal should be able to access the CosmosDB account. If `allowAccessFromAzure` is set to enabled, this value is ignored. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowedIPRanges` | `array` | Values to include in IP Filter. Can be IP Address or CIDR range. | N | If not specified, no additional values will be included in filters. |
 | `consistencyPolicy` | `object` | The consistency policy for the Cosmos DB account. | N | |
@@ -160,14 +263,14 @@ Binding returns the following connection details and shared credentials:
 
 | Field Name | Type | Description |
 |------------|------|-------------|
-| `uri` | `string` | The fully-qualified address and port of the CosmosDB database. ||
-| `primarykey` | `string` | A secret key used for connecting to the CosmosDB database. |
-| `primaryconnectionstring` | `string` | The full connection string, which includes the URI and primary key. |
+| `uri` | `string` | The fully-qualified address and port of the CosmosDB database account. |
+| `primaryKey` | `string` | A secret key used for connecting to the CosmosDB database account. |
+| `primaryConnectionString` | `string` | The full connection string, which includes the URI and primary key. |
 
 ##### Unbind
 
 Does nothing.
-  
+
 ##### Deprovision
 
 Deletes the CosmosDB database account.
@@ -189,10 +292,10 @@ Provisions a new CosmosDB database account that can be accessed through any of t
 | Parameter Name | Type | Description | Required | Default Value |
 |----------------|------|-------------|----------|---------------|
 | `location` | `string` | The Azure region in which to provision applicable resources. | Required _unless_ an administrator has configured the broker itself with a default location. | The broker's default location, if configured. |
-| `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and nonde is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
+| `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and none is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
 | `tags` | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
 | `ipFilters` | `object` | IP Range Filter to be applied to new CosmosDB account | N | A default filter is created that allows only Azure service access |
-| `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account.Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
+| `ipFilters.allowAccessFromAzure` | `string` | Specifies if Azure Services should be able to access the CosmosDB account. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowAccessFromPortal` | `string` | Specifies if the Azure Portal should be able to access the CosmosDB account. If `allowAccessFromAzure` is set to enabled, this value is ignored. Valid valued are `""` (unspecified), `enabled`, or `disabled`. | N | If left unspecified, defaults to enabled. |
 | `ipFilters.allowedIPRanges` | `array` | Values to include in IP Filter. Can be IP Address or CIDR range. | N | If not specified, no additional values will be included in filters. |
 | `consistencyPolicy` | `object` | The consistency policy for the Cosmos DB account. | N | |
@@ -214,14 +317,14 @@ Binding returns the following connection details and shared credentials:
 
 | Field Name | Type | Description |
 |------------|------|-------------|
-| `uri` | `string` | The fully-qualified address and port of the CosmosDB database. ||
-| `primarykey` | `string` | A secret key used for connecting to the CosmosDB database. |
-| `primaryconnectionstring` | `string` | The full connection string, which includes the URI and primary key. |
+| `uri` | `string` | The fully-qualified address and port of the CosmosDB database account. |
+| `primaryKey` | `string` | A secret key used for connecting to the CosmosDB database account. |
+| `primaryConnectionString` | `string` | The full connection string, which includes the URI and primary key. |
 
 ##### Unbind
 
 Does nothing.
-  
+
 ##### Deprovision
 
 Deletes the CosmosDB database account.

--- a/pkg/services/cosmosdb/catalog.go
+++ b/pkg/services/cosmosdb/catalog.go
@@ -6,6 +6,39 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 	return service.NewCatalog([]service.Service{
 			service.NewService(
 				&service.ServiceProperties{
+					ID:          "58d9fbbd-7041-4dbe-aabe-6268cd31de84",
+					Name:        "azure-cosmosdb-sql",
+					Description: "Azure Cosmos DB Database Account (SQL API)",
+					Metadata: &service.ServiceMetadata{
+						DisplayName: "Azure Cosmos DB (SQL API)",
+						ImageURL: "https://azure.microsoft.com/svghandler/cosmos-db/" +
+							"?width=200",
+						LongDescription: "Globally distributed, multi-model database service" +
+							" (Experimental).",
+						DocumentationURL: "https://docs.microsoft.com/en-us/azure/cosmos-db/",
+						SupportURL:       "https://azure.microsoft.com/en-us/support/",
+					},
+					Bindable: true,
+					Tags: []string{"Azure",
+						"CosmosDB",
+						"Database",
+						"SQL",
+					},
+					ProvisionParamsSchema: m.sqlAccountManager.getProvisionParametersSchema(), // nolint: lll
+				},
+				m.sqlAllInOneManager,
+				service.NewPlan(&service.PlanProperties{
+					ID:          "58d7223d-934e-4fb5-a046-0c67781eb24e",
+					Name:        "default",
+					Description: "Database Account with the SQL API",
+					Free:        false,
+					Metadata: &service.ServicePlanMetadata{
+						DisplayName: "Azure CosmosDB (SQL API)",
+					},
+				}),
+			),
+			service.NewService(
+				&service.ServiceProperties{
 					ID:          "6330de6f-a561-43ea-a15e-b99f44d183e6",
 					Name:        "azure-cosmosdb-sql-account",
 					Description: "Azure Cosmos DB Database Account (SQL API)",

--- a/pkg/services/cosmosdb/catalog.go
+++ b/pkg/services/cosmosdb/catalog.go
@@ -8,9 +8,9 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				&service.ServiceProperties{
 					ID:          "58d9fbbd-7041-4dbe-aabe-6268cd31de84",
 					Name:        "azure-cosmosdb-sql",
-					Description: "Azure Cosmos DB Database Account (SQL API)",
+					Description: "Azure Cosmos DB (SQL API Database Account and Database)",
 					Metadata: &service.ServiceMetadata{
-						DisplayName: "Azure Cosmos DB (SQL API)",
+						DisplayName: "Azure Cosmos DB (SQL API Database Account and Database)",
 						ImageURL: "https://azure.microsoft.com/svghandler/cosmos-db/" +
 							"?width=200",
 						LongDescription: "Globally distributed, multi-model database service" +
@@ -24,26 +24,27 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 						"Database",
 						"SQL",
 					},
-					ProvisionParamsSchema: m.sqlAccountManager.getProvisionParametersSchema(), // nolint: lll
+					ProvisionParamsSchema: m.sqlAllInOneManager.getProvisionParametersSchema(), // nolint: lll
 				},
 				m.sqlAllInOneManager,
 				service.NewPlan(&service.PlanProperties{
 					ID:          "58d7223d-934e-4fb5-a046-0c67781eb24e",
-					Name:        "default",
-					Description: "Database Account with the SQL API",
+					Name:        "sql-api",
+					Description: "Azure CosmosDB With SQL API (Database Account and Database)",
 					Free:        false,
 					Metadata: &service.ServicePlanMetadata{
-						DisplayName: "Azure CosmosDB (SQL API)",
+						DisplayName: "Azure CosmosDB (SQL API Database Account and Database)",
 					},
 				}),
 			),
 			service.NewService(
 				&service.ServiceProperties{
-					ID:          "6330de6f-a561-43ea-a15e-b99f44d183e6",
-					Name:        "azure-cosmosdb-sql-account",
-					Description: "Azure Cosmos DB Database Account (SQL API)",
+					ID:             "6330de6f-a561-43ea-a15e-b99f44d183e6",
+					Name:           "azure-cosmosdb-sql-account",
+					Description:    "Azure Cosmos DB Database Account (SQL API)",
+					ChildServiceID: "87c5132a-6d76-40c6-9621-0c7b7542571b",
 					Metadata: &service.ServiceMetadata{
-						DisplayName: "Azure Cosmos DB (SQL API)",
+						DisplayName: "Azure Cosmos DB (SQL API - Database Account Only)",
 						ImageURL: "https://azure.microsoft.com/svghandler/cosmos-db/" +
 							"?width=200",
 						LongDescription: "Globally distributed, multi-model database service" +
@@ -66,7 +67,40 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 					Description: "Database Account with the SQL API",
 					Free:        false,
 					Metadata: &service.ServicePlanMetadata{
-						DisplayName: "Azure CosmosDB (SQL API)",
+						DisplayName: "Azure CosmosDB (SQL API - Database Account Only)",
+					},
+				}),
+			),
+			service.NewService(
+				&service.ServiceProperties{
+					ID:          "87c5132a-6d76-40c6-9621-0c7b7542571b",
+					Name:        "azure-cosmosdb-sql-database",
+					Description: "Azure Cosmos DB Database (SQL API - Database Only)",
+					Metadata: &service.ServiceMetadata{
+						DisplayName: "Azure Cosmos DB (SQL API - Database Only)",
+						ImageURL: "https://azure.microsoft.com/svghandler/cosmos-db/" +
+							"?width=200",
+						LongDescription: "Globally distributed, multi-model database service" +
+							" (Experimental).",
+						DocumentationURL: "https://docs.microsoft.com/en-us/azure/cosmos-db/",
+						SupportURL:       "https://azure.microsoft.com/en-us/support/",
+					},
+					Bindable: true,
+					Tags: []string{"Azure",
+						"CosmosDB",
+						"Database",
+						"SQL",
+					},
+					ParentServiceID: "6330de6f-a561-43ea-a15e-b99f44d183e6",
+				},
+				m.sqlDatabaseManager,
+				service.NewPlan(&service.PlanProperties{
+					ID:          "c821c68c-c8e0-4176-8cf2-f0ca582a07a3",
+					Name:        "database",
+					Description: "Azure CosmosDB (SQL API - Database only)",
+					Free:        false,
+					Metadata: &service.ServicePlanMetadata{
+						DisplayName: "Azure CosmosDB (SQL API - Database only)",
 					},
 				}),
 			),

--- a/pkg/services/cosmosdb/common-provision.go
+++ b/pkg/services/cosmosdb/common-provision.go
@@ -22,6 +22,11 @@ var (
 	}
 )
 
+const (
+	disabled = "disabled"
+	enabled  = "enabled"
+)
+
 func generateAccountName(location string) string {
 	databaseAccountName := uuid.NewV4().String()
 	// CosmosDB currently limits database account names to 50 characters,
@@ -63,16 +68,16 @@ func (c *cosmosAccountManager) ValidateProvisioningParameters(
 	}
 	if pp.IPFilterRules != nil {
 		allowAzure := strings.ToLower(pp.IPFilterRules.AllowAzure)
-		if allowAzure != "" && allowAzure != "enabled" &&
-			allowAzure != "disabled" {
+		if allowAzure != "" && allowAzure != enabled &&
+			allowAzure != disabled {
 			return service.NewValidationError(
 				"allowAzure",
 				fmt.Sprintf(`invalid option: "%s"`, pp.IPFilterRules.AllowAzure),
 			)
 		}
 		allowPortal := strings.ToLower(pp.IPFilterRules.AllowPortal)
-		if allowPortal != "" && allowPortal != "enabled" &&
-			allowPortal != "disabled" {
+		if allowPortal != "" && allowPortal != enabled &&
+			allowPortal != disabled {
 			return service.NewValidationError(
 				"allowPortal",
 				fmt.Sprintf(`invalid option: "%s"`, pp.IPFilterRules.AllowPortal),
@@ -173,9 +178,9 @@ func (c *cosmosAccountManager) buildGoTemplateParams(
 	if pp.IPFilterRules != nil {
 		allowAzure := strings.ToLower(pp.IPFilterRules.AllowPortal)
 		allowPortal := strings.ToLower(pp.IPFilterRules.AllowPortal)
-		if allowAzure != "disable" {
+		if allowAzure != disabled {
 			filters = append(filters, "0.0.0.0")
-		} else if allowPortal != "disable" {
+		} else if allowPortal != disabled {
 			// Azure Portal IP Addresses per:
 			// https://aka.ms/Vwxndo
 			//|| Region            || IP address(es) ||

--- a/pkg/services/cosmosdb/common-provision.go
+++ b/pkg/services/cosmosdb/common-provision.go
@@ -309,7 +309,9 @@ func (c *cosmosAccountManager) handleOutput(
 	var ok bool
 	fqdn, ok := outputs["fullyQualifiedDomainName"].(string)
 	if !ok {
-		return "", nil, fmt.Errorf("error retrieving fully qualified domain name from deployment")
+		return "", nil, fmt.Errorf(
+			"error retrieving fully qualified domain name from deployment",
+		)
 	}
 
 	primaryKey, ok := outputs["primaryKey"].(string)

--- a/pkg/services/cosmosdb/common-provision.go
+++ b/pkg/services/cosmosdb/common-provision.go
@@ -175,7 +175,7 @@ func (c *cosmosAccountManager) buildGoTemplateParams(
 		return nil, err
 	}
 
-	dt := &sqlAllInOneInstanceDetails{}
+	dt := &cosmosdbInstanceDetails{}
 	if err := service.GetStructFromMap(instance.Details, &dt); err != nil {
 		return nil, err
 	}

--- a/pkg/services/cosmosdb/cosmos-utils.go
+++ b/pkg/services/cosmosdb/cosmos-utils.go
@@ -17,7 +17,8 @@ import (
 // This method implements the CosmosDB API authentication token generation
 // scheme. For reference, please see the CosmosDB REST API at:
 // https://aka.ms/Fyra7j
-func generateAuthToken(verb, resource, id, date, key string) (string, error) {
+func generateAuthToken(verb, id, date, key string) (string, error) {
+	resource := "dbs"
 	var resourceID string
 	if id != "" {
 		resourceID = fmt.Sprintf("%s/%s", strings.ToLower(resource), id)
@@ -79,7 +80,6 @@ func createRequest(
 	dateStr := time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 GMT")
 	authHeader, err := generateAuthToken(
 		method,
-		resourceType,
 		resourceID,
 		dateStr,
 		key,

--- a/pkg/services/cosmosdb/cosmos-utils.go
+++ b/pkg/services/cosmosdb/cosmos-utils.go
@@ -1,0 +1,94 @@
+package cosmosdb
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+func generateAuthToken(verb, resource, id, date, key string) (string, error) {
+	payload := fmt.Sprintf(
+		"%s\n%s\n%s\n%s\n%s\n",
+		strings.ToLower(verb),
+		strings.ToLower(resource),
+		id,
+		strings.ToLower(date),
+		"",
+	)
+
+	decodedKey, _ := base64.StdEncoding.DecodeString(key)
+	hmac := hmac.New(sha256.New, decodedKey)
+	_, err := hmac.Write([]byte(payload))
+	if err != nil {
+		return "", err
+	}
+	b := hmac.Sum(nil)
+	authHash := base64.StdEncoding.EncodeToString(b)
+	authHeader := url.QueryEscape("type=master&ver=1.0&sig=" + authHash)
+	return authHeader, nil
+}
+
+func createRequest(
+	accountName string,
+	method string,
+	resourceType string,
+	resourceID string,
+	key string,
+	body interface{},
+) (*http.Request, error) {
+	path := fmt.Sprintf("%s/%s", resourceType, resourceID)
+	url := fmt.Sprintf("https://%s.documents.azure.com/%s", accountName, path)
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	buf := bytes.NewBuffer(b)
+	req, err := http.NewRequest(method, url, buf)
+	dateStr := time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 GMT")
+	authHeader, err := generateAuthToken(
+		method,
+		resourceType,
+		resourceID,
+		dateStr,
+		key,
+	)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("X-Ms-Date", dateStr)
+	req.Header.Add("X-Ms-version", "2017-02-22")
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", authHeader)
+
+	return req, nil
+}
+
+func createDatabase(
+	accountName string,
+	id string,
+	key string,
+) error {
+	request := &databaseCreationRequest{
+		ID: id,
+	}
+	req, err := createRequest(accountName, "POST", "dbs", "", key, request)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 201 {
+		return fmt.Errorf("error creating database")
+	}
+	return nil
+}

--- a/pkg/services/cosmosdb/cosmosdb.go
+++ b/pkg/services/cosmosdb/cosmosdb.go
@@ -8,6 +8,7 @@ import (
 
 type module struct {
 	sqlAccountManager   *sqlAccountManager
+	sqlAllInOneManager  *sqlAllInOneManager
 	mongoAccountManager *mongoAccountManager
 	graphAccountManager *graphAccountManager
 	tableAccountManager *tableAccountManager
@@ -20,6 +21,10 @@ type cosmosAccountManager struct {
 
 type sqlAccountManager struct {
 	cosmosAccountManager
+}
+
+type sqlAllInOneManager struct {
+	sqlAccountManager
 }
 
 type mongoAccountManager struct {
@@ -48,6 +53,9 @@ func New(
 	return &module{
 		mongoAccountManager: &mongoAccountManager{cosmos},
 		sqlAccountManager:   &sqlAccountManager{cosmos},
+		sqlAllInOneManager: &sqlAllInOneManager{
+			sqlAccountManager: sqlAccountManager{cosmos},
+		},
 		graphAccountManager: &graphAccountManager{cosmos},
 		tableAccountManager: &tableAccountManager{cosmos},
 	}

--- a/pkg/services/cosmosdb/cosmosdb.go
+++ b/pkg/services/cosmosdb/cosmosdb.go
@@ -9,6 +9,7 @@ import (
 type module struct {
 	sqlAccountManager   *sqlAccountManager
 	sqlAllInOneManager  *sqlAllInOneManager
+	sqlDatabaseManager  *sqlDatabaseManager
 	mongoAccountManager *mongoAccountManager
 	graphAccountManager *graphAccountManager
 	tableAccountManager *tableAccountManager
@@ -20,6 +21,10 @@ type cosmosAccountManager struct {
 }
 
 type sqlAccountManager struct {
+	cosmosAccountManager
+}
+
+type sqlDatabaseManager struct {
 	cosmosAccountManager
 }
 
@@ -56,6 +61,7 @@ func New(
 		sqlAllInOneManager: &sqlAllInOneManager{
 			sqlAccountManager: sqlAccountManager{cosmos},
 		},
+		sqlDatabaseManager:  &sqlDatabaseManager{cosmos},
 		graphAccountManager: &graphAccountManager{cosmos},
 		tableAccountManager: &tableAccountManager{cosmos},
 	}

--- a/pkg/services/cosmosdb/graph-api-provision.go
+++ b/pkg/services/cosmosdb/graph-api-provision.go
@@ -33,24 +33,21 @@ func (g *graphAccountManager) deployARMTemplate(
 		return nil, nil, err
 	}
 
-	p := g.buildGoTemplateParams(pp, dt, "GlobalDocumentDB")
+	p, err := g.buildGoTemplateParams(instance, "GlobalDocumentDB")
 	p["capability"] = "EnableGremlin"
 	if instance.Tags == nil {
 		instance.Tags = make(map[string]string)
 	}
 	instance.Tags["defaultExperience"] = "Graph"
-
-	dt, sdt, err := g.cosmosAccountManager.deployARMTemplate(ctx, instance, p)
-
+	fqdn, sdt, err := g.cosmosAccountManager.deployARMTemplate(ctx, instance, p)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error deploying ARM template: %s", err)
 	}
-
+	dt.FullyQualifiedDomainName = fqdn
 	sdt.ConnectionString = fmt.Sprintf("AccountEndpoint=%s;AccountKey=%s;",
 		dt.FullyQualifiedDomainName,
 		sdt.PrimaryKey,
 	)
-
 	dtMap, err := service.GetMapFromStruct(dt)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/services/cosmosdb/graph-api-provision.go
+++ b/pkg/services/cosmosdb/graph-api-provision.go
@@ -34,6 +34,9 @@ func (g *graphAccountManager) deployARMTemplate(
 	}
 
 	p, err := g.buildGoTemplateParams(instance, "GlobalDocumentDB")
+	if err != nil {
+		return nil, nil, fmt.Errorf("error building arm params: %s", err)
+	}
 	p["capability"] = "EnableGremlin"
 	if instance.Tags == nil {
 		instance.Tags = make(map[string]string)

--- a/pkg/services/cosmosdb/mongodb-provision.go
+++ b/pkg/services/cosmosdb/mongodb-provision.go
@@ -34,13 +34,17 @@ func (m *mongoAccountManager) deployARMTemplate(
 		return nil, nil, err
 	}
 
-	p := m.buildGoTemplateParams(pp, dt, "MongoDB")
-	dt, sdt, err := m.cosmosAccountManager.deployARMTemplate(ctx, instance, p)
+	p, err := m.buildGoTemplateParams(instance, "MongoDB")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fqdn, sdt, err := m.cosmosAccountManager.deployARMTemplate(ctx, instance, p)
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("error deploying ARM template: %s", err)
 	}
-
+	dt.FullyQualifiedDomainName = fqdn
 	// Allow to remove the https:// and the port 443 on the FQDN
 	// This will allow to adapt the FQDN for Azure Public / Azure Gov ...
 	// Before :

--- a/pkg/services/cosmosdb/sql-account-only-provision.go
+++ b/pkg/services/cosmosdb/sql-account-only-provision.go
@@ -32,18 +32,21 @@ func (s *sqlAccountManager) deployARMTemplate(
 		return nil, nil, err
 	}
 
-	p := s.buildGoTemplateParams(pp, dt, "GlobalDocumentDB")
+	p, err := s.buildGoTemplateParams(instance, "GlobalDocumentDB")
+	if err != nil {
+		return nil, nil, err
+	}
 	if instance.Tags == nil {
 		instance.Tags = make(map[string]string)
 	}
 	instance.Tags["defaultExperience"] = "DocumentDB"
 
-	dt, sdt, err := s.cosmosAccountManager.deployARMTemplate(ctx, instance, p)
+	fqdn, sdt, err := s.cosmosAccountManager.deployARMTemplate(ctx, instance, p)
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("error deploying ARM template: %s", err)
 	}
-
+	dt.FullyQualifiedDomainName = fqdn
 	sdt.ConnectionString = fmt.Sprintf("AccountEndpoint=%s;AccountKey=%s;",
 		dt.FullyQualifiedDomainName,
 		sdt.PrimaryKey,

--- a/pkg/services/cosmosdb/sql-all-in-one-bind.go
+++ b/pkg/services/cosmosdb/sql-all-in-one-bind.go
@@ -1,0 +1,28 @@
+package cosmosdb
+
+import (
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+)
+
+func (s *sqlAllInOneManager) GetCredentials(
+	instance service.Instance,
+	_ service.Binding,
+) (service.Credentials, error) {
+	dt := sqlAllInOneInstanceDetails{}
+	if err := service.GetStructFromMap(instance.Details, &dt); err != nil {
+		return nil, err
+	}
+	sdt := cosmosdbSecureInstanceDetails{}
+	if err := service.GetStructFromMap(instance.SecureDetails, &sdt); err != nil {
+		return nil, err
+	}
+	return sqlAPICredentials{
+		URI:                     dt.FullyQualifiedDomainName,
+		PrimaryKey:              sdt.PrimaryKey,
+		PrimaryConnectionString: sdt.ConnectionString,
+		DatabaseName:            dt.DatabaseName,
+		DatabaseID:              dt.DatabaseName,
+		Host:                    dt.FullyQualifiedDomainName,
+		MasterKey:               sdt.PrimaryKey,
+	}, nil
+}

--- a/pkg/services/cosmosdb/sql-all-in-one-deprovision.go
+++ b/pkg/services/cosmosdb/sql-all-in-one-deprovision.go
@@ -1,0 +1,46 @@
+package cosmosdb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+)
+
+func (s *sqlAllInOneManager) GetDeprovisioner(
+	service.Plan,
+) (service.Deprovisioner, error) {
+	return service.NewDeprovisioner(
+		service.NewDeprovisioningStep("deleteARMDeployment", s.deleteARMDeployment),
+		service.NewDeprovisioningStep(
+			"deleteDatabase", s.deleteDatabase,
+		),
+		service.NewDeprovisioningStep(
+			"deleteCosmosDBServer", s.deleteCosmosDBAccount,
+		),
+	)
+}
+
+func (s *sqlAllInOneManager) deleteDatabase(
+	_ context.Context,
+	instance service.Instance,
+) (service.InstanceDetails, service.SecureInstanceDetails, error) {
+	dt := &sqlAllInOneInstanceDetails{}
+	err := service.GetStructFromMap(instance.Details, &dt)
+	if err != nil {
+		fmt.Printf("Failed to get DT Struct from Map %s", err)
+		return nil, nil, err
+	}
+
+	sdt := &cosmosdbSecureInstanceDetails{}
+	err = service.GetStructFromMap(instance.SecureDetails, &sdt)
+	if err != nil {
+		fmt.Printf("Failed to get SDT Struct from Map %s", err)
+		return nil, nil, err
+	}
+	err = deleteDatabase(dt.DatabaseAccountName, dt.DatabaseName, sdt.PrimaryKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	return instance.Details, instance.SecureDetails, nil
+}

--- a/pkg/services/cosmosdb/sql-all-in-one-provision.go
+++ b/pkg/services/cosmosdb/sql-all-in-one-provision.go
@@ -1,0 +1,186 @@
+package cosmosdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+	uuid "github.com/satori/go.uuid"
+)
+
+func (s *sqlAllInOneManager) GetProvisioner(
+	service.Plan,
+) (service.Provisioner, error) {
+	return service.NewProvisioner(
+		service.NewProvisioningStep("preProvision", s.preProvision),
+		service.NewProvisioningStep("deployARMTemplate", s.deployARMTemplate),
+		service.NewProvisioningStep("createDatabase", s.createDatabase),
+	)
+}
+
+func (s *sqlAllInOneManager) preProvision(
+	_ context.Context,
+	instance service.Instance,
+) (service.InstanceDetails, service.SecureInstanceDetails, error) {
+	dt := sqlAllInOneInstanceDetails{
+		ARMDeploymentName:   uuid.NewV4().String(),
+		DatabaseAccountName: generateAccountName(instance.Location),
+		DatabaseName:        uuid.NewV4().String(),
+	}
+	dtMap, err := service.GetMapFromStruct(dt)
+	return dtMap, nil, err
+}
+
+func (s *sqlAllInOneManager) buildGoTemplateParams(
+	pp *provisioningParameters,
+	dt *sqlAllInOneInstanceDetails,
+	kind string,
+) map[string]interface{} {
+	p := map[string]interface{}{}
+	p["name"] = dt.DatabaseAccountName
+	p["kind"] = kind
+
+	filters := []string{}
+
+	if pp.IPFilterRules != nil {
+		allowAzure := strings.ToLower(pp.IPFilterRules.AllowPortal)
+		allowPortal := strings.ToLower(pp.IPFilterRules.AllowPortal)
+		if allowAzure != "disable" {
+			filters = append(filters, "0.0.0.0")
+		} else if allowPortal != "disable" {
+			// Azure Portal IP Addresses per:
+			// https://aka.ms/Vwxndo
+			//|| Region            || IP address(es) ||
+			//||=====================================||
+			//|| China             || 139.217.8.252  ||
+			//||===================||================||
+			//|| Germany           || 51.4.229.218   ||
+			//||===================||================||
+			//|| US Gov            || 52.244.48.71   ||
+			//||===================||================||
+			//|| All other regions || 104.42.195.92  ||
+			//||                   || 40.76.54.131   ||
+			//||                   || 52.176.6.30    ||
+			//||                   || 52.169.50.45   ||
+			//||                   || 52.187.184.26  ||
+			//=======================================||
+			// Given that we don't really have context of the cloud
+			// we are provisioning with right now, use all of the above
+			// addresses.
+			filters = append(filters,
+				"104.42.195.92",
+				"40.76.54.131",
+				"52.176.6.30",
+				"52.169.50.45",
+				"52.187.184.26",
+				"51.4.229.218",
+				"139.217.8.252",
+				"52.244.48.71",
+			)
+		}
+		filters = append(filters, pp.IPFilterRules.Filters...)
+	} else {
+		filters = append(filters, "0.0.0.0")
+	}
+	if len(filters) > 0 {
+		p["ipFilters"] = strings.Join(filters, ",")
+	}
+	return p
+}
+
+func (s *sqlAllInOneManager) deployARMTemplate(
+	ctx context.Context,
+	instance service.Instance,
+) (service.InstanceDetails, service.SecureInstanceDetails, error) {
+
+	pp := &provisioningParameters{}
+	if err :=
+		service.GetStructFromMap(instance.ProvisioningParameters, pp); err != nil {
+		return nil, nil, err
+	}
+
+	dt := &sqlAllInOneInstanceDetails{}
+	if err := service.GetStructFromMap(instance.Details, &dt); err != nil {
+		return nil, nil, err
+	}
+
+	p := s.buildGoTemplateParams(pp, dt, "GlobalDocumentDB")
+	if instance.Tags == nil {
+		instance.Tags = make(map[string]string)
+	}
+
+	outputs, err := s.armDeployer.Deploy(
+		dt.ARMDeploymentName,
+		instance.ResourceGroup,
+		instance.Location,
+		armTemplateBytes,
+		p, // Go template params
+		map[string]interface{}{},
+		instance.Tags,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error deploying ARM template: %s", err)
+	}
+
+	var ok bool
+	dt.FullyQualifiedDomainName, ok = outputs["fullyQualifiedDomainName"].(string)
+	if !ok {
+		return nil, nil, fmt.Errorf(
+			"error retrieving fully qualified domain name from deployment: %s",
+			err,
+		)
+	}
+
+	primaryKey, ok := outputs["primaryKey"].(string)
+	if !ok {
+		return nil, nil, fmt.Errorf(
+			"error retrieving primary key from deployment: %s",
+			err,
+		)
+	}
+
+	sdt := cosmosdbSecureInstanceDetails{
+		PrimaryKey: primaryKey,
+	}
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("error deploying ARM template: %s", err)
+	}
+
+	sdt.ConnectionString = fmt.Sprintf("AccountEndpoint=%s;AccountKey=%s;",
+		dt.FullyQualifiedDomainName,
+		sdt.PrimaryKey,
+	)
+
+	dtMap, err := service.GetMapFromStruct(dt)
+	if err != nil {
+		return nil, nil, err
+	}
+	sdtMap, err := service.GetMapFromStruct(sdt)
+	return dtMap, sdtMap, err
+}
+
+func (s *sqlAllInOneManager) createDatabase(
+	ctx context.Context,
+	instance service.Instance,
+) (service.InstanceDetails, service.SecureInstanceDetails, error) {
+	dt := &sqlAllInOneInstanceDetails{}
+	err := service.GetStructFromMap(instance.Details, &dt)
+	if err != nil {
+		fmt.Printf("Failed to get DT Struct from Map %s", err)
+		return nil, nil, err
+	}
+
+	sdt := &cosmosdbSecureInstanceDetails{}
+	err = service.GetStructFromMap(instance.SecureDetails, &sdt)
+	if err != nil {
+		fmt.Printf("Failed to get SDT Struct from Map %s", err)
+		return nil, nil, err
+	}
+	err = createDatabase(dt.DatabaseAccountName, dt.DatabaseName, sdt.PrimaryKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	return instance.Details, instance.SecureDetails, nil
+}

--- a/pkg/services/cosmosdb/sql-all-in-one-provision.go
+++ b/pkg/services/cosmosdb/sql-all-in-one-provision.go
@@ -46,7 +46,10 @@ func (s *sqlAllInOneManager) deployARMTemplate(
 		return nil, nil, err
 	}
 
-	p, err := s.cosmosAccountManager.buildGoTemplateParams(instance, "GlobalDocumentDB")
+	p, err := s.cosmosAccountManager.buildGoTemplateParams(
+		instance,
+		"GlobalDocumentDB",
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -73,7 +76,7 @@ func (s *sqlAllInOneManager) deployARMTemplate(
 }
 
 func (s *sqlAllInOneManager) createDatabase(
-	ctx context.Context,
+	_ context.Context,
 	instance service.Instance,
 ) (service.InstanceDetails, service.SecureInstanceDetails, error) {
 	dt := &sqlAllInOneInstanceDetails{}

--- a/pkg/services/cosmosdb/sql-all-in-one-provision.go
+++ b/pkg/services/cosmosdb/sql-all-in-one-provision.go
@@ -3,7 +3,6 @@ package cosmosdb
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 	uuid "github.com/satori/go.uuid"
@@ -32,63 +31,6 @@ func (s *sqlAllInOneManager) preProvision(
 	return dtMap, nil, err
 }
 
-func (s *sqlAllInOneManager) buildGoTemplateParams(
-	pp *provisioningParameters,
-	dt *sqlAllInOneInstanceDetails,
-	kind string,
-) map[string]interface{} {
-	p := map[string]interface{}{}
-	p["name"] = dt.DatabaseAccountName
-	p["kind"] = kind
-
-	filters := []string{}
-
-	if pp.IPFilterRules != nil {
-		allowAzure := strings.ToLower(pp.IPFilterRules.AllowPortal)
-		allowPortal := strings.ToLower(pp.IPFilterRules.AllowPortal)
-		if allowAzure != "disable" {
-			filters = append(filters, "0.0.0.0")
-		} else if allowPortal != "disable" {
-			// Azure Portal IP Addresses per:
-			// https://aka.ms/Vwxndo
-			//|| Region            || IP address(es) ||
-			//||=====================================||
-			//|| China             || 139.217.8.252  ||
-			//||===================||================||
-			//|| Germany           || 51.4.229.218   ||
-			//||===================||================||
-			//|| US Gov            || 52.244.48.71   ||
-			//||===================||================||
-			//|| All other regions || 104.42.195.92  ||
-			//||                   || 40.76.54.131   ||
-			//||                   || 52.176.6.30    ||
-			//||                   || 52.169.50.45   ||
-			//||                   || 52.187.184.26  ||
-			//=======================================||
-			// Given that we don't really have context of the cloud
-			// we are provisioning with right now, use all of the above
-			// addresses.
-			filters = append(filters,
-				"104.42.195.92",
-				"40.76.54.131",
-				"52.176.6.30",
-				"52.169.50.45",
-				"52.187.184.26",
-				"51.4.229.218",
-				"139.217.8.252",
-				"52.244.48.71",
-			)
-		}
-		filters = append(filters, pp.IPFilterRules.Filters...)
-	} else {
-		filters = append(filters, "0.0.0.0")
-	}
-	if len(filters) > 0 {
-		p["ipFilters"] = strings.Join(filters, ",")
-	}
-	return p
-}
-
 func (s *sqlAllInOneManager) deployARMTemplate(
 	ctx context.Context,
 	instance service.Instance,
@@ -99,55 +41,24 @@ func (s *sqlAllInOneManager) deployARMTemplate(
 		service.GetStructFromMap(instance.ProvisioningParameters, pp); err != nil {
 		return nil, nil, err
 	}
-
 	dt := &sqlAllInOneInstanceDetails{}
 	if err := service.GetStructFromMap(instance.Details, &dt); err != nil {
 		return nil, nil, err
 	}
 
-	p := s.buildGoTemplateParams(pp, dt, "GlobalDocumentDB")
+	p, err := s.cosmosAccountManager.buildGoTemplateParams(instance, "GlobalDocumentDB")
+	if err != nil {
+		return nil, nil, err
+	}
 	if instance.Tags == nil {
 		instance.Tags = make(map[string]string)
 	}
 
-	outputs, err := s.armDeployer.Deploy(
-		dt.ARMDeploymentName,
-		instance.ResourceGroup,
-		instance.Location,
-		armTemplateBytes,
-		p, // Go template params
-		map[string]interface{}{},
-		instance.Tags,
-	)
+	fqdn, sdt, err := s.cosmosAccountManager.deployARMTemplate(ctx, instance, p)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error deploying ARM template: %s", err)
 	}
-
-	var ok bool
-	dt.FullyQualifiedDomainName, ok = outputs["fullyQualifiedDomainName"].(string)
-	if !ok {
-		return nil, nil, fmt.Errorf(
-			"error retrieving fully qualified domain name from deployment: %s",
-			err,
-		)
-	}
-
-	primaryKey, ok := outputs["primaryKey"].(string)
-	if !ok {
-		return nil, nil, fmt.Errorf(
-			"error retrieving primary key from deployment: %s",
-			err,
-		)
-	}
-
-	sdt := cosmosdbSecureInstanceDetails{
-		PrimaryKey: primaryKey,
-	}
-
-	if err != nil {
-		return nil, nil, fmt.Errorf("error deploying ARM template: %s", err)
-	}
-
+	dt.FullyQualifiedDomainName = fqdn
 	sdt.ConnectionString = fmt.Sprintf("AccountEndpoint=%s;AccountKey=%s;",
 		dt.FullyQualifiedDomainName,
 		sdt.PrimaryKey,
@@ -171,7 +82,6 @@ func (s *sqlAllInOneManager) createDatabase(
 		fmt.Printf("Failed to get DT Struct from Map %s", err)
 		return nil, nil, err
 	}
-
 	sdt := &cosmosdbSecureInstanceDetails{}
 	err = service.GetStructFromMap(instance.SecureDetails, &sdt)
 	if err != nil {

--- a/pkg/services/cosmosdb/sql-all-in-one-types.go
+++ b/pkg/services/cosmosdb/sql-all-in-one-types.go
@@ -8,50 +8,8 @@ func (
 	s *sqlAllInOneManager,
 ) getProvisionParametersSchema() map[string]service.ParameterSchema {
 	p := s.cosmosAccountManager.getProvisionParametersSchema()
-
-	p["storageCapacity"] = &service.SimpleParameterSchema{
-		Type: "string",
-		Description: "Represents the maximum storage size of the collection." +
-			" Can be either `fixed` (10 GB) or `unlimited`. If unspecified " +
-			"defaults to `unlimited`",
-		AllowedValues: []string{"", "fixed", "unlimited"},
-		Default:       "unlimited",
-	}
-
-	p["partitionKey"] = &service.SimpleParameterSchema{
-		Type: "string",
-		Description: "The Partition Key is used to automatically partition" +
-			"data among multiple servers for scalability. Choose a JSON" +
-			" property name that has a wide range of values and is likely" +
-			"  to have evenly distributed access patterns. Required if" +
-			" storage is unlimited. Otherwise ignored.",
-	}
-
-	p["throughput"] = &service.SimpleParameterSchema{
-		Type: "integer",
-		Description: "Each collection can be provisioned throughput in " +
-			"Request Units per second (RU/s). 1 RU corresponds to the " +
-			"throughput of a read of a 1 KB document. Maximum value is ",
-	}
-
-	p["uniqueKeys"] = &service.ArrayParameterSchema{
-		ItemsSchema: &service.SimpleParameterSchema{
-			Type: "string",
-		},
-		Description: "Unique keys provide developers with the ability to " +
-			"add a layer of data integrity to their database. By creating a " +
-			"unique key policy when a container is created, you ensure the " +
-			"uniqueness of one or more values per partition key.",
-	}
 	return p
 }
-
-// type cosmosdbInstanceDetails struct {
-// 	ARMDeploymentName        string `json:"armDeployment"`
-// 	DatabaseAccountName      string `json:"name"`
-// 	FullyQualifiedDomainName string `json:"fullyQualifiedDomainName"`
-// 	IPFilters                string `json:"ipFilters"`
-// }
 
 type sqlAllInOneInstanceDetails struct {
 	ARMDeploymentName        string `json:"armDeployment"`
@@ -68,7 +26,7 @@ type sqlAPICredentials struct {
 	PrimaryConnectionString string `json:"primaryConnectionString,omitempty"`
 	PrimaryKey              string `json:"primaryKey,omitempty"`
 	DatabaseName            string `json:"databaseName"`
-	DatabaseID              string `json:"documentdb_database_id"`
+	DatabaseID              string `json:"documentdb_database_id"` //The Azure Spring Library looks for these
 	Host                    string `json:"documentdb_host_endpoint"`
 	MasterKey               string `json:"documentdb_master_key"`
 }

--- a/pkg/services/cosmosdb/sql-all-in-one-types.go
+++ b/pkg/services/cosmosdb/sql-all-in-one-types.go
@@ -1,0 +1,78 @@
+package cosmosdb
+
+import (
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+)
+
+func (
+	s *sqlAllInOneManager,
+) getProvisionParametersSchema() map[string]service.ParameterSchema {
+	p := s.cosmosAccountManager.getProvisionParametersSchema()
+
+	p["storageCapacity"] = &service.SimpleParameterSchema{
+		Type: "string",
+		Description: "Represents the maximum storage size of the collection." +
+			" Can be either `fixed` (10 GB) or `unlimited`. If unspecified " +
+			"defaults to `unlimited`",
+		AllowedValues: []string{"", "fixed", "unlimited"},
+		Default:       "unlimited",
+	}
+
+	p["partitionKey"] = &service.SimpleParameterSchema{
+		Type: "string",
+		Description: "The Partition Key is used to automatically partition" +
+			"data among multiple servers for scalability. Choose a JSON" +
+			" property name that has a wide range of values and is likely" +
+			"  to have evenly distributed access patterns. Required if" +
+			" storage is unlimited. Otherwise ignored.",
+	}
+
+	p["throughput"] = &service.SimpleParameterSchema{
+		Type: "integer",
+		Description: "Each collection can be provisioned throughput in " +
+			"Request Units per second (RU/s). 1 RU corresponds to the " +
+			"throughput of a read of a 1 KB document. Maximum value is ",
+	}
+
+	p["uniqueKeys"] = &service.ArrayParameterSchema{
+		ItemsSchema: &service.SimpleParameterSchema{
+			Type: "string",
+		},
+		Description: "Unique keys provide developers with the ability to " +
+			"add a layer of data integrity to their database. By creating a " +
+			"unique key policy when a container is created, you ensure the " +
+			"uniqueness of one or more values per partition key.",
+	}
+	return p
+}
+
+// type cosmosdbInstanceDetails struct {
+// 	ARMDeploymentName        string `json:"armDeployment"`
+// 	DatabaseAccountName      string `json:"name"`
+// 	FullyQualifiedDomainName string `json:"fullyQualifiedDomainName"`
+// 	IPFilters                string `json:"ipFilters"`
+// }
+
+type sqlAllInOneInstanceDetails struct {
+	ARMDeploymentName        string `json:"armDeployment"`
+	DatabaseAccountName      string `json:"name"`
+	FullyQualifiedDomainName string `json:"fullyQualifiedDomainName"`
+	IPFilters                string `json:"ipFilters"`
+	DatabaseName             string `json:"databaseName"`
+}
+
+// cosmosCredentials encapsulates CosmosDB-specific details for connecting via
+// a variety of APIs. This excludes MongoDB.
+type sqlAPICredentials struct {
+	URI                     string `json:"uri,omitempty"`
+	PrimaryConnectionString string `json:"primaryConnectionString,omitempty"`
+	PrimaryKey              string `json:"primaryKey,omitempty"`
+	DatabaseName            string `json:"databaseName"`
+	DatabaseID              string `json:"documentdb_database_id"`
+	Host                    string `json:"documentdb_host_endpoint"`
+	MasterKey               string `json:"documentdb_master_key"`
+}
+
+type databaseCreationRequest struct {
+	ID string `json:"id"`
+}

--- a/pkg/services/cosmosdb/sql-all-in-one-types.go
+++ b/pkg/services/cosmosdb/sql-all-in-one-types.go
@@ -26,7 +26,7 @@ type sqlAPICredentials struct {
 	PrimaryConnectionString string `json:"primaryConnectionString,omitempty"`
 	PrimaryKey              string `json:"primaryKey,omitempty"`
 	DatabaseName            string `json:"databaseName"`
-	DatabaseID              string `json:"documentdb_database_id"` //The Azure Spring Library looks for these
+	DatabaseID              string `json:"documentdb_database_id"`
 	Host                    string `json:"documentdb_host_endpoint"`
 	MasterKey               string `json:"documentdb_master_key"`
 }

--- a/pkg/services/cosmosdb/sql-database-only-bind.go
+++ b/pkg/services/cosmosdb/sql-database-only-bind.go
@@ -17,7 +17,10 @@ func (s *sqlDatabaseManager) GetCredentials(
 		return nil, err
 	}
 	psdt := cosmosdbSecureInstanceDetails{}
-	if err := service.GetStructFromMap(instance.Parent.SecureDetails, &psdt); err != nil {
+	if err := service.GetStructFromMap(
+		instance.Parent.SecureDetails,
+		&psdt,
+	); err != nil {
 		return nil, err
 	}
 	return sqlAPICredentials{

--- a/pkg/services/cosmosdb/sql-database-only-bind.go
+++ b/pkg/services/cosmosdb/sql-database-only-bind.go
@@ -1,0 +1,32 @@
+package cosmosdb
+
+import (
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+)
+
+func (s *sqlDatabaseManager) GetCredentials(
+	instance service.Instance,
+	_ service.Binding,
+) (service.Credentials, error) {
+	dt := sqlDatabaseOnlyInstanceDetails{}
+	if err := service.GetStructFromMap(instance.Details, &dt); err != nil {
+		return nil, err
+	}
+	pdt := cosmosdbInstanceDetails{}
+	if err := service.GetStructFromMap(instance.Details, &pdt); err != nil {
+		return nil, err
+	}
+	psdt := cosmosdbSecureInstanceDetails{}
+	if err := service.GetStructFromMap(instance.Parent.SecureDetails, &psdt); err != nil {
+		return nil, err
+	}
+	return sqlAPICredentials{
+		URI:                     pdt.FullyQualifiedDomainName,
+		PrimaryKey:              psdt.PrimaryKey,
+		PrimaryConnectionString: psdt.ConnectionString,
+		DatabaseName:            dt.DatabaseName,
+		DatabaseID:              dt.DatabaseName,
+		Host:                    pdt.FullyQualifiedDomainName,
+		MasterKey:               psdt.PrimaryKey,
+	}, nil
+}

--- a/pkg/services/cosmosdb/sql-database-only-deprovision.go
+++ b/pkg/services/cosmosdb/sql-database-only-deprovision.go
@@ -1,0 +1,47 @@
+package cosmosdb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+)
+
+func (s *sqlDatabaseManager) GetDeprovisioner(
+	service.Plan,
+) (service.Deprovisioner, error) {
+	return service.NewDeprovisioner(
+		service.NewDeprovisioningStep("deleteDatabase", s.deleteDatabase),
+	)
+}
+
+func (s *sqlDatabaseManager) deleteDatabase(
+	_ context.Context,
+	instance service.Instance,
+) (service.InstanceDetails, service.SecureInstanceDetails, error) {
+	dt := &sqlDatabaseOnlyInstanceDetails{}
+	err := service.GetStructFromMap(instance.Details, &dt)
+	if err != nil {
+		fmt.Printf("Failed to get DT Struct from Map %s", err)
+		return nil, nil, err
+	}
+
+	pdt := &cosmosdbInstanceDetails{}
+	err = service.GetStructFromMap(instance.Parent.Details, &pdt)
+	if err != nil {
+		fmt.Printf("Failed to get PDT Struct from Map %s", err)
+		return nil, nil, err
+	}
+
+	psdt := &cosmosdbSecureInstanceDetails{}
+	err = service.GetStructFromMap(instance.Parent.SecureDetails, &psdt)
+	if err != nil {
+		fmt.Printf("Failed to get SDT Struct from Map %s", err)
+		return nil, nil, err
+	}
+	err = deleteDatabase(pdt.DatabaseAccountName, dt.DatabaseName, psdt.PrimaryKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	return instance.Details, instance.SecureDetails, nil
+}

--- a/pkg/services/cosmosdb/sql-database-only-provision.go
+++ b/pkg/services/cosmosdb/sql-database-only-provision.go
@@ -19,7 +19,7 @@ func (s *sqlDatabaseManager) GetProvisioner(
 
 func (s *sqlDatabaseManager) preProvision(
 	_ context.Context,
-	instance service.Instance,
+	_ service.Instance,
 ) (service.InstanceDetails, service.SecureInstanceDetails, error) {
 	dt := sqlDatabaseOnlyInstanceDetails{
 		DatabaseName: uuid.NewV4().String(),

--- a/pkg/services/cosmosdb/sql-database-only-provision.go
+++ b/pkg/services/cosmosdb/sql-database-only-provision.go
@@ -29,7 +29,7 @@ func (s *sqlDatabaseManager) preProvision(
 }
 
 func (s *sqlDatabaseManager) createDatabase(
-	ctx context.Context,
+	_ context.Context,
 	instance service.Instance,
 ) (service.InstanceDetails, service.SecureInstanceDetails, error) {
 	dt := &sqlDatabaseOnlyInstanceDetails{}

--- a/pkg/services/cosmosdb/sql-database-only-provision.go
+++ b/pkg/services/cosmosdb/sql-database-only-provision.go
@@ -21,7 +21,7 @@ func (s *sqlDatabaseManager) preProvision(
 	_ context.Context,
 	instance service.Instance,
 ) (service.InstanceDetails, service.SecureInstanceDetails, error) {
-	dt := sqlAllInOneInstanceDetails{
+	dt := sqlDatabaseOnlyInstanceDetails{
 		DatabaseName: uuid.NewV4().String(),
 	}
 	dtMap, err := service.GetMapFromStruct(dt)

--- a/pkg/services/cosmosdb/sql-database-only-provision.go
+++ b/pkg/services/cosmosdb/sql-database-only-provision.go
@@ -1,0 +1,60 @@
+package cosmosdb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+	uuid "github.com/satori/go.uuid"
+)
+
+func (s *sqlDatabaseManager) GetProvisioner(
+	service.Plan,
+) (service.Provisioner, error) {
+	return service.NewProvisioner(
+		service.NewProvisioningStep("preProvision", s.preProvision),
+		service.NewProvisioningStep("createDatabase", s.createDatabase),
+	)
+}
+
+func (s *sqlDatabaseManager) preProvision(
+	_ context.Context,
+	instance service.Instance,
+) (service.InstanceDetails, service.SecureInstanceDetails, error) {
+	dt := sqlAllInOneInstanceDetails{
+		DatabaseName: uuid.NewV4().String(),
+	}
+	dtMap, err := service.GetMapFromStruct(dt)
+	return dtMap, nil, err
+}
+
+func (s *sqlDatabaseManager) createDatabase(
+	ctx context.Context,
+	instance service.Instance,
+) (service.InstanceDetails, service.SecureInstanceDetails, error) {
+	dt := &sqlDatabaseOnlyInstanceDetails{}
+	err := service.GetStructFromMap(instance.Details, &dt)
+	if err != nil {
+		fmt.Printf("Failed to get DT Struct from Map %s", err)
+		return nil, nil, err
+	}
+
+	pdt := &cosmosdbInstanceDetails{}
+	err = service.GetStructFromMap(instance.Parent.Details, &pdt)
+	if err != nil {
+		fmt.Printf("Failed to get PDT Struct from Map %s", err)
+		return nil, nil, err
+	}
+
+	psdt := &cosmosdbSecureInstanceDetails{}
+	err = service.GetStructFromMap(instance.Parent.SecureDetails, &psdt)
+	if err != nil {
+		fmt.Printf("Failed to get SDT Struct from Map %s", err)
+		return nil, nil, err
+	}
+	err = createDatabase(pdt.DatabaseAccountName, dt.DatabaseName, psdt.PrimaryKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	return instance.Details, instance.SecureDetails, nil
+}

--- a/pkg/services/cosmosdb/sql-database-only-types.go
+++ b/pkg/services/cosmosdb/sql-database-only-types.go
@@ -1,0 +1,5 @@
+package cosmosdb
+
+type sqlDatabaseOnlyInstanceDetails struct {
+	DatabaseName string `json:"databaseName"`
+}

--- a/pkg/services/cosmosdb/table-api-provision.go
+++ b/pkg/services/cosmosdb/table-api-provision.go
@@ -32,14 +32,17 @@ func (t *tableAccountManager) deployARMTemplate(
 		return nil, nil, err
 	}
 
-	p := t.buildGoTemplateParams(pp, dt, "GlobalDocumentDB")
+	p, err := t.buildGoTemplateParams(instance, "GlobalDocumentDB")
+	if err != nil {
+		return nil, nil, err
+	}
 	p["capability"] = "EnableTable"
 	if instance.Tags == nil {
 		instance.Tags = make(map[string]string)
 	}
 	instance.Tags["defaultExperience"] = "Table"
 
-	dt, sdt, err := t.cosmosAccountManager.deployARMTemplate(
+	fqdn, sdt, err := t.cosmosAccountManager.deployARMTemplate(
 		ctx,
 		instance,
 		p,
@@ -49,6 +52,7 @@ func (t *tableAccountManager) deployARMTemplate(
 		return nil, nil, fmt.Errorf("error deploying ARM template: %s", err)
 	}
 
+	dt.FullyQualifiedDomainName = fqdn
 	sdt.ConnectionString = fmt.Sprintf(
 		"DefaultEndpointsProtocol=https;AccountName=%s;"+
 			"AccountKey=%s;TableEndpoint=%s",

--- a/tests/lifecycle/cosmosdb_cases_test.go
+++ b/tests/lifecycle/cosmosdb_cases_test.go
@@ -16,22 +16,35 @@ import (
 var cosmosdbTestCases = []serviceLifecycleTestCase{
 	{ // SQL API
 		group:     "cosmosdb",
-		name:      "sql-api",
+		name:      "sql-api-account-only",
 		serviceID: "6330de6f-a561-43ea-a15e-b99f44d183e6",
 		planID:    "71168d1a-c704-49ff-8c79-214dd3d6f8eb",
 		provisioningParameters: service.CombinedProvisioningParameters{
+			"alias": "cosmos-account",
 			"ipFilters": map[string]interface{}{
 				"allowedIPRanges": []string{"0.0.0.0/0"},
 			},
 		},
 		location: "eastus",
+		childTestCases: []*serviceLifecycleTestCase{
+			{ // database only scenario
+				group:     "cosmosdb",
+				name:      "database-only",
+				serviceID: "87c5132a-6d76-40c6-9621-0c7b7542571b",
+				planID:    "c821c68c-c8e0-4176-8cf2-f0ca582a07a3",
+				location:  "", // This is actually irrelevant for this test
+				provisioningParameters: service.CombinedProvisioningParameters{
+					"parentAlias": "cosmos-account",
+				},
+			},
+		},
 	},
 	{ // Graph API
 		group:     "cosmosdb",
-		name:      "graph-api",
+		name:      "graph-api-account-only",
 		serviceID: "5f5252a0-6922-4a0c-a755-f9be70d7c79b",
 		planID:    "126a2c47-11a3-49b1-833a-21b563de6c04",
-		location:  "southcentralus",
+		location:  "eastus",
 		provisioningParameters: service.CombinedProvisioningParameters{
 			"ipFilters": map[string]interface{}{
 				"allowedIPRanges": []string{"0.0.0.0/0"},
@@ -47,7 +60,7 @@ var cosmosdbTestCases = []serviceLifecycleTestCase{
 	},
 	{ // Table API
 		group:     "cosmosdb",
-		name:      "table-api",
+		name:      "table-api-account-only",
 		serviceID: "37915cad-5259-470d-a7aa-207ba89ada8c",
 		planID:    "c970b1e8-794f-4d7c-9458-d28423c08856",
 		location:  "southcentralus",
@@ -59,16 +72,28 @@ var cosmosdbTestCases = []serviceLifecycleTestCase{
 	},
 	{ // MongoDB
 		group:           "cosmosdb",
-		name:            "mongo-api",
+		name:            "mongo-api-account-only",
 		serviceID:       "8797a079-5346-4e84-8018-b7d5ea5c0e3a",
 		planID:          "86fdda05-78d7-4026-a443-1325928e7b02",
-		location:        "southcentralus",
+		location:        "centralus",
 		testCredentials: testMongoDBCreds,
 		provisioningParameters: service.CombinedProvisioningParameters{
 			"ipFilters": map[string]interface{}{
 				"allowedIPRanges": []string{"0.0.0.0/0"},
 			},
 		},
+	},
+	{ // SQL API All In One
+		group:     "cosmosdb",
+		name:      "sql-api-all-in-one",
+		serviceID: "58d9fbbd-7041-4dbe-aabe-6268cd31de84",
+		planID:    "58d7223d-934e-4fb5-a046-0c67781eb24e",
+		provisioningParameters: service.CombinedProvisioningParameters{
+			"ipFilters": map[string]interface{}{
+				"allowedIPRanges": []string{"0.0.0.0/0"},
+			},
+		},
+		location: "eastus",
 	},
 }
 

--- a/tests/lifecycle/cosmosdb_cases_test.go
+++ b/tests/lifecycle/cosmosdb_cases_test.go
@@ -75,7 +75,7 @@ var cosmosdbTestCases = []serviceLifecycleTestCase{
 		name:            "mongo-api-account-only",
 		serviceID:       "8797a079-5346-4e84-8018-b7d5ea5c0e3a",
 		planID:          "86fdda05-78d7-4026-a443-1325928e7b02",
-		location:        "centralus",
+		location:        "eastus",
 		testCredentials: testMongoDBCreds,
 		provisioningParameters: service.CombinedProvisioningParameters{
 			"ipFilters": map[string]interface{}{


### PR DESCRIPTION
This PR introduces the needed logic and changes to allow the user to provision
the equivalent of an All-In-One CosmosDB instance: a database account and
a database. This is functionally equivalent to what MASB did, but follows
the OSBA pattern of not allowing the user to name things.

Note, the CosmosDB capabilities to create and delete a database is not exposed via the azure-go-sdk, so I needed to implement that purely with REST API invocations. This includes the very specific authentication scheme that they use. When there is a Go SDK for this, I'd like to refactor this to utilize that instead of this hand crafted approach. This updates the existing contrib examples to use the new database service and plan. 

Closes: #259