### PR TITLE
[Redis] Make Redis premium able to be deployed inside a subnet

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,7 @@
     "services/eventhub/mgmt/2017-04-01/eventhub",
     "services/keyvault/mgmt/2016-10-01/keyvault",
     "services/mysql/mgmt/2017-04-30-preview/mysql",
+    "services/network/mgmt/2018-01-01/network",
     "services/postgresql/mgmt/2017-04-30-preview/postgresql",
     "services/redis/mgmt/2017-10-01/redis",
     "services/resources/mgmt/2017-05-10/resources",
@@ -211,6 +212,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e7b24abc329a22d2a05f968645a749596c11e732e6a8d3177e70e864834a2a58"
+  inputs-digest = "add149e2845794e0833cf506bf80d3255d7c7ed34e39ad07fa6062cfa35ceed0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/docs/modules/rediscache.md
+++ b/docs/modules/rediscache.md
@@ -29,10 +29,11 @@ Provisions a new Redis cache.
 | `tags`              | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N                                                            | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
 
 For `premium` plan, following provisioning parameter is available:
-| Parameter Name | Type     | Description                                                  | Required | Default Value                                                |
-| -------------- | -------- | ------------------------------------------------------------ | -------- | ------------------------------------------------------------ |
-| ` subnetId `   | `string` | The full resource ID of a subnet in a virtual network to deploy the Redis cache in. The subnet should be in the same region with Redis cache. Example format: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{vn}/subnets/{sn} | N        | If not specified, the Redis cache won't be deployed in a subnet, that is, the Redis cache is publicly addressable and the access is not limited to a particular VNet. |
-| `staticIP`     | `string` | Static IP address. Required when deploying a Redis cache inside an existing Azure Virtual Network. Only valid when `subnetId` is provided. | N        | If `staticIP` **is not** specified and `subnetId` **is** specified, one valid IP will be chosen randomly in the subnet. |
+| Parameter Name                | Type     | Description                                                  | Required                                             | Default Value                                                |
+| ----------------------------- | -------- | ------------------------------------------------------------ | ---------------------------------------------------- | ------------------------------------------------------------ |
+| `subnetSettings`              | `object` | Setting to deploy the Redis cache inside a subnet, so that the  cache is only accessible in the subnet | N                                                    | If not specified, the Redis cache won't be deployed in a subnet, that is, the Redis cache is publicly addressable and the access is not limited to a particular VNet. |
+| `subnetSettings`.` subnetId ` | `string` | The full resource ID of a subnet in a virtual network to deploy the Redis cache in. The subnet should be in the same region with Redis cache. Example format: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{vn}/subnets/{sn} | Yes when `subnetSettings` is provided, otherwise no. |                                                              |
+| `subnetSettings`.`staticIP`   | `string` | Static IP address. Required when deploying a Redis cache inside an existing Azure Virtual Network. Only valid when `subnetId` is provided. | N                                                    | If `staticIP` **is not** specified and `subnetId` **is** specified, one valid IP will be chosen randomly in the subnet. |
 
 ##### Bind
 

--- a/docs/modules/rediscache.md
+++ b/docs/modules/rediscache.md
@@ -29,6 +29,7 @@ Provisions a new Redis cache.
 | `tags`              | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N                                                            | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
 
 For `premium` plan, following provisioning parameter is available:
+
 | Parameter Name                | Type     | Description                                                  | Required                                             | Default Value                                                |
 | ----------------------------- | -------- | ------------------------------------------------------------ | ---------------------------------------------------- | ------------------------------------------------------------ |
 | `subnetSettings`              | `object` | Setting to deploy the Redis cache inside a subnet, so that the  cache is only accessible in the subnet | N                                                    | If not specified, the Redis cache won't be deployed in a subnet, that is, the Redis cache is publicly addressable and the access is not limited to a particular VNet. |

