### PR TITLE
Add temporary fix for CosmosDB lifecycle test

### DIFF
--- a/pkg/boot/modules.go
+++ b/pkg/boot/modules.go
@@ -61,7 +61,7 @@ func getModules(
 	resourceDeploymentsClient.Authorizer = authorizer
 	resourceDeploymentsClient.UserAgent =
 		getUserAgent(resourceDeploymentsClient.Client)
-	resourceDeploymentsClient.PollingDuration = time.Minute * 30
+	resourceDeploymentsClient.PollingDuration = time.Minute * 45
 	armDeployer := arm.NewDeployer(
 		resourceGroupsClient,
 		resourceDeploymentsClient,

--- a/pkg/services/cosmosdb/cosmos-utils.go
+++ b/pkg/services/cosmosdb/cosmos-utils.go
@@ -238,6 +238,7 @@ func pollingUntilReadLocationsReady(
 				readLocations,
 				currentLocations,
 			) {
+				time.Sleep(time.Second * 20)
 				return nil
 			}
 		}

--- a/pkg/services/cosmosdb/cosmos-utils.go
+++ b/pkg/services/cosmosdb/cosmos-utils.go
@@ -238,6 +238,7 @@ func pollingUntilReadLocationsReady(
 				readLocations,
 				currentLocations,
 			) {
+				// This is a temporary fix and should be removed after #617 is resolved
 				time.Sleep(time.Second * 20)
 				return nil
 			}


### PR DESCRIPTION
See IcM ticket in #617 . CosmosDB team is fixing the error. They suggest us "While we are working to fix this, please add a delay of 10s in between region changes succeeding and sending delete request." I make the go routine sleep for 20 seconds after all regions are created. I'll follow up on the issue after the bug is fixed by CosmosDB team. 