### PR TITLE
Add a service to use existing Azure SQL database

### DIFF
--- a/docs/modules/mssql.md
+++ b/docs/modules/mssql.md
@@ -1,14 +1,16 @@
 # [Azure SQL Database](https://azure.microsoft.com/en-us/services/sql-database/)
 
-Open Service Broker for Azure (OSBA) contains three Azure SQL Database services. These services enable you to select the most appropriate provisioning scenario for your needs. These services are:
+Open Service Broker for Azure (OSBA) contains five Azure SQL Database services. These services enable you to select the most appropriate provisioning scenario for your needs. These services are:
 
 | Service Name | Description |
 |--------------|-------------|
-| `azure-sql-12-0` | Provision both a SQL Server DBMS and a database. |
-| `azure-sql-12-0-dbms` | Provision only a SQL Server Database Management System (DBMS). This can be used to provision multiple databases at a later time. |
-| `azure-sql-12-0-database` | Provision a new database only upon a previously provisioned DBMS. |
+| [`azure-sql-12-0`](#service-azure-sql-12-0) | Provision both a SQL Server DBMS and a database. |
+| [`azure-sql-12-0-dbms`](#service-azure-sql-12-0-dbms) | Provision only a SQL Server Database Management System (DBMS). This can be used to provision multiple databases at a later time. |
+| [`azure-sql-12-0-database`](#service-azure-sql-12-0-database) | Provision a new database only upon a previously provisioned DBMS. |
+| [`azure-sql-12-0-dbms-registered`](#service-azure-sql-12-0-dbms-registered) | Register an existing server as a DBMS service instance. |
+| [`azure-sql-12-0-database-from-existing`](#service-azure-sql-12-0-database-from-existing) | Taking over an existing database upon a previous DBMS as a database service instance. The service requires `ENABLE_MIGRATION_SERVICES` to be `true` in OSBA environment variables. |
 
-The `azure-sql` service allows you to provision both a DBMS and a database. When the provision operation is successful, the database will be ready to use. You can not provision additional databases onto an instance provisioned through this service. The `azure-sql-dbms` and `azure-sql-database` services, on the other hand, can be combined to provision multiple databases on a single DBMS.  For more information on each service, refer to the descriptions below.
+The `azure-sql-12-0` service allows you to provision both a DBMS and a database. When the provision operation is successful, the database will be ready to use. You can not provision additional databases onto an instance provisioned through this service. The `azure-sql-12-0-dbms` and `azure-sql-12-0-database` services, on the other hand, can be combined to provision multiple databases on a single DBMS. The `azure-sql-12-0-dbms-registered` is in the same position with `azure-sql-12-0-dbms`. And `azure-sql-12-0-database-from-existing` is in the same position with `azure-sql-12-0-database`. For more information on each service, refer to the descriptions below.
 
 ## Services & Plans
 
@@ -478,3 +480,54 @@ curl -X PUT \
 }
 '
 ```
+
+### Service: azure-sql-12-0-dbms-registered
+
+It is to *register* an existing Azure SQL Server as a SQL DBMS service instance. Both **azure-sql-12-0-database** service and **azure-sql-12-0-database-from-existing** service can be its child service.
+
+#### Behaviors
+
+##### Provision
+
+Please refer to [**azure-sql-12-0-dbms** service](#service-azure-sql-12-0-dbms) with extra required provisioning parameters below.
+
+###### Provisioning Parameters
+
+| Parameter Name | Type | Description | Required | Default Value |
+|----------------|------|-------------|----------|---------------|
+| `server` | `string` | The SQL server name. | Y | |
+| `administratorLogin` | `string` | The administratorLogin input when creating the SQL server. | Y | |
+| `administratorLoginPassword` | `string` | The administratorLoginPassword input when creating the SQL server. | Y | |
+
+##### Update
+
+Update the `administratorLogin` and/or `administratorLoginPassword` as they may change and the server is assumed to be managed by yourself.
+
+###### Updating Parameters
+
+| Parameter Name | Type | Description | Required | Default Value |
+|----------------|------|-------------|----------|---------------|
+| `administratorLogin` | `string` | New administratorLogin. | N | |
+| `administratorLoginPassword` | `string` | New administratorLoginPassword. | N | |
+
+##### Bind, Unbind, Deprovision
+
+Please refer to [**azure-sql-12-0-dbms** service](#service-azure-sql-12-0-dbms).
+
+### Service: azure-sql-12-0-database-from-existing
+
+It is to create SQL database service instance from existing Azure SQL Database *for taking over the database*. Both **azure-sql-12-0-dbms** service and **azure-sql-12-0-dbms-registered** service can be its parent service.
+
+##### Provision
+
+Please refer to [**azure-sql-12-0-database** service](#service-azure-sql-12-0-database) with extra required provisioning parameters below.
+
+###### Provisioning Parameters
+
+| Parameter Name | Type | Description | Required | Default Value |
+|----------------|------|-------------|----------|---------------|
+| `database` | `string` | The SQL database name. | Y | |
+
+##### Update, Bind, Unbind, Deprovision
+
+Please refer to [**azure-sql-12-0-database** service](#service-azure-sql-12-0-database).

--- a/pkg/services/mssql/catalog.go
+++ b/pkg/services/mssql/catalog.go
@@ -5,6 +5,7 @@ import "github.com/Azure/open-service-broker-azure/pkg/service"
 func buildBasicPlan(
 	id string,
 	includesDBMS bool,
+	fe bool,
 ) service.PlanProperties {
 
 	planDetails := dtuPlanDetails{
@@ -17,7 +18,7 @@ func buildBasicPlan(
 		includeDBMS: includesDBMS,
 	}
 
-	return service.PlanProperties{
+	planProperties := service.PlanProperties{
 		ID:          id,
 		Name:        "basic",
 		Description: "Basic Tier, 5 DTUs, 2GB Storage, 7 days point-in-time restore",
@@ -41,11 +42,18 @@ func buildBasicPlan(
 			},
 		},
 	}
+	if fe {
+		planProperties.Schemas.ServiceInstances.ProvisioningParametersSchema =
+			planDetails.getFeProvisionSchema()
+	}
+
+	return planProperties
 }
 
 func buildStandardPlan(
 	id string,
 	includesDBMS bool,
+	fe bool,
 ) service.PlanProperties {
 	planDetails := dtuPlanDetails{
 		storageInGB: 250,
@@ -68,7 +76,7 @@ func buildStandardPlan(
 		includeDBMS: includesDBMS,
 	}
 
-	return service.PlanProperties{
+	planProperties := service.PlanProperties{
 		ID:   id,
 		Name: "standard",
 		Description: "Standard Tier, Up to 3000 DTUs, 250GB Storage, " +
@@ -93,11 +101,18 @@ func buildStandardPlan(
 			},
 		},
 	}
+	if fe {
+		planProperties.Schemas.ServiceInstances.ProvisioningParametersSchema =
+			planDetails.getFeProvisionSchema()
+	}
+
+	return planProperties
 }
 
 func buildPremiumPlan(
 	id string,
 	includesDBMS bool,
+	fe bool,
 ) service.PlanProperties {
 	planDetails := dtuPlanDetails{
 		storageInGB: 500,
@@ -117,7 +132,7 @@ func buildPremiumPlan(
 		includeDBMS: includesDBMS,
 	}
 
-	return service.PlanProperties{
+	planProperties := service.PlanProperties{
 		ID:   id,
 		Name: "premium",
 		Description: "Premium Tier, Up to 4000 DTUs, 500GB Storage, " +
@@ -142,18 +157,25 @@ func buildPremiumPlan(
 			},
 		},
 	}
+	if fe {
+		planProperties.Schemas.ServiceInstances.ProvisioningParametersSchema =
+			planDetails.getFeProvisionSchema()
+	}
+
+	return planProperties
 }
 
 func buildGeneralPurposePlan(
 	id string,
 	includesDBMS bool,
+	fe bool,
 ) service.PlanProperties {
 	planDetails := vCorePlanDetails{
 		tierName:      "GeneralPurpose",
 		tierShortName: "GP",
 		includeDBMS:   includesDBMS,
 	}
-	return service.PlanProperties{
+	planProperties := service.PlanProperties{
 		ID:          id,
 		Name:        "general-purpose",
 		Description: "Up to 80 vCores, 440 GB memory and 1 TB of storage (preview)",
@@ -180,18 +202,25 @@ func buildGeneralPurposePlan(
 			},
 		},
 	}
+	if fe {
+		planProperties.Schemas.ServiceInstances.ProvisioningParametersSchema =
+			planDetails.getFeProvisionSchema()
+	}
+
+	return planProperties
 }
 
 func buildBusinessCriticalPlan(
 	id string,
 	includesDBMS bool,
+	fe bool,
 ) service.PlanProperties {
 	planDetails := vCorePlanDetails{
 		tierName:      "BusinessCritical",
 		tierShortName: "BC",
 		includeDBMS:   includesDBMS,
 	}
-	return service.PlanProperties{
+	planProperties := service.PlanProperties{
 		ID:   id,
 		Name: "business-critical",
 		Description: "Up to 80 vCores, 440 GB memory and 1 TB of storage. " +
@@ -218,6 +247,12 @@ func buildBusinessCriticalPlan(
 			},
 		},
 	}
+	if fe {
+		planProperties.Schemas.ServiceInstances.ProvisioningParametersSchema =
+			planDetails.getFeProvisionSchema()
+	}
+
+	return planProperties
 }
 
 // nolint: lll
@@ -248,30 +283,35 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				buildBasicPlan(
 					"3819fdfa-0aaa-11e6-86f4-000d3a002ed5",
 					true,
+					false,
 				),
 			),
 			service.NewPlan(
 				buildStandardPlan(
 					"2497b7f3-341b-4ac6-82fb-d4a48c005e19",
 					true,
+					false,
 				),
 			),
 			service.NewPlan(
 				buildPremiumPlan(
 					"f9a3cc8e-a6e2-474d-b032-9837ea3dfcaa",
 					true,
+					false,
 				),
 			),
 			service.NewPlan(
 				buildGeneralPurposePlan(
 					"c77e86af-f050-4457-a2ff-2b48451888f3",
 					true,
+					false,
 				),
 			),
 			service.NewPlan(
 				buildBusinessCriticalPlan(
 					"ebc3ae35-91bc-480c-807b-e798c1ca8c4e",
 					true,
+					false,
 				),
 			),
 		),
@@ -320,7 +360,7 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				Name:            "azure-sql-12-0-database",
 				Description:     "Azure SQL 12.0-- database only",
 				Bindable:        true,
-				ParentServiceID: "a7454e0e-be2c-46ac-b55f-8c4278117525",
+				ParentServiceID: "a7454e0e-be2c-46ac-b55f-8c4278117525", // more parents in fact
 				Metadata: service.ServiceMetadata{
 					DisplayName:      "Azure SQL 12.0-- Database Only",
 					ImageURL:         "https://azure.microsoft.com/svghandler/sql-database/?width=200",
@@ -338,11 +378,13 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				buildBasicPlan(
 					"8fa8d759-c142-45dd-ae38-b93482ddc04a",
 					false,
+					false,
 				),
 			),
 			service.NewPlan(
 				buildStandardPlan(
 					"9d36b6b3-b5f3-4907-a713-5cc13b785409",
+					false,
 					false,
 				),
 			),
@@ -350,11 +392,13 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				buildPremiumPlan(
 					"220e922a-a5b2-43e4-9388-fe45a32bbf31",
 					false,
+					false,
 				),
 			),
 			service.NewPlan(
 				buildGeneralPurposePlan(
 					"da591616-77a1-4df8-a493-6c119649bc6b",
+					false,
 					false,
 				),
 			),
@@ -362,16 +406,17 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 				buildBusinessCriticalPlan(
 					"b05c25d2-1d63-4d09-a50a-e68c2710a069",
 					false,
+					false,
 				),
 			),
 		),
-		// registered dbms only service
+		// dbms only registered service
 		service.NewService(
 			service.ServiceProperties{
 				ID:             "c9bd94e7-5b7d-4b20-96e6-c5678f99d997",
 				Name:           "azure-sql-12-0-dbms-registered",
 				Description:    "Azure SQL 12.0-- DBMS only registered",
-				ChildServiceID: "2bbc160c-e279-4757-a6b6-4c0a4822d0aa",
+				ChildServiceID: "2bbc160c-e279-4757-a6b6-4c0a4822d0aa", // database-from-existing is also a valid child
 				Metadata: service.ServiceMetadata{
 					DisplayName:      "Azure SQL 12.0-- DBMS Only registered",
 					ImageURL:         "https://azure.microsoft.com/svghandler/sql-database/?width=200",
@@ -402,6 +447,63 @@ func (m *module) GetCatalog() (service.Catalog, error) {
 					},
 				},
 			}),
+		),
+		// database only from existing service
+		service.NewService(
+			service.ServiceProperties{
+				ID:              "b0b2a2f7-9b5e-4692-8b94-24fe2f6a9a8e",
+				Name:            "azure-sql-12-0-database-from-existing",
+				Description:     "Azure SQL 12.0-- database only from existing",
+				Bindable:        true,
+				ParentServiceID: "a7454e0e-be2c-46ac-b55f-8c4278117525", // dbms-registered is also a valid parent
+				Metadata: service.ServiceMetadata{
+					DisplayName:      "Azure SQL 12.0-- Database Only from existing",
+					ImageURL:         "https://azure.microsoft.com/svghandler/sql-database/?width=200",
+					LongDescription:  "Azure SQL 12.0-- database only from existing",
+					DocumentationURL: "https://docs.microsoft.com/en-us/azure/sql-database/",
+					SupportURL:       "https://azure.microsoft.com/en-us/support/",
+				},
+				Tags: []string{"Azure", "SQL", "Database", service.MigrationTag},
+				Extended: map[string]interface{}{
+					"version": "12.0",
+				},
+			},
+			m.databaseFeManager,
+			service.NewPlan(
+				buildBasicPlan(
+					"e5804586-625a-4f67-996f-ca19a14711cc",
+					false,
+					true,
+				),
+			),
+			service.NewPlan(
+				buildStandardPlan(
+					"ee01d17b-37ee-46b7-bfc7-39faf3230d02",
+					false,
+					true,
+				),
+			),
+			service.NewPlan(
+				buildPremiumPlan(
+					"19f31593-6727-451e-95cf-3e64a90bd968",
+					false,
+					true,
+				),
+			),
+			service.NewPlan(
+				buildGeneralPurposePlan(
+					"e8a788a0-2968-43ec-b8bb-5ecf2ce90ade",
+					false,
+					true,
+				),
+			),
+			service.NewPlan(
+				buildBusinessCriticalPlan(
+					"9a26cd40-af08-4e05-bb8e-a521c3d3b60e",
+					false,
+					true,
+				),
+			),
 		),
 	}), nil
 }

--- a/pkg/services/mssql/database_fe_arm_template.go
+++ b/pkg/services/mssql/database_fe_arm_template.go
@@ -1,0 +1,25 @@
+package mssql
+
+// nolint: lll
+var databaseFeARMTemplateBytes = []byte(`
+{
+	"$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+	"contentVersion": "1.0.0.0",
+	"parameters": {
+		"tags": {
+			"type": "object"
+		}
+	},
+	"resources": [
+		{
+			"type": "Microsoft.Sql/servers/databases",
+			"name": "{{ .serverName}}/{{ .databaseName }}",
+			"apiVersion": "2017-10-01-preview",
+			"location": "{{.location}}",
+			"tags": "[parameters('tags')]"
+		}
+	],
+	"outputs": {
+	}
+}
+`)

--- a/pkg/services/mssql/database_fe_provision.go
+++ b/pkg/services/mssql/database_fe_provision.go
@@ -1,0 +1,88 @@
+package mssql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/open-service-broker-azure/pkg/service"
+	uuid "github.com/satori/go.uuid"
+)
+
+func (d *databaseFeManager) GetProvisioner(
+	service.Plan,
+) (service.Provisioner, error) {
+	return service.NewProvisioner(
+		service.NewProvisioningStep("preProvision", d.preProvision),
+		service.NewProvisioningStep("getDatabase", d.getDatabase),
+		service.NewProvisioningStep("deployARMTemplate", d.deployARMTemplate),
+	)
+}
+
+func (d *databaseFeManager) preProvision(
+	_ context.Context,
+	_ service.Instance,
+) (service.InstanceDetails, error) {
+	return &databaseInstanceDetails{
+		ARMDeploymentName: uuid.NewV4().String(),
+	}, nil
+}
+
+func (d *databaseFeManager) getDatabase(
+	ctx context.Context,
+	instance service.Instance,
+) (service.InstanceDetails, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	pdt := instance.Parent.Details.(*dbmsInstanceDetails)
+	resourceGroup :=
+		instance.Parent.ProvisioningParameters.GetString("resourceGroup")
+	databaseName :=
+		instance.ProvisioningParameters.GetString("database")
+	_, err := d.databasesClient.Get(
+		ctx,
+		resourceGroup,
+		pdt.ServerName,
+		databaseName,
+		"",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error getting sql database: %s", err)
+	}
+	return instance.Details, nil
+}
+
+func (d *databaseFeManager) deployARMTemplate(
+	_ context.Context,
+	instance service.Instance,
+) (service.InstanceDetails, error) {
+	dt := instance.Details.(*databaseInstanceDetails)
+	pdt := instance.Parent.Details.(*dbmsInstanceDetails)
+	goTemplateParams := map[string]interface{}{}
+	location := instance.Parent.ProvisioningParameters.GetString("location")
+	databaseName := instance.ProvisioningParameters.GetString("database")
+	goTemplateParams["serverName"] = pdt.ServerName
+	goTemplateParams["location"] = location
+	goTemplateParams["databaseName"] = databaseName
+	instance.ProvisioningParameters.GetString("database")
+	tagsObj := instance.ProvisioningParameters.GetObject("tags")
+	tags := make(map[string]string, len(tagsObj.Data))
+	for k := range tagsObj.Data {
+		tags[k] = tagsObj.GetString(k)
+	}
+	// No output, so ignore the output
+	_, err := d.armDeployer.Deploy(
+		dt.ARMDeploymentName,
+		instance.Parent.ProvisioningParameters.GetString("resourceGroup"),
+		location,
+		databaseFeARMTemplateBytes,
+		goTemplateParams,
+		map[string]interface{}{}, // empty arm params
+		tags,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error deploying ARM template: %s", err)
+	}
+
+	dt.DatabaseName = databaseName
+	return instance.Details, nil
+}

--- a/pkg/services/mssql/mssql.go
+++ b/pkg/services/mssql/mssql.go
@@ -12,6 +12,7 @@ type module struct {
 	dbmsManager            *dbmsManager
 	databaseManager        *databaseManager
 	dbmsRegisteredManager  *dbmsRegisteredManager
+	databaseFeManager      *databaseFeManager
 }
 
 type allInOneManager struct {
@@ -36,6 +37,10 @@ type dbmsRegisteredManager struct {
 	dbmsManager
 }
 
+type databaseFeManager struct {
+	databaseManager
+}
+
 // New returns a new instance of a type that fulfills the service.Module
 // interface and is capable of provisioning MS SQL servers and databases
 // using "Azure SQL Database"
@@ -50,6 +55,10 @@ func New(
 		armDeployer:          armDeployer,
 		serversClient:        serversClient,
 	}
+	databaseMan := databaseManager{
+		armDeployer:     armDeployer,
+		databasesClient: databasesClient,
+	}
 	return &module{
 		allInOneServiceManager: &allInOneManager{
 			sqlDatabaseDNSSuffix: azureEnvironment.SQLDatabaseDNSSuffix,
@@ -57,13 +66,13 @@ func New(
 			serversClient:        serversClient,
 			databasesClient:      databasesClient,
 		},
-		dbmsManager: &dbmsMan,
-		databaseManager: &databaseManager{
-			armDeployer:     armDeployer,
-			databasesClient: databasesClient,
-		},
+		dbmsManager:     &dbmsMan,
+		databaseManager: &databaseMan,
 		dbmsRegisteredManager: &dbmsRegisteredManager{
 			dbmsMan,
+		},
+		databaseFeManager: &databaseFeManager{
+			databaseMan,
 		},
 	}
 }

--- a/pkg/services/mssql/plan_details.go
+++ b/pkg/services/mssql/plan_details.go
@@ -12,6 +12,7 @@ import (
 
 type planDetails interface {
 	getProvisionSchema() service.InputParametersSchema
+	getFeProvisionSchema() service.InputParametersSchema
 	getTierProvisionParameters(
 		pp service.ProvisioningParameters,
 	) (map[string]interface{}, error)
@@ -70,6 +71,19 @@ func (d dtuPlanDetails) getProvisionSchema() service.InputParametersSchema {
 			Description: "DTUs are a bundled measure of compute, " +
 				"storage, and IO resources.",
 		}
+	}
+	return ips
+}
+
+func (d dtuPlanDetails) getFeProvisionSchema() service.InputParametersSchema {
+	ips := service.InputParametersSchema{
+		PropertySchemas: map[string]service.PropertySchema{},
+	}
+	if d.includeDBMS {
+		ips = getDBMSCommonProvisionParamSchema()
+	}
+	ips.PropertySchemas["database"] = &service.StringPropertySchema{
+		Description: "The name of the existing database",
 	}
 	return ips
 }
@@ -152,6 +166,19 @@ func (v vCorePlanDetails) getProvisionSchema() service.InputParametersSchema {
 		DefaultValue: ptr.ToInt64(10),
 		Title:        "Storage",
 		Description:  "The maximum data storage capacity (in GB)",
+	}
+	return ips
+}
+
+func (v vCorePlanDetails) getFeProvisionSchema() service.InputParametersSchema {
+	ips := service.InputParametersSchema{
+		PropertySchemas: map[string]service.PropertySchema{},
+	}
+	if v.includeDBMS {
+		ips = getDBMSCommonProvisionParamSchema()
+	}
+	ips.PropertySchemas["database"] = &service.StringPropertySchema{
+		Description: "The name of the existing database",
 	}
 	return ips
 }

--- a/tests/lifecycle/driver_test.go
+++ b/tests/lifecycle/driver_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/Azure/open-service-broker-azure/pkg/azure"
 	"github.com/Azure/open-service-broker-azure/pkg/boot"
+	"github.com/Azure/open-service-broker-azure/pkg/crypto"
+	"github.com/Azure/open-service-broker-azure/pkg/crypto/noop"
 	"github.com/Azure/open-service-broker-azure/pkg/service"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
@@ -51,6 +53,9 @@ func TestServices(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	if err := crypto.InitializeGlobalCodec(noop.NewCodec()); err != nil {
+		os.Exit(-1)
+	}
 	if err := setup(); err != nil {
 		os.Exit(-1)
 	}

--- a/tests/lifecycle/driver_test.go
+++ b/tests/lifecycle/driver_test.go
@@ -25,6 +25,7 @@ func TestServices(t *testing.T) {
 
 	catalogConfig := service.NewCatalogConfigWithDefaults()
 	catalogConfig.MinStability = service.StabilityExperimental
+	catalogConfig.EnableMigrationServices = true
 
 	catalog, err := boot.GetCatalog(catalogConfig, azureConfig)
 	assert.Nil(t, err)


### PR DESCRIPTION
The third step in https://github.com/Azure/open-service-broker-azure/issues/566. It is also a child service like the original database-only service.
Several changes might look tricky. Point it out if it doesn't look good to you, I'd love to do refactor.