### PR TITLE
Add TLS support to the broker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,3 @@ ARG BASE_PACKAGE_NAME
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=0 /go/src/$BASE_PACKAGE_NAME/bin/broker /app/broker
 CMD ["/app/broker"]
-EXPOSE 8080

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -178,7 +178,7 @@ func main() {
 	}()
 
 	// Run broker
-	if err := broker.Start(ctx); err != nil {
+	if err := broker.Run(ctx); err != nil {
 		if err == ctx.Err() {
 			// Allow some time for goroutines to shut down
 			time.Sleep(time.Second * 3)

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -140,9 +140,13 @@ func main() {
 		apiFilters.NewAPIVersionFilter(),
 	)
 
+	apiServerConfig, err := api.GetConfigFromEnvironment()
+	if err != nil {
+		log.Fatal(err)
+	}
 	// Create API server
 	apiServer, err := api.NewServer(
-		8080,
+		apiServerConfig,
 		store,
 		asyncEngine,
 		filterChain,

--- a/cmd/broker/broker.go
+++ b/cmd/broker/broker.go
@@ -140,11 +140,23 @@ func main() {
 		apiFilters.NewAPIVersionFilter(),
 	)
 
-	// Create broker
-	broker, err := broker.NewBroker(
+	// Create API server
+	apiServer, err := api.NewServer(
+		8080,
 		store,
 		asyncEngine,
 		filterChain,
+		catalog,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create broker
+	broker, err := broker.NewBroker(
+		apiServer,
+		asyncEngine,
+		store,
 		catalog,
 	)
 	if err != nil {

--- a/cmd/compliance-test-broker/compliance-test-broker.go
+++ b/cmd/compliance-test-broker/compliance-test-broker.go
@@ -36,7 +36,9 @@ func main() {
 	)
 
 	server, err := api.NewServer(
-		8088,
+		api.Config{
+			Port: 8088,
+		},
 		memoryStorage.NewStore(fakeCatalog),
 		fakeAsync.NewEngine(),
 		filterChain,

--- a/cmd/compliance-test-broker/compliance-test-broker.go
+++ b/cmd/compliance-test-broker/compliance-test-broker.go
@@ -61,7 +61,7 @@ func main() {
 		cancel()
 	}()
 
-	if err := server.Start(ctx); err != nil {
+	if err := server.Run(ctx); err != nil {
 		if err == ctx.Err() {
 			// Allow some time for goroutines to shut down
 			time.Sleep(time.Second * 3)

--- a/contrib/cmd/cli/bind.go
+++ b/contrib/cmd/cli/bind.go
@@ -9,6 +9,8 @@ import (
 )
 
 func bind(c *cli.Context) error {
+	useSSL := c.GlobalBool(flagSSL)
+	skipCertValidation := c.GlobalBool(flagInsecure)
 	host := c.GlobalString(flagHost)
 	port := c.GlobalInt(flagPort)
 	username := c.GlobalString(flagUsername)
@@ -22,6 +24,8 @@ func bind(c *cli.Context) error {
 		return err
 	}
 	bindingID, credentialMap, err := client.Bind(
+		useSSL,
+		skipCertValidation,
 		host,
 		port,
 		username,

--- a/contrib/cmd/cli/catalog.go
+++ b/contrib/cmd/cli/catalog.go
@@ -8,11 +8,20 @@ import (
 )
 
 func catalog(c *cli.Context) error {
+	useSSL := c.GlobalBool(flagSSL)
+	skipCertValidation := c.GlobalBool(flagInsecure)
 	host := c.GlobalString(flagHost)
 	port := c.GlobalInt(flagPort)
 	username := c.GlobalString(flagUsername)
 	password := c.GlobalString(flagPassword)
-	catalog, err := client.GetCatalog(host, port, username, password)
+	catalog, err := client.GetCatalog(
+		useSSL,
+		skipCertValidation,
+		host,
+		port,
+		username,
+		password,
+	)
 	if err != nil {
 		return fmt.Errorf("error retrieving catalog: %s", err)
 	}

--- a/contrib/cmd/cli/cli.go
+++ b/contrib/cmd/cli/cli.go
@@ -14,6 +14,14 @@ func main() {
 	app.UsageText = "broker-cli [global options] <command> [command options] " +
 		"[arguments...]"
 	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  flagsSSL,
+			Usage: "use a secure connection (HTTPS)",
+		},
+		cli.BoolFlag{
+			Name:  flagsInsecure,
+			Usage: "skip SSL cert validation",
+		},
 		cli.StringFlag{
 			Name:  flagsHost,
 			Usage: "specify the broker's host",

--- a/contrib/cmd/cli/deprovision.go
+++ b/contrib/cmd/cli/deprovision.go
@@ -10,6 +10,8 @@ import (
 )
 
 func deprovision(c *cli.Context) error {
+	useSSL := c.GlobalBool(flagSSL)
+	skipCertValidation := c.GlobalBool(flagInsecure)
 	host := c.GlobalString(flagHost)
 	port := c.GlobalInt(flagPort)
 	username := c.GlobalString(flagUsername)
@@ -18,7 +20,15 @@ func deprovision(c *cli.Context) error {
 	if instanceID == "" {
 		return fmt.Errorf("--%s is a required flag", flagInstanceID)
 	}
-	err := client.Deprovision(host, port, username, password, instanceID)
+	err := client.Deprovision(
+		useSSL,
+		skipCertValidation,
+		host,
+		port,
+		username,
+		password,
+		instanceID,
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -28,6 +38,8 @@ func deprovision(c *cli.Context) error {
 		defer ticker.Stop()
 		for range ticker.C {
 			result, err := client.Poll(
+				useSSL,
+				skipCertValidation,
 				host,
 				port,
 				username,

--- a/contrib/cmd/cli/flags.go
+++ b/contrib/cmd/cli/flags.go
@@ -22,4 +22,8 @@ const (
 	flagOperation   = "operation"
 	flagsOperation  = "operation, o"
 	flagPoll        = "poll"
+	flagSSL         = "ssl"
+	flagsSSL        = "ssl, s"
+	flagInsecure    = "insecure"
+	flagsInsecure   = "insecure, i"
 )

--- a/contrib/cmd/cli/poll.go
+++ b/contrib/cmd/cli/poll.go
@@ -9,6 +9,8 @@ import (
 )
 
 func poll(c *cli.Context) error {
+	useSSL := c.GlobalBool(flagSSL)
+	skipCertValidation := c.GlobalBool(flagInsecure)
 	host := c.GlobalString(flagHost)
 	port := c.GlobalInt(flagPort)
 	username := c.GlobalString(flagUsername)
@@ -27,6 +29,8 @@ func poll(c *cli.Context) error {
 		return fmt.Errorf("invalid value for flag --%s", flagOperation)
 	}
 	status, err := client.Poll(
+		useSSL,
+		skipCertValidation,
 		host,
 		port,
 		username,

--- a/contrib/cmd/cli/provision.go
+++ b/contrib/cmd/cli/provision.go
@@ -10,6 +10,8 @@ import (
 )
 
 func provision(c *cli.Context) error {
+	useSSL := c.GlobalBool(flagSSL)
+	skipCertValidation := c.GlobalBool(flagInsecure)
 	host := c.GlobalString(flagHost)
 	port := c.GlobalInt(flagPort)
 	username := c.GlobalString(flagUsername)
@@ -27,6 +29,8 @@ func provision(c *cli.Context) error {
 		return err
 	}
 	instanceID, err := client.Provision(
+		useSSL,
+		skipCertValidation,
 		host,
 		port,
 		username,
@@ -44,6 +48,8 @@ func provision(c *cli.Context) error {
 		defer ticker.Stop()
 		for range ticker.C {
 			result, err := client.Poll(
+				useSSL,
+				skipCertValidation,
 				host,
 				port,
 				username,

--- a/contrib/cmd/cli/unbind.go
+++ b/contrib/cmd/cli/unbind.go
@@ -9,6 +9,8 @@ import (
 )
 
 func unbind(c *cli.Context) error {
+	useSSL := c.GlobalBool(flagSSL)
+	skipCertValidation := c.GlobalBool(flagInsecure)
 	host := c.GlobalString(flagHost)
 	port := c.GlobalInt(flagPort)
 	username := c.GlobalString(flagUsername)
@@ -21,7 +23,16 @@ func unbind(c *cli.Context) error {
 	if bindingID == "" {
 		return fmt.Errorf("--%s is a required flag", flagBindingID)
 	}
-	err := client.Unbind(host, port, username, password, instanceID, bindingID)
+	err := client.Unbind(
+		useSSL,
+		skipCertValidation,
+		host,
+		port,
+		username,
+		password,
+		instanceID,
+		bindingID,
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/contrib/cmd/cli/update.go
+++ b/contrib/cmd/cli/update.go
@@ -10,6 +10,8 @@ import (
 )
 
 func update(c *cli.Context) error {
+	useSSL := c.GlobalBool(flagSSL)
+	skipCertValidation := c.GlobalBool(flagInsecure)
 	host := c.GlobalString(flagHost)
 	port := c.GlobalInt(flagPort)
 	username := c.GlobalString(flagUsername)
@@ -28,6 +30,8 @@ func update(c *cli.Context) error {
 		return err
 	}
 	if err := client.Update(
+		useSSL,
+		skipCertValidation,
 		host,
 		port,
 		username,
@@ -45,6 +49,8 @@ func update(c *cli.Context) error {
 		defer ticker.Stop()
 		for range ticker.C {
 			result, err := client.Poll(
+				useSSL,
+				skipCertValidation,
 				host,
 				port,
 				username,

--- a/contrib/k8s/charts/open-service-broker-azure/templates/broker.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/templates/broker.yaml
@@ -1,10 +1,37 @@
+{{- $ca := genCA "osba-ca" 3650 }}
+{{- if .Values.tls.enabled }}
+{{- $cn := printf "%s-open-service-broker-azure" .Release.Name }}
+{{- $altName1 := printf "%s-open-service-broker-azure.%s" .Release.Name .Release.Namespace }}
+{{- $altName2 := printf "%s-open-service-broker-azure.%s.svc" .Release.Name .Release.Namespace }}
+{{- $altName3 := printf "%s-open-service-broker-azure.%s.svc.cluster" .Release.Name .Release.Namespace }}
+{{- $altName4 := printf "%s-open-service-broker-azure.%s.svc.cluster.local" .Release.Name .Release.Namespace }}
+{{- $cert := genSignedCert $cn nil (list $altName1 $altName2 $altName3 $altName4) 3650 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}-cert
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  tls.crt: {{ b64enc $cert.Cert }}
+  tls.key: {{ b64enc $cert.Key }}
+{{- end }}
 {{- if .Values.registerBroker }}
+---
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ClusterServiceBroker
 metadata:
   name: osba
 spec:
+  {{- if .Values.tls.enabled }}
+  url: https://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  caBundle: {{ b64enc $ca.Cert }}
+  {{- else }}
   url: http://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  {{- end }}
   authInfo:
     basic:
       secretRef:

--- a/contrib/k8s/charts/open-service-broker-azure/templates/deployment.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/templates/deployment.yaml
@@ -60,6 +60,17 @@ spec:
               secretKeyRef:
                 name: {{ template "fullname" . }}
                 key: encryption-key
+          {{- if .Values.tls.enabled }}
+          - name: API_SERVER_PORT
+            value: "8443"
+          - name: API_SERVER_TLS_CERT_PATH
+            value: /app/certs/tls.crt
+          - name: API_SERVER_TLS_KEY_PATH
+            value: /app/certs/tls.key
+          {{- else }}
+          - name: API_SERVER_PORT
+            value: "8080"
+          {{- end }}
           - name: BASIC_AUTH_USERNAME
             value: {{ .Values.basicAuth.username }}
           - name: BASIC_AUTH_PASSWORD
@@ -69,21 +80,51 @@ spec:
                 key: basic-auth-password
           - name: MIN_STABILITY
             value: {{ .Values.modules.minStability }}
+          {{- if .Values.tls.enabled }}
+          volumeMounts:
+          - name: cert
+            mountPath: /app/certs
+            readOnly: true
+          {{- end }}
           ports:
+          {{- if .Values.tls.enabled }}
+          - containerPort: 8443
+          {{- else }}
           - containerPort: 8080
+          {{- end }}
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /healthz
+              {{- if .Values.tls.enabled }}
+              port: 8443
+              scheme: HTTPS
+              {{- else }}
               port: 8080
+              scheme: HTTP
+              {{- end }}
             failureThreshold: 1
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 2
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /healthz
+              {{- if .Values.tls.enabled }}
+              port: 8443
+              scheme: HTTPS
+              {{- else }}
               port: 8080
+              scheme: HTTP
+              {{- end }}
             failureThreshold: 3
             initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 2
+      {{- if .Values.tls.enabled }}
+      volumes:
+      - name: cert
+        secret:
+          secretName: {{ template "fullname" . }}-cert
+      {{- end }}

--- a/contrib/k8s/charts/open-service-broker-azure/templates/service.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/templates/service.yaml
@@ -12,10 +12,16 @@ spec:
   selector:
     app: {{ template "fullname" . }}
   ports:
+  {{- if .Values.tls.enabled }}
+  - name: https
+    port: 443
+    targetPort: 8443
+  {{- else }}
   - name: http
-    protocol: TCP
     port: 80
+    targetPort: 8080
+  {{- end }}
+    protocol: TCP
     {{- if eq .Values.service.type "NodePort" }}
     nodePort: {{ .Values.service.nodePort.port }}
     {{- end }}
-    targetPort: 8080

--- a/contrib/k8s/charts/open-service-broker-azure/values.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/values.yaml
@@ -44,6 +44,9 @@ azure:
   ## Required
   clientSecret: 
 
+tls:
+  enabled: true
+
 ## Basic auth credentials that can later be used to access this broker
 basicAuth:
   ## DO NOT USE THIS DEFAULT VALUE IN PRODUCTION

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -53,7 +53,7 @@ func getTestServer() (*server, *fake.Module, error) {
 		return nil, nil, err
 	}
 	s, err := NewServer(
-		8080,
+		NewConfigWithDefaults(),
 		memoryStorage.NewStore(fakeCatalog),
 		fakeAsync.NewEngine(),
 		filter.NewChain(),

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"github.com/kelseyhightower/envconfig"
+)
+
+const envconfigPrefix = "API_SERVER"
+
+// Config represents configuration options for the API server
+type Config struct {
+	Port        int    `envconfig:"PORT"`
+	TLSCertPath string `envconfig:"TLS_CERT_PATH"`
+	TLSKeyPath  string `envconfig:"TLS_KEY_PATH"`
+}
+
+// NewConfigWithDefaults returns a Config object with default values already
+// applied. Callers are then free to set custom values for the remaining fields
+// and/or override default values.
+func NewConfigWithDefaults() Config {
+	return Config{Port: 8080}
+}
+
+// GetConfigFromEnvironment returns configuration derived from environment
+// variables
+func GetConfigFromEnvironment() (Config, error) {
+	c := NewConfigWithDefaults()
+	err := envconfig.Process(envconfigPrefix, &c)
+	return c, err
+}

--- a/pkg/api/fake/server.go
+++ b/pkg/api/fake/server.go
@@ -18,9 +18,9 @@ func NewServer() *Server {
 	}
 }
 
-// Start causes the api server to start serving HTTP requests. It will block
+// Run causes the api server to start serving HTTP requests. It will block
 // until an error occurs and will return that error.
-func (s *Server) Start(ctx context.Context) error {
+func (s *Server) Run(ctx context.Context) error {
 	return s.RunBehavior(ctx)
 }
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -29,9 +29,9 @@ func (e *errHTTPServerStopped) Error() string {
 // Server is an interface for components that respond to HTTP requests on behalf
 // of the broker
 type Server interface {
-	// Start causes the api server to start serving HTTP requests. It will block
+	// Run causes the api server to start serving HTTP requests. It will block
 	// until an error occurs and will return that error.
-	Start(context.Context) error
+	Run(context.Context) error
 }
 
 type server struct {
@@ -109,7 +109,7 @@ func NewServer(
 	return s, nil
 }
 
-func (s *server) Start(ctx context.Context) error {
+func (s *server) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	errChan := make(chan error)

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -21,7 +21,7 @@ func TestServerStartBlocksUntilListenAndServeErrors(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err = s.Start(ctx)
+	err = s.Run(ctx)
 	assert.Equal(t, &errHTTPServerStopped{err: errSome}, err)
 }
 
@@ -33,7 +33,7 @@ func TestServerStartBlocksUntilListenAndServeReturns(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err = s.Start(ctx)
+	err = s.Run(ctx)
 	assert.Equal(t, &errHTTPServerStopped{}, err)
 }
 
@@ -46,7 +46,7 @@ func TestServerStartBlocksUntilContextCanceled(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err = s.Start(ctx)
+	err = s.Run(ctx)
 	assert.Equal(t, ctx.Err(), err)
 }
 

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Azure/open-service-broker-azure/pkg/api"
 	"github.com/Azure/open-service-broker-azure/pkg/async"
-	"github.com/Azure/open-service-broker-azure/pkg/http/filter"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/Azure/open-service-broker-azure/pkg/storage"
 	log "github.com/Sirupsen/logrus"
@@ -46,12 +45,13 @@ type broker struct {
 
 // NewBroker returns a new Broker
 func NewBroker(
-	store storage.Store,
+	apiServer api.Server,
 	asyncEngine async.Engine,
-	filterChain filter.Filter,
+	store storage.Store,
 	catalog service.Catalog,
 ) (Broker, error) {
 	b := &broker{
+		apiServer:   apiServer,
 		store:       store,
 		asyncEngine: asyncEngine,
 		catalog:     catalog,
@@ -98,17 +98,6 @@ func NewBroker(
 			"error registering async job for executing check of children " +
 				"statuses",
 		)
-	}
-
-	b.apiServer, err = api.NewServer(
-		8080,
-		b.store,
-		b.asyncEngine,
-		filterChain,
-		b.catalog,
-	)
-	if err != nil {
-		return nil, err
 	}
 
 	return b, nil

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -31,9 +31,9 @@ func (e *errAPIServerStopped) Error() string {
 // Broker is an interface to be implemented by components that implement full
 // OSB functionality.
 type Broker interface {
-	// Start starts all broker components (e.g. API server and async execution
+	// Run starts all broker components (e.g. API server and async execution
 	// engine) and blocks until one of those components returns or fails.
-	Start(context.Context) error
+	Run(context.Context) error
 }
 
 type broker struct {
@@ -103,9 +103,9 @@ func NewBroker(
 	return b, nil
 }
 
-// Start starts all broker components (e.g. API server and async execution
+// Run starts all broker components (e.g. API server and async execution
 // engine) and blocks until one of those components returns or fails.
-func (b *broker) Start(ctx context.Context) error {
+func (b *broker) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	errChan := make(chan error)
@@ -119,7 +119,7 @@ func (b *broker) Start(ctx context.Context) error {
 	// Start api server
 	go func() {
 		select {
-		case errChan <- &errAPIServerStopped{err: b.apiServer.Start(ctx)}:
+		case errChan <- &errAPIServerStopped{err: b.apiServer.Run(ctx)}:
 		case <-ctx.Done():
 		}
 	}()

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -34,7 +34,7 @@ func TestBrokerStartBlocksUntilAsyncEngineErrors(t *testing.T) {
 	b.apiServer = svr
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	err = b.Start(ctx)
+	err = b.Run(ctx)
 	assert.Equal(t, &errAsyncEngineStopped{err: errSome}, err)
 	time.Sleep(time.Second)
 	assert.True(t, apiServerStopped)
@@ -58,7 +58,7 @@ func TestBrokerStartBlocksUntilAsyncEngineReturns(t *testing.T) {
 	b.apiServer = svr
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	err = b.Start(ctx)
+	err = b.Run(ctx)
 	assert.Equal(t, &errAsyncEngineStopped{}, err)
 	time.Sleep(time.Second)
 	assert.True(t, apiServerStopped)
@@ -82,7 +82,7 @@ func TestBrokerStartBlocksUntilAPIServerErrors(t *testing.T) {
 	b.apiServer = svr
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	err = b.Start(ctx)
+	err = b.Run(ctx)
 	assert.Equal(t, &errAPIServerStopped{err: errSome}, err)
 	time.Sleep(time.Second)
 	assert.True(t, asyncEngineStopped)
@@ -106,7 +106,7 @@ func TestBrokerStartBlocksUntilAPIServerReturns(t *testing.T) {
 	b.apiServer = svr
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	err = b.Start(ctx)
+	err = b.Run(ctx)
 	assert.Equal(t, &errAPIServerStopped{}, err)
 	time.Sleep(time.Second)
 	assert.True(t, asyncEngineStopped)
@@ -133,7 +133,7 @@ func TestBrokerStartBlocksUntilContextCanceled(t *testing.T) {
 	b.apiServer = svr
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err = b.Start(ctx)
+	err = b.Run(ctx)
 	assert.Equal(t, ctx.Err(), err)
 	time.Sleep(time.Second)
 	assert.True(t, apiServerStopped)

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -144,7 +144,7 @@ func getTestBroker() (*broker, error) {
 	asyncEngine := fakeAsync.NewEngine()
 	catalog := service.NewCatalog(nil)
 	apiServer, err := api.NewServer(
-		8080,
+		api.NewConfigWithDefaults(),
 		nil,
 		asyncEngine,
 		filter.NewChain(),

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/open-service-broker-azure/pkg/http/filter"
-	"github.com/Azure/open-service-broker-azure/pkg/service"
-
+	"github.com/Azure/open-service-broker-azure/pkg/api"
 	fakeAPI "github.com/Azure/open-service-broker-azure/pkg/api/fake"
 	fakeAsync "github.com/Azure/open-service-broker-azure/pkg/async/fake"
+	"github.com/Azure/open-service-broker-azure/pkg/http/filter"
+	"github.com/Azure/open-service-broker-azure/pkg/service"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -141,11 +141,23 @@ func TestBrokerStartBlocksUntilContextCanceled(t *testing.T) {
 }
 
 func getTestBroker() (*broker, error) {
-	b, err := NewBroker(
+	asyncEngine := fakeAsync.NewEngine()
+	catalog := service.NewCatalog(nil)
+	apiServer, err := api.NewServer(
+		8080,
 		nil,
-		fakeAsync.NewEngine(),
+		asyncEngine,
 		filter.NewChain(),
-		service.NewCatalog(nil),
+		catalog,
+	)
+	if err != nil {
+		return nil, err
+	}
+	b, err := NewBroker(
+		apiServer,
+		asyncEngine,
+		nil,
+		catalog,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/client/bind.go
+++ b/pkg/client/bind.go
@@ -11,6 +11,8 @@ import (
 
 // Bind carries out binding to an existing service
 func Bind(
+	useSSL bool,
+	skipCertValidation bool,
 	host string,
 	port int,
 	username string,
@@ -21,7 +23,7 @@ func Bind(
 	bindingID := uuid.NewV4().String()
 	url := fmt.Sprintf(
 		"%s/v2/service_instances/%s/service_bindings/%s",
-		getBaseURL(host, port),
+		getBaseURL(useSSL, host, port),
 		instanceID,
 		bindingID,
 	)
@@ -36,7 +38,7 @@ func Bind(
 	if err != nil {
 		return "", nil, err
 	}
-	httpClient := &http.Client{}
+	httpClient := getHTTPClient(skipCertValidation)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", nil, fmt.Errorf("error executing bind call: %s", err)

--- a/pkg/client/catalog.go
+++ b/pkg/client/catalog.go
@@ -10,18 +10,20 @@ import (
 // GetCatalog retrieves the catalog from the broker specified by host name
 // and port number
 func GetCatalog(
+	useSSL bool,
+	skipCertValidation bool,
 	host string,
 	port int,
 	username string,
 	password string,
 ) (Catalog, error) {
 	catalog := Catalog{}
-	url := fmt.Sprintf("%s/v2/catalog", getBaseURL(host, port))
+	url := fmt.Sprintf("%s/v2/catalog", getBaseURL(useSSL, host, port))
 	req, err := newRequest(http.MethodGet, url, username, password, nil)
 	if err != nil {
 		return catalog, err
 	}
-	httpClient := &http.Client{}
+	httpClient := getHTTPClient(skipCertValidation)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return catalog, fmt.Errorf("error requesting catalog: %s", err)

--- a/pkg/client/common.go
+++ b/pkg/client/common.go
@@ -6,8 +6,12 @@ import (
 	"net/http"
 )
 
-func getBaseURL(host string, port int) string {
-	return fmt.Sprintf("http://%s:%d", host, port)
+func getBaseURL(useSSL bool, host string, port int) string {
+	proto := "http"
+	if useSSL {
+		proto = "https"
+	}
+	return fmt.Sprintf("%s://%s:%d", proto, host, port)
 }
 
 func newRequest(

--- a/pkg/client/deprovision.go
+++ b/pkg/client/deprovision.go
@@ -7,6 +7,8 @@ import (
 
 // Deprovision initiates deprovisioning of a service instance
 func Deprovision(
+	useSSL bool,
+	skipCertValidation bool,
 	host string,
 	port int,
 	username string,
@@ -15,7 +17,7 @@ func Deprovision(
 ) error {
 	url := fmt.Sprintf(
 		"%s/v2/service_instances/%s",
-		getBaseURL(host, port),
+		getBaseURL(useSSL, host, port),
 		instanceID,
 	)
 	req, err := newRequest(http.MethodDelete, url, username, password, nil)
@@ -25,7 +27,7 @@ func Deprovision(
 	q := req.URL.Query()
 	q.Add("accepts_incomplete", "true")
 	req.URL.RawQuery = q.Encode()
-	httpClient := &http.Client{}
+	httpClient := getHTTPClient(skipCertValidation)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("error executing deprovision call: %s", err)

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -1,0 +1,19 @@
+package client
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+func getHTTPClient(skipCertValidation bool) *http.Client {
+	if !skipCertValidation {
+		return &http.Client{}
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+}

--- a/pkg/client/poll.go
+++ b/pkg/client/poll.go
@@ -10,6 +10,8 @@ import (
 
 // Poll polls the status of an instance
 func Poll(
+	useSSL bool,
+	skipCertValidation bool,
 	host string,
 	port int,
 	username string,
@@ -19,7 +21,7 @@ func Poll(
 ) (string, error) {
 	url := fmt.Sprintf(
 		"%s/v2/service_instances/%s/last_operation",
-		getBaseURL(host, port),
+		getBaseURL(useSSL, host, port),
 		instanceID,
 	)
 	req, err := newRequest(http.MethodGet, url, username, password, nil)
@@ -29,7 +31,7 @@ func Poll(
 	q := req.URL.Query()
 	q.Add("operation", operation)
 	req.URL.RawQuery = q.Encode()
-	httpClient := &http.Client{}
+	httpClient := getHTTPClient(skipCertValidation)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("error executing polling call: %s", err)

--- a/pkg/client/provision.go
+++ b/pkg/client/provision.go
@@ -10,6 +10,8 @@ import (
 
 // Provision initiates provisioning of a new service instance
 func Provision(
+	useSSL bool,
+	skipCertValidation bool,
 	host string,
 	port int,
 	username string,
@@ -21,7 +23,7 @@ func Provision(
 	instanceID := uuid.NewV4().String()
 	url := fmt.Sprintf(
 		"%s/v2/service_instances/%s",
-		getBaseURL(host, port),
+		getBaseURL(useSSL, host, port),
 		instanceID,
 	)
 	provisioningRequest := ProvisioningRequest{
@@ -40,7 +42,7 @@ func Provision(
 	q := req.URL.Query()
 	q.Add("accepts_incomplete", "true")
 	req.URL.RawQuery = q.Encode()
-	httpClient := &http.Client{}
+	httpClient := getHTTPClient(skipCertValidation)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("error executing provision call: %s", err)

--- a/pkg/client/unbind.go
+++ b/pkg/client/unbind.go
@@ -7,6 +7,8 @@ import (
 
 // Unbind carries out unbinding
 func Unbind(
+	useSSL bool,
+	skipCertValidation bool,
 	host string,
 	port int,
 	username string,
@@ -16,7 +18,7 @@ func Unbind(
 ) error {
 	url := fmt.Sprintf(
 		"%s/v2/service_instances/%s/service_bindings/%s",
-		getBaseURL(host, port),
+		getBaseURL(useSSL, host, port),
 		instanceID,
 		bindingID,
 	)
@@ -24,7 +26,7 @@ func Unbind(
 	if err != nil {
 		return err
 	}
-	httpClient := &http.Client{}
+	httpClient := getHTTPClient(skipCertValidation)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("error executing unbind call: %s", err)

--- a/pkg/client/update.go
+++ b/pkg/client/update.go
@@ -8,6 +8,8 @@ import (
 
 // Update initiates updating of an existing service instance
 func Update(
+	useSSL bool,
+	skipCertValidation bool,
 	host string,
 	port int,
 	username string,
@@ -19,7 +21,7 @@ func Update(
 ) error {
 	url := fmt.Sprintf(
 		"%s/v2/service_instances/%s",
-		getBaseURL(host, port),
+		getBaseURL(useSSL, host, port),
 		instanceID,
 	)
 	updatingRequest := UpdatingRequest{
@@ -38,7 +40,7 @@ func Update(
 	q := req.URL.Query()
 	q.Add("accepts_incomplete", "true")
 	req.URL.RawQuery = q.Encode()
-	httpClient := &http.Client{}
+	httpClient := getHTTPClient(skipCertValidation)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("error executing update call: %s", err)

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -1,0 +1,11 @@
+package file
+
+import (
+	"os"
+)
+
+// Exists returns a bool indicating if the specified file exists or not
+func Exists(filename string) bool {
+	_, err := os.Stat(filename)
+	return !os.IsNotExist(err)
+}

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -1,0 +1,27 @@
+package file
+
+import (
+	"fmt"
+	"go/build"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExists(t *testing.T) {
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		gopath = build.Default.GOPATH
+	}
+	file := fmt.Sprintf(
+		"%s/src/github.com/Azure/open-service-broker-azure/pkg/file/file_test.go",
+		gopath,
+	)
+	assert.True(t, Exists(file))
+	file = fmt.Sprintf(
+		"%s/src/github.com/Azure/open-service-broker-azure/pkg/file/bogus.go",
+		gopath,
+	)
+	assert.False(t, Exists(file))
+}

--- a/tests/e2e/test_case_test.go
+++ b/tests/e2e/test_case_test.go
@@ -15,8 +15,10 @@ import (
 )
 
 const (
-	host = "broker"
-	port = 8080
+	useSSL             = false
+	skipCertValidation = true
+	host               = "broker"
+	port               = 8080
 )
 
 // e2eTestCase encapsulates all the required details for an end-to-end test
@@ -68,6 +70,8 @@ func (e e2eTestCase) execute(
 
 	// Provision...
 	instanceID, err := client.Provision(
+		useSSL,
+		skipCertValidation,
 		host,
 		port,
 		basicAuthConfig.GetUsername(),
@@ -87,6 +91,8 @@ provisionPollLoop:
 		case <-ticker.C:
 			var result string
 			result, err = client.Poll(
+				useSSL,
+				skipCertValidation,
 				host,
 				port,
 				basicAuthConfig.GetUsername(),
@@ -119,6 +125,8 @@ provisionPollLoop:
 	// Bind...
 	if e.bind {
 		bindingID, _, err = client.Bind(
+			useSSL,
+			skipCertValidation,
 			host,
 			port,
 			basicAuthConfig.GetUsername(),
@@ -143,6 +151,8 @@ provisionPollLoop:
 	// Unbind...
 	if e.bind {
 		err = client.Unbind(
+			useSSL,
+			skipCertValidation,
 			host,
 			port,
 			basicAuthConfig.GetUsername(),
@@ -157,6 +167,8 @@ provisionPollLoop:
 
 	// Deprovision...
 	err = client.Deprovision(
+		useSSL,
+		skipCertValidation,
 		host,
 		port,
 		basicAuthConfig.GetUsername(),
@@ -171,6 +183,8 @@ deprovisionPollLoop:
 		select {
 		case <-ticker.C:
 			result, err := client.Poll(
+				useSSL,
+				skipCertValidation,
 				host,
 				port,
 				basicAuthConfig.GetUsername(),


### PR DESCRIPTION
Fixes #225

Highlights:

- Improves DI / bootstrapping to make API server easier to configure
- Introduces new configuration object for API server
- Automatically uses TLS cert and key if found
- Helm chart automatically generates CA and cert signed by that CA, unless you opt out
- Client gets SSL support-- including option to skip cert validation