### PR TITLE
Tune service catalog install command for AKS

### DIFF
--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -191,7 +191,11 @@ You should also ensure that the `Microsoft.Compute` and `Microsoft.Network` prov
     ```console
     helm repo add svc-cat https://svc-catalog-charts.storage.googleapis.com
     helm install svc-cat/catalog --name catalog --namespace catalog \
-       --set apiserver.storage.etcd.persistence.enabled=true
+       --set apiserver.storage.etcd.persistence.enabled=true \
+       --set apiserver.healthcheck.enabled=false \
+       --set controllerManager.healthcheck.enabled=false \
+       --set apiserver.verbosity=2 \
+       --set controllerManager.verbosity=2
     ```
 
 1. Deploy Open Service Broker for Azure on the cluster:


### PR DESCRIPTION
* Disable health checks by default to workaround https://github.com/Azure/AKS/issues/417
* Lower logging threshold (from 10 to 2) so that the logs don't include every successful HTTP request/response (which is what you get at 4 which unfortunately is where Service Catalog logs its info messages).