### PR TITLE
Removing references to setting min stability in the docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ Use [Helm](https://helm.sh) to install Open Service Broker for Azure onto your K
 cluster. Refer to the OSBA [Helm chart](https://github.com/Azure/open-service-broker-azure/tree/master/contrib/k8s/charts/open-service-broker-azure)
 for details on how to complete the installation.
 
-By default, the Helm chart will install OSBA with the flag `modules.minStability` set to `preview`. This will limit the services exposed by OSBA to Azure SQL, Azure Database for MySQL, and Azure Database for PostgreSQL. If you'd like to use other services, you'll need to provide `experimental` for that setting. This will instruct OSBA to include modules that are marked as `experimental` in the catalog. For more information on module stability, please refer to the [documentation](docs/stability.md). The offical [roadmap](docs/roadmap.md) has more information about the OSAB roadmap and plans to promote modules.
-
 #### OpenShift Project Template
 
 Deploy OSBA using a OpenShift Project Template

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -27,19 +27,6 @@ After checking on the health of the kube-system pods, kube-dns was not working. 
 to be unable to connect to its Redis instance. The problem was resolved by deleting the
 kube-dns pods, so that Kubernetes would recreate them.
 
-### I don't see all the services
-
-Open Service Broker for Azure provides a number of services and each of these services is implemented by a separate module. The stability of individual modules is independent of overall broker stability and is ranked on a scale of `experimental`, `preview`, and `stable`. The broker can be configured to only load modules at or above a specified stability threshold. By default, the helm chart configures the broker to only load modules that are marked as `preview` or `stable`. This currently includes Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database. If you would like to use other services, you will need to add an additional flag to your helm install command:
-
-```console
-helm install azure/open-service-broker-azure --name osba --namespace osba \
-  --set azure.subscriptionId=$AZURE_SUBSCRIPTION_ID \
-  --set azure.tenantId=$AZURE_TENANT_ID \
-  --set azure.clientId=$AZURE_CLIENT_ID \
-  --set azure.clientSecret=$AZURE_CLIENT_SECRET \
-  --set modules.minStability=EXPERIMENTAL
-```
-
 ## "osba" is forbidden: not yet ready to handle request
 
 [Service Catalog](https://github.com/kubernetes-incubator/service-catalog) is the software component that is used to integrate Open Service Broker for Azure with Kubernetes clusters. Service Catalog currently works with Kubernetes version 1.9.0 and higher, so you will need a Kubernetes cluster that is version 1.9.0 or higher. If you receive this error message when trying to install Open Service Broker For Azure, check the version of your Kubernetes cluster. If you are running a version less than 1.9.0, please upgrade. If you are making a new cluster with AKS, you can specify the version with the `--kubernetes-version` flag like so:

--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -201,11 +201,6 @@ You should also ensure that the `Microsoft.Compute` and `Microsoft.Network` prov
 
 1. Deploy Open Service Broker for Azure on the cluster:
 
-    **Note**
-    Open Service Broker for Azure provides a number of services and each of these services is implemented by a separate module. The stability of individual modules is independent of overall broker stability and is ranked on a scale of `experimental`, `preview`, and `stable`. The broker can be configured to only load modules at or above a specified stability threshold. By default, the helm chart configures the broker to only load modules that are marked as `preview` or `stable`. This currently includes Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database. 
-
-    To install OSBA with only `preview` and `stable` services, use the following command. If you'd like to use all of the services available, including those marked experimental, change the `--set modules.minStability` flag to `--set modules.minStability=EXPERIMENTAL`
-
     **Bash**
     ```console
     helm repo add azure https://kubernetescharts.blob.core.windows.net/azure
@@ -213,8 +208,7 @@ You should also ensure that the `Microsoft.Compute` and `Microsoft.Network` prov
       --set azure.subscriptionId=$AZURE_SUBSCRIPTION_ID \
       --set azure.tenantId=$AZURE_TENANT_ID \
       --set azure.clientId=$AZURE_CLIENT_ID \
-      --set azure.clientSecret=$AZURE_CLIENT_SECRET \
-      --set modules.minStability=PREVIEW
+      --set azure.clientSecret=$AZURE_CLIENT_SECRET
     ```
 
     **PowerShell**
@@ -224,8 +218,7 @@ You should also ensure that the `Microsoft.Compute` and `Microsoft.Network` prov
       --set azure.subscriptionId=$env:AZURE_SUBSCRIPTION_ID `
       --set azure.tenantId=$env:AZURE_TENANT_ID `
       --set azure.clientId=$env:AZURE_CLIENT_ID `
-      --set azure.clientSecret=$env:AZURE_CLIENT_SECRET `
-      --set modules.minStability=PREVIEW
+      --set azure.clientSecret=$env:AZURE_CLIENT_SECRET
     ```
 
   

--- a/docs/quickstart-minikube.md
+++ b/docs/quickstart-minikube.md
@@ -214,11 +214,6 @@ Next we will create a local cluster using Minikube. You can also [try OSBA on th
     ```
 1. Deploy Open Service Broker for Azure on the cluster:
 
-   **Note**
-    Open Service Broker for Azure provides a number of services and each of these services is implemented by a separate module. The stability of individual modules is independent of overall broker stability and is ranked on a scale of `experimental`, `preview`, and `stable`. The broker can be configured to only load modules at or above a specified stability threshold. By default, the helm chart configures the broker to only load modules that are marked as `preview` or `stable`. This currently includes Azure Database for MySQL, Azure Database for PostgreSQL and Azure SQL Database.
-
-    To install OSBA with only `preview` and `stable` services, use the following command. If you'd like to use all of the services available, including those marked experimental, change the `--set modules.minStability` flag to `--set modules.minStability=EXPERIMENTAL`
-
     **Bash**
     ```console
     helm repo add azure https://kubernetescharts.blob.core.windows.net/azure
@@ -226,8 +221,7 @@ Next we will create a local cluster using Minikube. You can also [try OSBA on th
       --set azure.subscriptionId=$AZURE_SUBSCRIPTION_ID \
       --set azure.tenantId=$AZURE_TENANT_ID \
       --set azure.clientId=$AZURE_CLIENT_ID \
-      --set azure.clientSecret=$AZURE_CLIENT_SECRET \
-      --set modules.minStability=PREVIEW
+      --set azure.clientSecret=$AZURE_CLIENT_SECRET 
     ```
 
     **PowerShell**
@@ -237,8 +231,7 @@ Next we will create a local cluster using Minikube. You can also [try OSBA on th
       --set azure.subscriptionId=$env:AZURE_SUBSCRIPTION_ID `
       --set azure.tenantId=$env:AZURE_TENANT_ID `
       --set azure.clientId=$env:AZURE_CLIENT_ID `
-      --set azure.clientSecret=$env:AZURE_CLIENT_SECRET `
-      --set modules.minStability=PREVIEW
+      --set azure.clientSecret=$env:AZURE_CLIENT_SECRET 
     ```
 
 1. Check on the status of Open Service Broker for Azure by running the


### PR DESCRIPTION
We will add this back once we bring back the experimental modules