### PR TITLE
Adding use of Redis SET to store instance and binding ids

### DIFF
--- a/pkg/storage/redis/store_test.go
+++ b/pkg/storage/redis/store_test.go
@@ -57,6 +57,15 @@ func TestWriteInstance(t *testing.T) {
 	// Assert that the instance is now in Redis
 	strCmd = testStore.redisClient.Get(key)
 	assert.Nil(t, strCmd.Err())
+	sCmd := testStore.redisClient.SMembers(instances)
+	assert.Nil(t, strCmd.Err())
+	count, err := sCmd.Result()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(count))
+	boolCmd := testStore.redisClient.SIsMember(instances, key)
+	assert.Nil(t, boolCmd.Err())
+	found, _ := boolCmd.Result()
+	assert.True(t, found)
 }
 
 func TestWriteInstanceWithAlias(t *testing.T) {
@@ -260,6 +269,10 @@ func TestDeleteExistingInstance(t *testing.T) {
 	assert.Nil(t, err)
 	strCmd := testStore.redisClient.Get(key)
 	assert.Equal(t, redis.Nil, strCmd.Err())
+	boolCmd := testStore.redisClient.SIsMember(instances, key)
+	assert.Nil(t, boolCmd.Err())
+	found, _ := boolCmd.Result()
+	assert.False(t, found)
 }
 
 func TestDeleteExistingInstanceWithAlias(t *testing.T) {
@@ -355,6 +368,10 @@ func TestWriteBinding(t *testing.T) {
 	// Assert that the binding is now in Redis
 	strCmd = testStore.redisClient.Get(key)
 	assert.Nil(t, strCmd.Err())
+	boolCmd := testStore.redisClient.SIsMember(bindings, key)
+	assert.Nil(t, boolCmd.Err())
+	found, _ := boolCmd.Result()
+	assert.True(t, found)
 }
 
 func TestGetNonExistingBinding(t *testing.T) {


### PR DESCRIPTION
This will enable us to bulk operate over the set of ids later for
transformation purposes.

Changed write binding and delete binding to use pipelines, then added a step to other method pipelines to add or remove from a set (SAdd, SRem). 