--- a/docs/modules/rediscache.md
+++ b/docs/modules/rediscache.md
@@ -28,6 +28,12 @@ Provisions a new Redis cache.
 | `enableNonSslPort ` | `string`            | Specifies whether the non-SSL Redis server port (6379) is enabled. Valid values: (`enabled`, `disabled`) | N                                                            | If not provided, `disabled` is used. That is, you can't use non-SSL Redis server port by default. |
 | `tags`              | `map[string]string` | Tags to be applied to new resources, specified as key/value pairs. | N                                                            | Tags (even if none are specified) are automatically supplemented with `heritage: open-service-broker-azure`. |
 
+For `premium` plan, following provisioning parameter is available:
+| Parameter Name | Type     | Description                                                  | Required | Default Value                                                |
+| -------------- | -------- | ------------------------------------------------------------ | -------- | ------------------------------------------------------------ |
+| ` subnetId `   | `string` | The full resource ID of a subnet in a virtual network to deploy the Redis cache in. The subnet should be in the same region with Redis cache. Example format: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{vn}/subnets/{sn} | N        | If not specified, the Redis cache won't be deployed in a subnet, that is, the Redis cache is publicly addressable and the access is not limited to a particular VNet. |
+| `staticIP`     | `string` | Static IP address. Required when deploying a Redis cache inside an existing Azure Virtual Network. Only valid when `subnetId` is provided. | N        | If `staticIP` **is not** specified and `subnetId` **is** specified, one valid IP will be chosen randomly in the subnet. |
+
 ##### Bind
 
 Returns a copy of one shared set of credentials.

