### PR TITLE
Make timeout of lifecycle test to 70 minutes

### DIFF
--- a/tests/lifecycle/test_case_test.go
+++ b/tests/lifecycle/test_case_test.go
@@ -50,7 +50,7 @@ func (s serviceLifecycleTestCase) execute(
 	catalog service.Catalog,
 	resourceGroup string,
 ) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*50)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*70)
 	defer cancel()
 
 	name := s.getName()


### PR DESCRIPTION
This PR makes the timeout of lifecycle test to 70 minutes. Because recently we noticed, some complicated test case can't finish within 50 minutes.