### PR TITLE
[Redis] Make capacity and ssl configurable and make instance updatable

### DIFF
--- a/docs/modules/rediscache.md
+++ b/docs/modules/rediscache.md
@@ -6,29 +6,30 @@ _Note: This module is EXPERIMENTAL. To enable this module, you must run Open Ser
 
 ### Service: azure-rediscache
 
-| Plan Name | Description |
-|-----------|-------------|
-| `basic` | Basic Tier, 250MB Cache |
-| `standard` | Standard Tier, 1GB Cache |
-| `standard` | Standard Tier, 1GB Cache |
-| `premium` | Premium Tier, 6GB Cache |
+| Plan Name  | Description                      |
+| ---------- | -------------------------------- |
+| `basic`    | Basic Tier, default 250MB Cache  |
+| `standard` | Standard Tier, default 1GB Cache |
+| `premium`  | Premium Tier, default 6GB Cache  |
 
 #### Behaviors
 
 ##### Provision
-  
+
 Provisions a new Redis cache.
 
 ###### Provisioning Parameters
 
-| Parameter Name | Type | Description | Required | Default Value |
-|----------------|------|-------------|----------|---------------|
-| `location` | `string` | The Azure region in which to provision applicable resources. | Required _unless_ an administrator has configured the broker itself with a default location. | The broker's default location, if configured. |
-| `resourceGroup` | `string` | The (new or existing) resource group with which to associate new resources. | N | If an administrator has configured the broker itself with a default resource group and nonde is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
-| `tags` | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
-  
+| Parameter Name      | Type                | Description                                                  | Required                                                     | Default Value                                                |
+| ------------------- | ------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `location`          | `string`            | The Azure region in which to provision applicable resources. | Required _unless_ an administrator has configured the broker itself with a default location. | The broker's default location, if configured.                |
+| `resourceGroup`     | `string`            | The (new or existing) resource group with which to associate new resources. | N                                                            | If an administrator has configured the broker itself with a default resource group and nonde is specified, that default will be applied, otherwise, a new resource group will be created with a UUID as its name. |
+| `skuCapacity`       | `integer`           | The size of the Redis cache to deploy.  Valid values: for C (Basic/Standard) family (0, 1, 2, 3, 4, 5, 6), for P (Premium) family (1, 2, 3, 4). They denotes real size  (250MB, 1GB, 2.5 GB, 6 GB, 13 GB, 26 GB, 53GB) and (6 GB, 13 GB, 26 GB, 53GB) respectively. | N                                                            | If not provided, `0` is used for C (Basic/Standard) family; `1` is used for P (Premium) family. |
+| `enableNonSslPort ` | `string`            | Specifies whether the non-SSL Redis server port (6379) is enabled. Valid values: (`enabled`, `disabled`) | N                                                            | If not provided, `disabled` is used. That is, you can't use non-SSL Redis server port by default. |
+| `tags`              | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N                                                            | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
+
 ##### Bind
-  
+
 Returns a copy of one shared set of credentials.
 
 ###### Binding Parameters
@@ -39,16 +40,30 @@ This binding operation does not support any parameters.
 
 Binding returns the following connection details and shared credentials:
 
-| Field Name | Type | Description |
-|------------|------|-------------|
-| `host` | `string` | The fully-qualified address of the Redis cache. |
-| `port` | `int` | The port number to connect to on the Redis cache. |
-| `password` | `string` | The password for the Redis cache. |
+| Field Name | Type     | Description                                       |
+| ---------- | -------- | ------------------------------------------------- |
+| `host`     | `string` | The fully-qualified address of the Redis cache.   |
+| `port`     | `int`    | The port number to connect to on the Redis cache. |
+| `password` | `string` | The password for the Redis cache.                 |
+| `uri`      | `string` | The connection string for the Redis cache.        |
+
+**Note**: if `enableNonSslPort` is set to `enabled`, then `port` will be `6379` and the scheme will be `redis` in `uri`; if `enableNonSslPort`  is set to `disabled`, then `port` will be `6380` and the scheme will be `rediss` in `uri`, and you can only use rediss to connect to the Redis cache.
 
 ##### Unbind
 
 Does nothing.
