### PR TITLE
Fixing the build for broker-cli and updating the documentation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ else
 	docker-compose kill test-api-compliance-broker
 	docker-compose rm -f test-api-compliance-broker
 endif
-	
+
 LINT_CMD := gometalinter ./... \
 	--concurrency=1 \
 	--disable-all \
@@ -422,7 +422,7 @@ endif
 CONTRIB_BINARY_DIR := contrib/bin
 CLI_BINARY_NAME := broker-cli
 
-BUILD_CMD := go build -o $(CONTRIB_BINARY_DIR)/$(CLI_BINARY_NAME) ./cmd/cli
+BUILD_CMD := go build -o $(CONTRIB_BINARY_DIR)/$(CLI_BINARY_NAME) ./contrib/cmd/cli
 
 .PHONY: build-broker-cli
 build-broker-cli:
@@ -433,8 +433,8 @@ else
 	--rm \
 	-e GOOS=$(GOOS) \
 	-e GOARCH=$(GOARCH) \
-	-v $$(pwd)/..:/go/src/$(BASE_PACKAGE_NAME) \
-	-w /go/src/$(BASE_PACKAGE_NAME)/contrib \
+	-v $$(pwd):/go/src/$(BASE_PACKAGE_NAME) \
+	-w /go/src/$(BASE_PACKAGE_NAME) \
 	$(DEV_IMAGE) \
 	$(BUILD_CMD)
 endif

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -322,9 +322,9 @@ resuse the binary rather than build it each time it's used.
 This can be accomplished for your chosen OS using the appropriate command from
 the following list:
 
-- Mac OS: `make build-mac-broker-cli`
-- Linux: `make build-linux-broker-cli`
-- Windows: `make build-win-broker-cli`
+- Mac OS: `GOOS=darwin make build-broker-cli`
+- Linux: `GOOS=linux make build-broker-cli`
+- Windows: `GOOS=windows make build-broker-cli`
 
 In all cases, the binary is cross-compiled in the previously-discussed
 containerized development environment for an AMD64 architecture. (If you have


### PR DESCRIPTION
Hi, 
The broker-cli to use to test the local development osba build is broken. Fixing it. 
Let me know if you need to make any changes. 