### PR TITLE
Including Eventhub name and namespace in the returning credentials

### DIFF
--- a/pkg/services/eventhubs/bind.go
+++ b/pkg/services/eventhubs/bind.go
@@ -17,7 +17,9 @@ func (s *serviceManager) GetCredentials(
 ) (service.Credentials, error) {
 	dt := instance.Details.(*instanceDetails)
 	return credentials{
-		ConnectionString: string(dt.ConnectionString),
-		PrimaryKey:       string(dt.PrimaryKey),
+		ConnectionString:  string(dt.ConnectionString),
+		PrimaryKey:        string(dt.PrimaryKey),
+		EventHubNamespace: string(dt.EventHubNamespace),
+		EventHubName:      string(dt.EventHubName),
 	}, nil
 }

--- a/pkg/services/eventhubs/bind.go
+++ b/pkg/services/eventhubs/bind.go
@@ -19,7 +19,7 @@ func (s *serviceManager) GetCredentials(
 	return credentials{
 		ConnectionString:  string(dt.ConnectionString),
 		PrimaryKey:        string(dt.PrimaryKey),
-		EventHubNamespace: string(dt.EventHubNamespace),
-		EventHubName:      string(dt.EventHubName),
+		EventHubNamespace: dt.EventHubNamespace,
+		EventHubName:      dt.EventHubName,
 	}, nil
 }

--- a/pkg/services/eventhubs/types.go
+++ b/pkg/services/eventhubs/types.go
@@ -19,6 +19,8 @@ func (s *serviceManager) GetEmptyBindingDetails() service.BindingDetails {
 }
 
 type credentials struct {
-	ConnectionString string `json:"connectionString"`
-	PrimaryKey       string `json:"primaryKey"`
+	ConnectionString  string               `json:"connectionString"`
+	PrimaryKey        string               `json:"primaryKey"`
+	EventHubNamespace string               `json:"eventHubNamespace"`
+	EventHubName      string               `json:"eventHubName"`
 }

--- a/pkg/services/eventhubs/types.go
+++ b/pkg/services/eventhubs/types.go
@@ -19,8 +19,8 @@ func (s *serviceManager) GetEmptyBindingDetails() service.BindingDetails {
 }
 
 type credentials struct {
-	ConnectionString  string               `json:"connectionString"`
-	PrimaryKey        string               `json:"primaryKey"`
-	EventHubNamespace string               `json:"eventHubNamespace"`
-	EventHubName      string               `json:"eventHubName"`
+	ConnectionString  string `json:"connectionString"`
+	PrimaryKey        string `json:"primaryKey"`
+	EventHubNamespace string `json:"eventHubNamespace"`
+	EventHubName      string `json:"eventHubName"`
 }


### PR DESCRIPTION
Fixes #685 
I described this minor change as WIP to understand what kind of tests I am required to execute.
Including the EventHub name and namespace in the secrets file generated after the binding operation makes it easier to access and use the created environment.  