-  
+
+##### Update
+
+Updates existing Redis cache.
+
+###### Updating parameters
+
+| Parameter Name     | Type      | Description                                                  | Required |
+| ------------------ | --------- | ------------------------------------------------------------ | -------- |
+| `skuCapacity`      | `integer` | The size of the Redis cache to deploy.  Valid values: for C (Basic/Standard) family (0, 1, 2, 3, 4, 5, 6), for P (Premium) family (1, 2, 3, 4). They denotes real size  (250MB, 1GB, 2.5 GB, 6 GB, 13 GB, 26 GB, 53GB) and (6 GB, 13 GB, 26 GB, 53GB) respectively. **Note**: you can only update from a smaller capacity to a larger capacity, the reverse is not allowed. | N        |
+| `enableNonSslPort` | `string`  | Specifies whether the non-ssl Redis server port (6379) is enabled. Valid values: (`enabled`, `disabled`) | N        |
+
 ##### Deprovision
 
 Deletes the Redis cache.

--- a/pkg/services/rediscache/arm_template.go
+++ b/pkg/services/rediscache/arm_template.go
@@ -17,7 +17,7 @@ var armTemplateBytes = []byte(`
 			"type": "Microsoft.Cache/Redis",
 			"location": "{{.location}}",
 			"properties": {
-				"enableNonSslPort": true,
+				"enableNonSslPort": {{.enableNonSslPort}},
 				"sku": {
 					"capacity": "{{.redisCacheCapacity}}",
 					"family": "{{.redisCacheFamily}}",

--- a/pkg/services/rediscache/bind.go
+++ b/pkg/services/rediscache/bind.go
@@ -20,13 +20,23 @@ func (s *serviceManager) GetCredentials(
 ) (service.Credentials, error) {
 	dt := instance.Details.(*instanceDetails)
 
-	redisPort := 6379
+	var redisPort int
+	var scheme string
+	if dt.NonSSLEnabled {
+		redisPort = 6379
+		scheme = "redis"
+	} else {
+		redisPort = 6380
+		scheme = "rediss"
+	}
+
 	return credentials{
 		Host:     dt.FullyQualifiedDomainName,
 		Password: string(dt.PrimaryKey),
 		Port:     redisPort,
 		URI: fmt.Sprintf(
-			"redis://:%s@%s:%d",
+			"%s://:%s@%s:%d",
+			scheme,
 			url.QueryEscape(string(dt.PrimaryKey)),
 			dt.FullyQualifiedDomainName,
 			redisPort,

--- a/pkg/services/rediscache/catalog.go
+++ b/pkg/services/rediscache/catalog.go
@@ -2,7 +2,24 @@ package rediscache
 
 import "github.com/Azure/open-service-broker-azure/pkg/service"
 
+const basic = "basic"
+const standard = "standard"
+const premium = "premium"
+
 func (m *module) GetCatalog() (service.Catalog, error) {
+	bpd := planDetail{
+		planName:        basic,
+		allowedCapacity: []int64{0, 1, 2, 3, 4, 5, 6},
+	}
+	spd := planDetail{
+		planName:        standard,
+		allowedCapacity: []int64{0, 1, 2, 3, 4, 5, 6},
+	}
+	ppd := planDetail{
+		planName:        premium,
+		allowedCapacity: []int64{1, 2, 3, 4},
+	}
+
 	return service.NewCatalog([]service.Service{
 		service.NewService(
 			service.ServiceProperties{
@@ -29,9 +46,8 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				Free:        false,
 				Stability:   service.StabilityExperimental,
 				Extended: map[string]interface{}{
-					"redisCacheSKU":      "Basic",
-					"redisCacheFamily":   "C",
-					"redisCacheCapacity": 0,
+					"redisCacheSKU":    "Basic",
+					"redisCacheFamily": "C",
 				},
 				Metadata: service.ServicePlanMetadata{
 					DisplayName: "Basic Tier",
@@ -39,7 +55,8 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				},
 				Schemas: service.PlanSchemas{
 					ServiceInstances: service.InstanceSchemas{
-						ProvisioningParametersSchema: generateProvisioningParamsSchema(),
+						ProvisioningParametersSchema: bpd.getProvisioningParamsSchema(),
+						UpdatingParametersSchema:     bpd.getUpdatingParamsSchema(),
 					},
 				},
 			}),
@@ -50,9 +67,8 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				Free:        false,
 				Stability:   service.StabilityExperimental,
 				Extended: map[string]interface{}{
-					"redisCacheSKU":      "Standard",
-					"redisCacheFamily":   "C",
-					"redisCacheCapacity": 1,
+					"redisCacheSKU":    "Standard",
+					"redisCacheFamily": "C",
 				},
 				Metadata: service.ServicePlanMetadata{
 					DisplayName: "Standard Tier",
@@ -60,7 +76,8 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				},
 				Schemas: service.PlanSchemas{
 					ServiceInstances: service.InstanceSchemas{
-						ProvisioningParametersSchema: generateProvisioningParamsSchema(),
+						ProvisioningParametersSchema: spd.getProvisioningParamsSchema(),
+						UpdatingParametersSchema:     spd.getUpdatingParamsSchema(),
 					},
 				},
 			}),
@@ -71,9 +88,8 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				Free:        false,
 				Stability:   service.StabilityExperimental,
 				Extended: map[string]interface{}{
-					"redisCacheSKU":      "Premium",
-					"redisCacheFamily":   "P",
-					"redisCacheCapacity": 1,
+					"redisCacheSKU":    "Premium",
+					"redisCacheFamily": "P",
 				},
 				Metadata: service.ServicePlanMetadata{
 					DisplayName: "Premium Tier",
@@ -81,7 +97,8 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				},
 				Schemas: service.PlanSchemas{
 					ServiceInstances: service.InstanceSchemas{
-						ProvisioningParametersSchema: generateProvisioningParamsSchema(),
+						ProvisioningParametersSchema: ppd.getProvisioningParamsSchema(),
+						UpdatingParametersSchema:     ppd.getUpdatingParamsSchema(),
 					},
 				},
 			}),

--- a/pkg/services/rediscache/plan_schemas.go
+++ b/pkg/services/rediscache/plan_schemas.go
@@ -5,8 +5,14 @@ import (
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func generateProvisioningParamsSchema() service.InputParametersSchema {
-	return service.InputParametersSchema{
+type planDetail struct {
+	planName        string
+	allowedCapacity []int64
+}
+
+// nolint: lll
+func (pd planDetail) getProvisioningParamsSchema() service.InputParametersSchema {
+	ips := service.InputParametersSchema{
 		RequiredProperties: []string{"location", "resourceGroup"},
 		PropertySchemas: map[string]service.PropertySchema{
 			"location": &service.StringPropertySchema{
@@ -20,6 +26,38 @@ func generateProvisioningParamsSchema() service.InputParametersSchema {
 				Description: "The (new or existing) resource group with which" +
 					" to associate new resources.",
 			},
+			"enableNonSslPort": &service.StringPropertySchema{
+				Title:         "Enable non-SSL port",
+				Description:   "Specifies whether the non-ssl Redis server port (6379) is enabled.",
+				AllowedValues: []string{"enabled", "disabled"},
+				DefaultValue:  "disabled",
+			},
+			"skuCapacity": &service.IntPropertySchema{
+				Title:         "SKU capacity",
+				Description:   "The size of the Redis cache to deploy.",
+				AllowedValues: pd.allowedCapacity,
+				DefaultValue:  &(pd.allowedCapacity[0]),
+			},
 		},
 	}
+	return ips
+}
+
+// nolint: lll
+func (pd planDetail) getUpdatingParamsSchema() service.InputParametersSchema {
+	ips := service.InputParametersSchema{
+		PropertySchemas: map[string]service.PropertySchema{
+			"enableNonSslPort": &service.StringPropertySchema{
+				Title:         "Enable non-SSL port",
+				Description:   "Specifies whether the non-ssl Redis server port (6379) is enabled.",
+				AllowedValues: []string{"enabled", "disabled"},
+			},
+			"skuCapacity": &service.IntPropertySchema{
+				Title:         "SKU capacity",
+				Description:   "The size of the Redis cache to deploy.",
+				AllowedValues: pd.allowedCapacity,
+			},
+		},
+	}
+	return ips
 }

--- a/pkg/services/rediscache/types.go
+++ b/pkg/services/rediscache/types.go
@@ -6,6 +6,7 @@ type instanceDetails struct {
 	ARMDeploymentName        string               `json:"armDeployment"`
 	ServerName               string               `json:"server"`
 	FullyQualifiedDomainName string               `json:"fullyQualifiedDomainName"`
+	NonSSLEnabled            bool                 `json:"nonSSLEnabled"`
 	PrimaryKey               service.SecureString `json:"primaryKey"`
 }
 

--- a/pkg/services/rediscache/update.go
+++ b/pkg/services/rediscache/update.go
@@ -1,13 +1,60 @@
 package rediscache
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 )
 
-func (s *serviceManager) ValidateUpdatingParameters(service.Instance) error {
+func (s *serviceManager) ValidateUpdatingParameters(
+	instance service.Instance,
+) error {
+	pp := instance.ProvisioningParameters
+	up := instance.UpdatingParameters
+
+	// Can't update the instance from a larger capacity to a smaller capacity
+	provisionCapacity := pp.GetInt64("skuCapacity")
+	updateCapacity := up.GetInt64("skuCapacity")
+	if provisionCapacity > updateCapacity {
+		return fmt.Errorf("can not update an instance from larger capacity %d to "+
+			"smaller capacity %d", provisionCapacity, updateCapacity)
+	}
 	return nil
 }
 
 func (s *serviceManager) GetUpdater(service.Plan) (service.Updater, error) {
-	return service.NewUpdater()
+	return service.NewUpdater(
+		service.NewUpdatingStep("updateARMTemplate", s.updateARMTemplate),
+	)
+}
+
+func (s *serviceManager) updateARMTemplate(
+	_ context.Context,
+	instance service.Instance,
+) (service.InstanceDetails, error) {
+	dt := instance.Details.(*instanceDetails)
+	up := instance.UpdatingParameters
+	tagsObj := up.GetObject("tags")
+	tags := make(map[string]string, len(tagsObj.Data))
+	for k := range tagsObj.Data {
+		tags[k] = tagsObj.GetString(k)
+	}
+
+	_, err := s.armDeployer.Update(
+		dt.ARMDeploymentName,
+		instance.ProvisioningParameters.GetString("resourceGroup"),
+		instance.ProvisioningParameters.GetString("location"),
+		armTemplateBytes,
+		buildGoTemplate(instance, update),
+		map[string]interface{}{},
+		tags,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error updating redis instance %s", err)
+	}
+
+	nonSSLPortEnabled := up.GetString("enableNonSslPort")
+	dt.NonSSLEnabled = (nonSSLPortEnabled == enabled)
+	return dt, nil
 }

--- a/tests/lifecycle/rediscache_cases_test.go
+++ b/tests/lifecycle/rediscache_cases_test.go
@@ -5,11 +5,17 @@ package lifecycle
 var rediscacheTestCases = []serviceLifecycleTestCase{
 	{
 		group:     "rediscache",
-		name:      "rediscache",
+		name:      "rediscache-basic-provision-and-update",
 		serviceID: "0346088a-d4b2-4478-aa32-f18e295ec1d9",
 		planID:    "362b3d1b-5b57-4289-80ad-4a15a760c29c",
 		provisioningParameters: map[string]interface{}{
-			"location": "southcentralus",
+			"location":         "southcentralus",
+			"skuCapacity":      1,
+			"enableNonSslPort": "disabled",
+		},
+		updatingParameters: map[string]interface{}{
+			"skuCapacity":      2,
+			"enableNonSslPort": "enabled",
 		},
 	},
 }


### PR DESCRIPTION
As @krancour said in #564 , this PR is the first one of separated PRs. Later PRs will be based on this PR. This PR enables several basic and fundamental features mentioned in #561 :
- Provision
  - Make `skuCapacity` as an optional parameter. For now, there is only one default capacity for each plan, we can provide users more options after parameterizing capacity. It has several valid values for different plan.
  - Make `enableNonSslPort` as an optional parameter.

Provide the ability to update an existing Redis instance:
- Update 
  - `skuCapacity`. The capacity can only be updated from a smaller size to a larger size.
  - `enableNonSslPort`

From my point of view, these features is necessary and should be added anyway. So I put them together so that we can avoid annoying rebase. 