### PR TITLE
Make the sample config for cf create-service a valid JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The following will create a Postgres service:
 ```console
 cf create-service azure-postgresql-9-6 basic50 mypostgresdb -c '{
   "location": "eastus",
-  "resourceGroup: "test",
+  "resourceGroup": "test",
   "firewallRules" : [
       {
         "name": "AllowAll",


### PR DESCRIPTION
There is missing closing double quote for the `resourceGroup` key in the sample configuration.