### PR TITLE
Cancel setting a timeout when provisioning

### DIFF
--- a/pkg/services/cosmosdb/common-provision.go
+++ b/pkg/services/cosmosdb/common-provision.go
@@ -81,7 +81,7 @@ func (c *cosmosAccountManager) waitForReadLocationsReady(
 		databaseAccountClient,
 		instance.ProvisioningParameters.GetString("location"),
 		instance.ProvisioningParameters.GetStringArray("readRegions"),
-		true,
+		false,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/services/cosmosdb/cosmos-utils.go
+++ b/pkg/services/cosmosdb/cosmos-utils.go
@@ -200,7 +200,7 @@ func pollingUntilReadLocationsReady(
 	// When updating an existing instance, data in existing database will
 	// be copied and synchronized across all regions, it's hard to estimate
 	// how long the process will take so we disable timeout when updating.
-	enableTimeout bool,
+	enableTimeout bool, // nolint: unparam
 ) error {
 	const timeForOneReadLocation = time.Minute * 7
 	readLocations = append([]string{location}, readLocations...)

--- a/pkg/services/cosmosdb/sql-all-in-one-provision.go
+++ b/pkg/services/cosmosdb/sql-all-in-one-provision.go
@@ -92,7 +92,7 @@ func (s *sqlAllInOneManager) waitForReadLocationsReady(
 		databaseAccountClient,
 		instance.ProvisioningParameters.GetString("location"),
 		instance.ProvisioningParameters.GetStringArray("readRegions"),
-		true,
+		false,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In recent PR, one the lifecycle test case for cosmos DB failed. However, when I tested in my own subscription, the lifecycle test passed. So I tested manually on Azure portal in CI subscription, the creation for a region in mongo account takes about 15 minutes, which exceeds the timeout we set for one region. The creation time for a region might vary from subscription to subscription, and it's hard to estimate, so I canceled setting a timeout when provisioning.