### PR TITLE
Doc fix :  typo/syntax issue with az aks delete (to tear down AKS cluster)

### DIFF
--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -314,7 +314,7 @@ az ad sp delete --id http://osba-quickstart
 To tear down the AKS cluster:
 
 ```console
-az aks delete -resource-group aks-group --name osba-quickstart-cluster --no-wait
+az aks delete --resource-group aks-group --name osba-quickstart-cluster --no-wait
 ```
 
 ## Next Steps


### PR DESCRIPTION
Fixed typo/syntax issue in AKS quickstart guide, where it tears down AKS cluster.