### PR TITLE
Rename CRYPTO_AES256_KEY to AES256_KEY in OpenShift template

### DIFF
--- a/contrib/openshift/osba-os-template.yaml
+++ b/contrib/openshift/osba-os-template.yaml
@@ -171,7 +171,7 @@ objects:
                 secretKeyRef:
                   name: osba-open-service-broker-azure
                   key: redis-password
-            - name: CRYPTO_AES256_KEY
+            - name: AES256_KEY
               valueFrom:
                 secretKeyRef:
                   name: osba-open-service-broker-azure


### PR DESCRIPTION
The environment variable in the OpenShift template was named `CRYPTO_AES256_KEY`, which was causing the deployment of `osba-open-service-broker-azure` to fail.

Per the code this variable should be named `AES256_KEY`:
https://github.com/Azure/open-service-broker-azure/blob/be79faa48d04794538100f3b7b6fc9a40ee04c91/pkg/crypto/aes256/config.go#L12