### PR TITLE
sql instance example is bad

### DIFF
--- a/contrib/k8s/examples/sql/sql-instance.yaml
+++ b/contrib/k8s/examples/sql/sql-instance.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-sql-instance
   namespace: default
 spec:
-  clusterServiceClassExternalName: azure-sql
+  clusterServiceClassExternalName: azure-sql-12-0
   clusterServicePlanExternalName: basic
   parameters:
     location: eastus


### PR DESCRIPTION
The class name in contrib/k8s/examples/sql-instance.yaml did not get updated when we changed class names. This fixes that. 