### PR TITLE
Add method to get token and config in test framework

### DIFF
--- a/tests/lifecycle/common_test.go
+++ b/tests/lifecycle/common_test.go
@@ -1,0 +1,34 @@
+// +build !unit
+
+package lifecycle
+
+import (
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/open-service-broker-azure/pkg/azure"
+)
+
+func getAzureConfig() (
+	*azure.Config,
+	error,
+) {
+	azureConfig, err := azure.GetConfigFromEnvironment()
+	if err != nil {
+		return nil, err
+	}
+	return &azureConfig, nil
+}
+func getBearerTokenAuthorizer(azureConfig *azure.Config) (
+	*autorest.BearerAuthorizer,
+	error,
+) {
+	authorizer, err := azure.GetBearerTokenAuthorizer(
+		azureConfig.Environment,
+		azureConfig.TenantID,
+		azureConfig.ClientID,
+		azureConfig.ClientSecret,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return authorizer, nil
+}


### PR DESCRIPTION
This PR adds two methods in test framework. They are used to get `azure.Config` and `autorest.BearerAuthorizer`, which may be required to create resources in [preProvisionFns](https://github.com/Azure/open-service-broker-azure/pull/572)