--- a/pkg/services/rediscache/arm_template.go
+++ b/pkg/services/rediscache/arm_template.go
@@ -17,6 +17,12 @@ var armTemplateBytes = []byte(`
 			"type": "Microsoft.Cache/Redis",
 			"location": "{{.location}}",
 			"properties": {
+				{{if .subnetId}}
+				"subnetId": "{{.subnetId}}",
+				{{end}}
+				{{if .staticIP}}
+				"staticIP": "{{.staticIP}}",
+				{{end}}
 				"enableNonSslPort": {{.enableNonSslPort}},
 				"sku": {
 					"capacity": "{{.redisCacheCapacity}}",

--- a/pkg/services/rediscache/provision.go
+++ b/pkg/services/rediscache/provision.go
@@ -108,5 +108,7 @@ func buildGoTemplate(
 		"redisCacheSKU":      plan.GetProperties().Extended["redisCacheSKU"],
 		"redisCacheFamily":   plan.GetProperties().Extended["redisCacheFamily"],
 		"redisCacheCapacity": pp.GetInt64("skuCapacity"),
+		"subnetId":           pp.GetString("subnetId"),
+		"staticIP":           pp.GetString("staticIP"),
 	}
 }

--- a/pkg/services/rediscache/provision.go
+++ b/pkg/services/rediscache/provision.go
@@ -101,6 +101,8 @@ func buildGoTemplate(
 		enableNonSslPort = "false"
 	}
 
+	subnetSettings := pp.GetObject("subnetSettings")
+
 	return map[string]interface{}{ // ARM template params
 		"location":           pp.GetString("location"),
 		"serverName":         dt.ServerName,
@@ -108,7 +110,7 @@ func buildGoTemplate(
 		"redisCacheSKU":      plan.GetProperties().Extended["redisCacheSKU"],
 		"redisCacheFamily":   plan.GetProperties().Extended["redisCacheFamily"],
 		"redisCacheCapacity": pp.GetInt64("skuCapacity"),
-		"subnetId":           pp.GetString("subnetId"),
-		"staticIP":           pp.GetString("staticIP"),
+		"subnetId":           subnetSettings.GetString("subnetId"),
+		"staticIP":           subnetSettings.GetString("staticIP"),
 	}
 }

--- a/tests/lifecycle/rediscache_cases_test.go
+++ b/tests/lifecycle/rediscache_cases_test.go
@@ -2,6 +2,17 @@
 
 package lifecycle
 
+import (
+	"context"
+	"fmt"
+
+	networkSDK "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-01-01/network" // nolint: lll
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+
+	uuid "github.com/satori/go.uuid"
+)
+
 var rediscacheTestCases = []serviceLifecycleTestCase{
 	{
 		group:     "rediscache",
@@ -18,4 +29,85 @@ var rediscacheTestCases = []serviceLifecycleTestCase{
 			"enableNonSslPort": "enabled",
 		},
 	},
+	{
+		group:     "rediscache",
+		name:      "rediscache-premium-provision-and-update",
+		serviceID: "0346088a-d4b2-4478-aa32-f18e295ec1d9",
+		planID:    "b1057a8f-9a01-423a-bc35-e168d5c04cf0",
+		provisioningParameters: map[string]interface{}{
+			"location": "eastus",
+		},
+		updatingParameters: map[string]interface{}{
+			"skuCapacity":      1,
+			"enableNonSslPort": "enabled",
+		},
+		preProvisionFns: []preProvisionFn{
+			createVirtualNetwork,
+		},
+	},
+}
+
+// nolint: lll
+func createVirtualNetwork(
+	ctx context.Context,
+	resourceGroup string,
+	parent *service.Instance,
+	pp *map[string]interface{},
+) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	azureConfig, err := getAzureConfig()
+	if err != nil {
+		return fmt.Errorf("error getting azure config %s", err)
+	}
+	authorizer, err := getBearerTokenAuthorizer(azureConfig)
+	if err != nil {
+		return fmt.Errorf("error getting authorizer %s", err)
+	}
+	virtualNetworksClient := networkSDK.NewVirtualNetworksClientWithBaseURI(
+		azureConfig.Environment.ResourceManagerEndpoint,
+		azureConfig.SubscriptionID,
+	)
+	virtualNetworksClient.Authorizer = authorizer
+	virtualNetworkName := uuid.NewV4().String()
+	subnetName := "default"
+	vnResult, err := virtualNetworksClient.CreateOrUpdate(
+		ctx,
+		resourceGroup,
+		virtualNetworkName,
+		networkSDK.VirtualNetwork{
+			Location: to.StringPtr("eastus"),
+			VirtualNetworkPropertiesFormat: &networkSDK.VirtualNetworkPropertiesFormat{
+				AddressSpace: &networkSDK.AddressSpace{
+					AddressPrefixes: &[]string{"172.19.0.0/16"},
+				},
+				Subnets: &[]networkSDK.Subnet{
+					{
+						Name: &subnetName,
+						SubnetPropertiesFormat: &networkSDK.SubnetPropertiesFormat{
+							AddressPrefix: to.StringPtr("172.19.0.0/24"),
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("error creating virtual network %s", err)
+	}
+	if err = vnResult.WaitForCompletion(
+		ctx,
+		virtualNetworksClient.Client,
+	); err != nil {
+		return fmt.Errorf("error waiting for virtual network creation complete %s", err)
+	}
+	subnetID := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s",
+		azureConfig.SubscriptionID,
+		resourceGroup,
+		virtualNetworkName,
+		subnetName,
+	)
+	(*pp)["subnetId"] = subnetID
+	return nil
 }

--- a/tests/lifecycle/rediscache_cases_test.go
+++ b/tests/lifecycle/rediscache_cases_test.go
@@ -108,6 +108,8 @@ func createVirtualNetwork(
 		virtualNetworkName,
 		subnetName,
 	)
-	(*pp)["subnetId"] = subnetID
+	(*pp)["subnetSettings"] = map[string]interface{}{
+		"subnetId": subnetID,
+	}
 	return nil
 }


### PR DESCRIPTION
This PR cherry-picks #572 and #574 , and make Redis premium able to be deployed inside a subnet. Following features are enabled:

- Provision:
For premium plan, following provisioning parameters are added:
  - `subnetId`. Optional, string, default null.
  - `staticIP`. Optional, string, default null, is valid only when subnetId is provided.

Note: deploying the Redis instance in a subnet is an irreversible operation and can only be configured while creating the instance, so there is no updating method for this feature.
