### PR TITLE
Add checksum of broker.yaml to annotation in deployment.yaml

### DIFF
--- a/contrib/k8s/charts/open-service-broker-azure/templates/deployment.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/templates/deployment.yaml
@@ -19,6 +19,8 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/broker.yaml") . | sha256sum }}
     spec:
       containers:
         - name: open-service-broker-azure

--- a/contrib/k8s/charts/open-service-broker-azure/templates/deployment.yaml
+++ b/contrib/k8s/charts/open-service-broker-azure/templates/deployment.yaml
@@ -19,8 +19,7 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
-      annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/broker.yaml") . | sha256sum }}
+        releaseRevision: "{{ .Release.Revision }}"
     spec:
       containers:
         - name: open-service-broker-azure


### PR DESCRIPTION
There is a bug:

OSBA brokes after deployment because every release it creates new TLS certificate in  [broker.yaml](https://github.com/Azure/open-service-broker-azure/blob/master/contrib/k8s/charts/open-service-broker-azure/templates/broker.yaml) 
```yaml
{{- $ca := genCA "osba-ca" 3650 }}
{{- $cert := genSignedCert $cn nil (list $altName1 $altName2 $altName3 $altName4) 3650 $ca }}
```
Error looks like 
```bash
NAME   URL                                                             STATUS                 AGE
osba   https://osba-open-service-broker-azure.osba.svc.cluster.local   ErrorFetchingCatalog   33m
```
OSBA logs
```bash
Error getting broker catalog: Get https://osba-open-service-broker-azure.osba.svc.cluster.local/v2/catalog: x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "osba-ca")
```

The main reason of this error is that osba pod doesn't recreates and it uses certificate from previous release, but  brocker is registered in service catalog with new certificate and ca.

To solve this issue, i have added checksum of broker.yaml to annotation in deployment.yaml related to [Chart Development best prectice](https://github.com/helm/helm/blob/master/docs/charts_tips_and_tricks.md#automatically-roll-deployments-when-configmaps-or-secrets-change) 