### PR TITLE
run lint checks in serial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,7 @@ else
 endif
 	
 LINT_CMD := gometalinter ./... \
+	--concurrency=1 \
 	--disable-all \
 	--enable gofmt \
 	--enable vet \


### PR DESCRIPTION
Making lint checks run in serial (they used to run with `concurrency=2`). Doing this because at least one of the many linters seems to be really greedy with memory and, according to container stats I have looked at locally, is consuming as much as 2.4GB all on its own. The observable problem with this is lint checks experiencing OOM failures as in this case: https://circleci.com/gh/Azure/open-service-broker-azure/4013?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

This PR should unblock some others that are failing on lint checks that encounter OOM.